### PR TITLE
Refactor shared helper domains and harden hosted validation

### DIFF
--- a/Generate-VulnerabilityDashboard.ps1
+++ b/Generate-VulnerabilityDashboard.ps1
@@ -229,11 +229,105 @@ $Script:LibraryConfig = @{
     }
 }
 
+function Get-LocalDiagnosticMemorySnapshot {
+    [CmdletBinding()]
+    [OutputType([pscustomobject])]
+    param()
+
+    $process = [System.Diagnostics.Process]::GetCurrentProcess()
+    return [PSCustomObject]@{
+        working_set_mb = [math]::Round(($process.WorkingSet64 / 1MB), 1)
+        gc_heap_mb = [math]::Round(([System.GC]::GetTotalMemory($false) / 1MB), 1)
+    }
+}
+
+function Write-LocalDiagnosticMemoryMarker {
+    [CmdletBinding()]
+    [OutputType([pscustomobject])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$PhaseName,
+
+        [Parameter(Mandatory = $true)]
+        [string]$Checkpoint
+    )
+
+    $snapshot = Get-LocalDiagnosticMemorySnapshot
+    Write-Host ("  [{0}/{1}] Memory - Working set: {2}MB | GC heap: {3}MB" -f $PhaseName, $Checkpoint, $snapshot.working_set_mb, $snapshot.gc_heap_mb) -ForegroundColor DarkGray
+    return $snapshot
+}
+
+function Get-LocalDiagnosticPhaseContext {
+    [CmdletBinding()]
+    [OutputType([System.Collections.IDictionary])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Name
+    )
+
+    Write-Host ("`n--- Local Phase: {0} ---" -f $Name) -ForegroundColor DarkCyan
+    $startSnapshot = Write-LocalDiagnosticMemoryMarker -PhaseName $Name -Checkpoint 'start'
+    return [ordered]@{
+        Name = $Name
+        Stopwatch = [System.Diagnostics.Stopwatch]::StartNew()
+        StartSnapshot = $startSnapshot
+    }
+}
+
+function Complete-LocalDiagnosticPhase {
+    [CmdletBinding()]
+    [OutputType([pscustomobject])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [System.Collections.IDictionary]$PhaseContext,
+
+        [Parameter(Mandatory = $false)]
+        [string]$Status = 'completed'
+    )
+
+    if ($PhaseContext.Stopwatch.IsRunning) {
+        $PhaseContext.Stopwatch.Stop()
+    }
+
+    $endSnapshot = Write-LocalDiagnosticMemoryMarker -PhaseName $PhaseContext.Name -Checkpoint 'end'
+    $elapsedSeconds = [math]::Round($PhaseContext.Stopwatch.Elapsed.TotalSeconds, 2)
+    Write-Host ("  [{0}] Elapsed: {1:N2}s ({2})" -f $PhaseContext.Name, $elapsedSeconds, $Status) -ForegroundColor DarkGray
+
+    return [PSCustomObject]@{
+        Name = $PhaseContext.Name
+        Status = $Status
+        ElapsedSeconds = $elapsedSeconds
+        StartWorkingSetMB = $PhaseContext.StartSnapshot.working_set_mb
+        EndWorkingSetMB = $endSnapshot.working_set_mb
+        StartGcHeapMB = $PhaseContext.StartSnapshot.gc_heap_mb
+        EndGcHeapMB = $endSnapshot.gc_heap_mb
+    }
+}
+
+function Write-LocalDiagnosticSummary {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [AllowEmptyCollection()]
+        [object[]]$PhaseSummaries
+    )
+
+    if (@($PhaseSummaries).Count -eq 0) {
+        return
+    }
+
+    Write-Host "`nLocal phase timing summary:" -ForegroundColor DarkCyan
+    foreach ($phase in $PhaseSummaries) {
+        Write-Host ("  {0}: {1:N2}s ({2})" -f $phase.Name, $phase.ElapsedSeconds, $phase.Status) -ForegroundColor DarkGray
+    }
+}
+
 # =============================================================================
 # MAIN SCRIPT
 # =============================================================================
 
 $tempRoot = $null
+$localPhaseTimings = [System.Collections.Generic.List[object]]::new()
 
 try {
     if ($Validate -and $ValidateOnly) {
@@ -261,6 +355,7 @@ try {
     Write-Host "========================================`n" -ForegroundColor Cyan
     if (-not $ValidateOnly) {
         if ((-not $PackageOnly) -and $ExportMachineData) {
+            $phaseContext = Get-LocalDiagnosticPhaseContext -Name 'Export machine data'
             try {
                 $accessToken = Get-MdeAccessToken -AccessToken $DefenderAccessToken -UseEnvironmentFallback -UseAzureCliFallback
                 $null = Export-MdeMachineData -AccessToken $accessToken -OutputPath $DirectoryPath
@@ -269,6 +364,7 @@ try {
                 Write-Warning "Failed to export machine data: $_"
                 Write-Host "  Continuing with existing machine data files..." -ForegroundColor Yellow
             }
+            $localPhaseTimings.Add((Complete-LocalDiagnosticPhase -PhaseContext $phaseContext)) | Out-Null
         }
 
         $tempRoot = Join-Path -Path ([System.IO.Path]::GetTempPath()) -ChildPath ("dashboard-generator-" + [System.Guid]::NewGuid().ToString('N'))
@@ -293,6 +389,7 @@ try {
         Invoke-FullGarbageCollection
 
         if ($PackageOnly) {
+            $phaseContext = Get-LocalDiagnosticPhaseContext -Name 'Prepare normalized payload'
             Write-Host "`nPreparing data for embedding..." -ForegroundColor Cyan
             if (-not [string]::IsNullOrWhiteSpace($NormalizedPayloadInputPath)) {
                 $resolvedNormalizedPayloadInputPath = [System.IO.Path]::GetFullPath($NormalizedPayloadInputPath)
@@ -339,8 +436,10 @@ try {
             $normalizedQuality = $payloadManifest.Quality
             $compressedSize = [math]::Round((Get-Item $tempPayloadPath).Length / 1KB, 1)
             Write-Host "  Cached payload: ${compressedSize}KB" -ForegroundColor Green
+            $localPhaseTimings.Add((Complete-LocalDiagnosticPhase -PhaseContext $phaseContext)) | Out-Null
         }
         elseif ($payloadCacheEntry) {
+            $phaseContext = Get-LocalDiagnosticPhaseContext -Name 'Prepare normalized payload'
             Write-Host "`nPreparing data for embedding..." -ForegroundColor Cyan
             Write-Host ("  Reusing cached normalized payload ({0})..." -f $payloadCacheEntry.Fingerprint.Substring(0, 12)) -ForegroundColor Gray
             Copy-Item -LiteralPath $payloadCacheEntry.PayloadPath -Destination $tempPayloadPath -Force
@@ -356,22 +455,88 @@ try {
             $normalizedQuality = $payloadManifest.Quality
             $compressedSize = [math]::Round((Get-Item $tempPayloadPath).Length / 1KB, 1)
             Write-Host "  Cached payload: ${compressedSize}KB" -ForegroundColor Green
+            $localPhaseTimings.Add((Complete-LocalDiagnosticPhase -PhaseContext $phaseContext)) | Out-Null
         }
         else {
+            $phaseContext = Get-LocalDiagnosticPhaseContext -Name 'Load source data'
             $machines = Read-MachineData -Path $DirectoryPath
             $advancedHuntingData = Read-AdvancedHuntingData -Path $DirectoryPath
             $advancedHuntingDeviceUsers = Read-AdvancedHuntingDeviceUserMap -Path $DirectoryPath
             $advancedHuntingInventoryData = Read-AdvancedHuntingInventoryData -Path $DirectoryPath
             $nvdCveData = Read-NvdCveData -Path $DirectoryPath
+            $localPhaseTimings.Add((Complete-LocalDiagnosticPhase -PhaseContext $phaseContext)) | Out-Null
+
+            $phaseContext = Get-LocalDiagnosticPhaseContext -Name 'Normalize source data'
             Write-Host "`nOptimizing data for client-side performance..." -ForegroundColor Cyan
-            $normalizedResult = ConvertTo-NormalizedData -DataPath $DirectoryPath -VulnOutputPath $tempVulnsPath -Machines $machines -AdvancedHuntingData $advancedHuntingData -AdvancedHuntingDeviceUsers $advancedHuntingDeviceUsers -AdvancedHuntingInventoryData $advancedHuntingInventoryData -NvdCveData $nvdCveData -SkipObservedWindowMerge:$effectiveSkipObservedWindowMerge
+            $normalizedVulnColumnCacheEntry = Get-NormalizedVulnColumnCacheEntry -BasePath $DirectoryPath -SkipObservedWindowMerge:$effectiveSkipObservedWindowMerge
+
+            if ($normalizedVulnColumnCacheEntry) {
+                try {
+                    Write-Host ("  Reusing cached normalized vuln columns ({0})..." -f $normalizedVulnColumnCacheEntry.Fingerprint.Substring(0, 12)) -ForegroundColor Gray
+                    $restoredLookups = Restore-ContentStoreNormalizedLookupsFromColumnCache `
+                        -DataPath $DirectoryPath `
+                        -Machines $machines `
+                        -AdvancedHuntingData $advancedHuntingData `
+                        -AdvancedHuntingDeviceUsers $advancedHuntingDeviceUsers `
+                        -AdvancedHuntingInventoryData $advancedHuntingInventoryData `
+                        -NvdCveData $nvdCveData `
+                        -CachedDates @($normalizedVulnColumnCacheEntry.Manifest.Dates)
+
+                    $cachedInventoryTupleCount = if ($normalizedVulnColumnCacheEntry.Manifest.PSObject.Properties['InventoryTupleCount']) {
+                        [int]$normalizedVulnColumnCacheEntry.Manifest.InventoryTupleCount
+                    }
+                    else {
+                        0
+                    }
+                    $restoredColumnPaths = Restore-NormalizedVulnColumnPathsFromCache `
+                        -CachedColumnPaths $normalizedVulnColumnCacheEntry.ColumnPaths `
+                        -RestoredLookupsResult $restoredLookups `
+                        -OutputDirectoryPath (Join-Path $tempRoot 'normalized-vuln-column-cache-reuse') `
+                        -CachedInventoryTupleCount $cachedInventoryTupleCount
+                    if ($restoredColumnPaths.RefreshedInventoryColumn) {
+                        Write-Host ("  Refreshed cached inventory column against current enrichment state for {0} row(s)..." -f $restoredColumnPaths.RowCount) -ForegroundColor Gray
+                    }
+
+                    $normalizedResult = [PSCustomObject]@{
+                        Lookups = $restoredLookups.Lookups
+                        Quality = if ($normalizedVulnColumnCacheEntry.Manifest.PSObject.Properties['Quality']) { $normalizedVulnColumnCacheEntry.Manifest.Quality } else { $restoredLookups.Quality }
+                        VulnCount = [int]$normalizedVulnColumnCacheEntry.Manifest.VulnCount
+                        VulnsPath = $null
+                        VulnColumnPaths = $restoredColumnPaths.ColumnPaths
+                        PayloadPath = $null
+                    }
+                }
+                catch {
+                    Write-Warning "  Normalized vuln column cache reuse failed; falling back to live normalization. $_"
+                    $normalizedVulnColumnCacheEntry = $null
+                }
+            }
+
+            if (-not $normalizedVulnColumnCacheEntry) {
+                $normalizedResult = ConvertTo-NormalizedData -DataPath $DirectoryPath -VulnOutputPath $tempVulnsPath -Machines $machines -AdvancedHuntingData $advancedHuntingData -AdvancedHuntingDeviceUsers $advancedHuntingDeviceUsers -AdvancedHuntingInventoryData $advancedHuntingInventoryData -NvdCveData $nvdCveData -SkipObservedWindowMerge:$effectiveSkipObservedWindowMerge
+                if ($normalizedResult.VulnColumnPaths) {
+                    $normalizedColumnCacheEntry = Publish-NormalizedVulnColumnCache `
+                        -BasePath $DirectoryPath `
+                        -VulnColumnPaths $normalizedResult.VulnColumnPaths `
+                        -VulnCount $normalizedResult.VulnCount `
+                        -Dates @($normalizedResult.Lookups.dates) `
+                        -Quality $normalizedResult.Quality `
+                        -SkipObservedWindowMerge:$effectiveSkipObservedWindowMerge `
+                        -InventoryTupleCount $advancedHuntingInventoryData.Count
+                    if ($normalizedColumnCacheEntry) {
+                        Write-Host ("  Cached normalized vuln columns as {0}" -f $normalizedColumnCacheEntry.Fingerprint.Substring(0, 12)) -ForegroundColor Gray
+                    }
+                }
+            }
             $machines = $null
             $advancedHuntingData = $null
             $advancedHuntingDeviceUsers = $null
             $advancedHuntingInventoryData = $null
             $nvdCveData = $null
             Invoke-FullGarbageCollection
+            $localPhaseTimings.Add((Complete-LocalDiagnosticPhase -PhaseContext $phaseContext)) | Out-Null
 
+            $phaseContext = Get-LocalDiagnosticPhaseContext -Name 'Prepare normalized payload'
             Write-Host "`nPreparing data for embedding..." -ForegroundColor Cyan
             $vulnCount = $normalizedResult.VulnCount
             $deviceCount = $normalizedResult.Lookups.devices.Count
@@ -392,7 +557,12 @@ try {
             }
 
             Write-Host "  Compressing data..." -ForegroundColor Gray
-            $normalizedQuality = $normalizedResult['Quality']
+            $normalizedQuality = if ($normalizedResult -is [System.Collections.IDictionary]) {
+                $normalizedResult['Quality']
+            }
+            else {
+                $normalizedResult.Quality
+            }
             Write-CombinedPayloadGzip -Lookups $normalizedResult.Lookups -VulnsPath $normalizedResult.VulnsPath -VulnColumnPaths $normalizedResult.VulnColumnPaths -OutputPath $tempPayloadPath
             $payloadVulnCount = Get-CompressedPayloadVulnCount -Path $tempPayloadPath
             if ($payloadVulnCount -ne $vulnCount) {
@@ -435,6 +605,7 @@ try {
 
             $compressedSize = [math]::Round((Get-Item $tempPayloadPath).Length / 1KB, 1)
             Write-Host "  Compressed: ${compressedSize}KB" -ForegroundColor Green
+            $localPhaseTimings.Add((Complete-LocalDiagnosticPhase -PhaseContext $phaseContext)) | Out-Null
         }
 
         if ($null -ne $machines) {
@@ -446,7 +617,9 @@ try {
         Invoke-FullGarbageCollection
 
         if ($NormalizeOnly) {
+            $phaseContext = Get-LocalDiagnosticPhaseContext -Name 'Materialize normalized payload'
             $materializedPayload = Export-NormalizedPayloadArtifacts -PayloadPath $tempPayloadPath -PayloadManifest $payloadManifest -OutputPayloadPath $NormalizedPayloadOutputPath -OutputManifestPath $NormalizedPayloadManifestOutputPath
+            $localPhaseTimings.Add((Complete-LocalDiagnosticPhase -PhaseContext $phaseContext)) | Out-Null
             Write-Host "`n========================================" -ForegroundColor Green
             Write-Host "  Normalized payload prepared." -ForegroundColor Green
             Write-Host "========================================" -ForegroundColor Green
@@ -466,6 +639,7 @@ try {
             return
         }
 
+        $phaseContext = Get-LocalDiagnosticPhaseContext -Name 'Prepare client libraries'
         Write-Host ("`nPreparing {0}client libraries..." -f ($(if ($SplitAssets) { 'dashboard ' } else { 'embedded ' }))) -ForegroundColor Cyan
         $lib = $Script:LibraryConfig.ChartJs
         $chartJsLibraryPath = Save-JSLibraryFile -Url $lib.Url -Name $lib.Name -OutputPath (Join-Path $tempLibrariesPath 'chart.js') -Critical $lib.Critical -CacheBasePath $DirectoryPath
@@ -489,9 +663,12 @@ try {
             $chartJsBundlePath = Compress-FileGzip -InputPath $chartJsLibraryPath -OutputPath (Join-Path $tempLibrariesPath 'chart.js.gz')
             $pdfExportBundlePath = Compress-FileGzip -InputPath $pdfExportBundleSourcePath -OutputPath (Join-Path $tempLibrariesPath 'pdf-export.bundle.js.gz')
         }
+        $localPhaseTimings.Add((Complete-LocalDiagnosticPhase -PhaseContext $phaseContext)) | Out-Null
 
+        $phaseContext = Get-LocalDiagnosticPhaseContext -Name 'Load templates'
         Write-Host "`nLoading template files..." -ForegroundColor Cyan
         $templates = Get-DashboardTemplateContent -TemplatesPath $TemplatesPath -DefaultRootPath $PSScriptRoot
+        $localPhaseTimings.Add((Complete-LocalDiagnosticPhase -PhaseContext $phaseContext)) | Out-Null
 
         $lookupsJsonEscaped = ""
         $generatedOnUtc = (Get-Date).ToUniversalTime().ToString('o')
@@ -514,6 +691,8 @@ try {
             generatedOnUtc = $generatedOnUtc
         }
         $dataQualityMetaScript = '<script id="dataQualityMeta" type="application/json">' + ($dataQualityMeta | ConvertTo-Json -Compress) + '</script>'
+
+        $phaseContext = Get-LocalDiagnosticPhaseContext -Name 'Write dashboard'
         Write-Host "Building dashboard HTML..." -ForegroundColor Cyan
         $templateHtml = $templates.Html
         $templateCss = $templates.Css
@@ -541,7 +720,8 @@ try {
             Write-Host ("  Split-assets output directory: {0}" -f $dashboardArtifacts.AssetsPath) -ForegroundColor Gray
         }
 
-        $dashboardPayloadCount = Get-EmbeddedDashboardPayloadVulnCount -Path $OutputPath
+        $dashboardPayloadInspection = Get-DashboardEmbeddedPayloadInspection -Path $OutputPath
+        $dashboardPayloadCount = [int]$dashboardPayloadInspection.PayloadRowCount
         if (-not $SplitAssets -and $dashboardPayloadCount -ne $vulnCount) {
             Write-Warning ("  Dashboard payload row count mismatch (expected {0}, found {1}); rewriting with wrapped base64 output." -f $vulnCount, $dashboardPayloadCount)
             $dashboardArtifacts = Write-DashboardArtifactBundle `
@@ -560,12 +740,13 @@ try {
                 -DataQualityMetaScript $dataQualityMetaScript `
                 -SplitAssets $false `
                 -InsertBase64LineBreaks $true
-            $dashboardPayloadCount = Get-EmbeddedDashboardPayloadVulnCount -Path $OutputPath
+            $dashboardPayloadInspection = Get-DashboardEmbeddedPayloadInspection -Path $OutputPath
+            $dashboardPayloadCount = [int]$dashboardPayloadInspection.PayloadRowCount
         }
 
         if ($dashboardPayloadCount -ne $vulnCount) {
             $sourcePayloadSha256 = Get-FileSha256Hex -Path $tempPayloadPath
-            $embeddedPayloadSha256 = Get-DashboardPayloadGzipSha256 -Path $OutputPath
+            $embeddedPayloadSha256 = [string]$dashboardPayloadInspection.PayloadSha256
             if ($embeddedPayloadSha256 -eq $sourcePayloadSha256) {
                 Write-Warning ("  Dashboard payload row count parser mismatch detected, but embedded payload bytes match the source payload ({0})." -f $sourcePayloadSha256.Substring(0, 12))
             }
@@ -582,7 +763,7 @@ try {
             $payloadManifestRecord.SkipObservedWindowMerge = ($effectiveSkipObservedWindowMerge -eq $true)
         }
         $payloadManifest = [PSCustomObject]$payloadManifestRecord
-        $dashboardPayloadSha256 = Get-DashboardPayloadGzipSha256 -Path $OutputPath
+        $dashboardPayloadSha256 = [string]$dashboardPayloadInspection.PayloadSha256
         $validationSidecarPath = Write-DashboardValidationSidecar -HtmlPath $OutputPath -PayloadManifest $payloadManifest -DashboardPayloadSha256 $dashboardPayloadSha256 -DashboardPayloadRowCount $dashboardPayloadCount
 
         $templateHtml = $null
@@ -601,6 +782,7 @@ try {
         Invoke-FullGarbageCollection
 
         $finalSize = [math]::Round((Get-Item $OutputPath).Length / 1MB, 2)
+        $localPhaseTimings.Add((Complete-LocalDiagnosticPhase -PhaseContext $phaseContext)) | Out-Null
         Write-Host "`n========================================" -ForegroundColor Green
         Write-Host "  Dashboard generated successfully!" -ForegroundColor Green
         Write-Host "========================================" -ForegroundColor Green
@@ -616,8 +798,10 @@ try {
     }
 
     if ($Validate -or $ValidateOnly) {
+        $phaseContext = Get-LocalDiagnosticPhaseContext -Name 'Validate dashboard'
         . (Join-Path $PSScriptRoot 'build\Import-ValidationHelpers.ps1')
         $null = Invoke-DashboardValidation -HtmlPath $OutputPath -ExportsPath $DirectoryPath -AuditPath $ValidationOutputPath -KeepDefaultAuditFile:$KeepValidationAuditFile -ResolvedBaselineAuditPath $BaselineAuditPath -ResolvedBaselineDashboardHtmlPath $BaselineDashboardHtmlPath -RunLegacyFixtureRegression:$IncludeLegacyFixtureRegression -ResolvedLegacyFixturePath $LegacyFixturePath
+        $localPhaseTimings.Add((Complete-LocalDiagnosticPhase -PhaseContext $phaseContext)) | Out-Null
     }
 }
 catch {
@@ -630,6 +814,7 @@ catch {
     exit 1
 }
 finally {
+    Write-LocalDiagnosticSummary -PhaseSummaries @($localPhaseTimings)
     if ($tempRoot -and (Test-Path -Path $tempRoot)) {
         Remove-Item -Path $tempRoot -Recurse -Force -ErrorAction SilentlyContinue
     }

--- a/README.md
+++ b/README.md
@@ -117,6 +117,8 @@ For local testing of the split-assets build, use a local HTTP server instead of 
 | [Azure setup](docs/azure-setup.md) | API permissions, authentication options, Azure Automation provisioning, and Container App publishing |
 | [Build guide](build/README.md) | Maintainer-facing build, validation, and packaging entrypoints |
 | [GitHub Actions setup](docs/github-actions-setup.md) | OIDC service principal setup, required repository secrets, and branch protection guidance |
+| [Performance baselines](docs/performance-baselines.md) | Merge-tracked durable benchmark ranges and accepted baseline notes |
+| [Performance gate playbook](docs/performance-gate-playbook.md) | Maintainer workflow for hot-phase review, benchmarking cadence, and Azure acceptance |
 | [Source layout](docs/source-layout.md) | Domain-based PowerShell source tree, artifact manifests, and maintainer workflow |
 | [Workflow notes](docs/workflows.md) | What each workflow does and when to use it |
 | [Changelog](CHANGELOG.md) | Release-style summary of notable changes |
@@ -166,6 +168,9 @@ flowchart TD
 - `azure/Invoke-DashboardPipeline.ps1` is generated from the `build/` sources and can be refreshed locally or by CI.
 - Edit `src/powershell/Shared/**/*.ps1`, `src/powershell/Validation/**/*.ps1`, and `build/azure/runbook-source.ps1`; the generated helper bundles are driven by `build/manifests/*.json`, so update the relevant manifest when you add or reorder source files.
 - Run `./build/Invoke-RegressionValidation.ps1` for the deterministic local and PR-aligned preflight path.
+- Run `./tests/Invoke-HotPhaseReview.ps1 -DirectoryPath <dataset>` when you want a local phase-and-memory review before taking changes to the heavier benchmark or Azure paths.
+- Run `./tests/New-BenchmarkDataset.ps1 -DatasetId benchmark-medium-v1` to materialize the standard durable benchmark dataset before recording baseline captures.
+- Run `./tests/Invoke-BenchmarkSeries.ps1 -BenchmarkDatasetId benchmark-medium-v1 -Iterations 3 -IncludePersistentLocalWorkflow` when you want the repeatable multi-run benchmark cadence used for durable baseline refreshes.
 - Run `./build/Invoke-LiveDashboardDryRun.ps1 -UseExistingAzContext` when you want the local command that mirrors the live GitHub Actions export and dashboard generation path.
 - Run `./build/Invoke-AzureDeploymentValidation.ps1 -AutomationAccountName <name> -FunctionAppName <name>` when you want the repo-owned manual validation path that rebuilds locally, redeploys Azure Automation and Function App, and executes both live Azure validation flows.
 - Run `./build/Build-AzureReleasePackage.ps1` when you want the exact local packaging path used by the release workflow.
@@ -175,3 +180,4 @@ flowchart TD
 - `.dashboard-cache/` directories are derived local caches and are intentionally ignored by git.
 - Manual troubleshooting harnesses live under `tests/manual/` and default to ignored local output paths.
 - Recorded benchmark baselines are summarized in `docs/performance-baselines.md`; raw benchmark JSON stays local-only.
+- The recommended performance review cadence now lives in `docs/performance-gate-playbook.md`.

--- a/Setup-AzureResources.ps1
+++ b/Setup-AzureResources.ps1
@@ -954,7 +954,23 @@ try {
 
     # Also assign Storage Blob Data Contributor to the caller (needed for template uploads, downloads)
     Write-Host "  Assigning Storage Blob Data Contributor to current user..." -ForegroundColor Gray
-    $callerObjectId = (Get-AzContext).Account.ExtendedProperties.HomeAccountId.Split('.')[0]
+    $callerObjectId = $null
+    $currentContext = Get-AzContext
+    $homeAccountId = $null
+    if ($null -ne $currentContext -and $null -ne $currentContext.Account) {
+        $extendedProperties = $currentContext.Account.ExtendedProperties
+        if ($extendedProperties -is [System.Collections.IDictionary]) {
+            $homeAccountId = [string]$extendedProperties['HomeAccountId']
+        }
+        elseif ($null -ne $extendedProperties -and $extendedProperties.PSObject.Properties['HomeAccountId']) {
+            $homeAccountId = [string]$extendedProperties.PSObject.Properties['HomeAccountId'].Value
+        }
+    }
+
+    if (-not [string]::IsNullOrWhiteSpace($homeAccountId)) {
+        $callerObjectId = $homeAccountId.Split('.')[0]
+    }
+
     if (-not $callerObjectId) {
         # Fallback: use Graph to resolve
         try {
@@ -964,7 +980,19 @@ try {
             $callerObjectId = $meResponse.id
         }
         catch {
-            Write-Warning "Could not determine current user's object ID. Assign Storage Blob Data Contributor manually."
+            try {
+                $callerObjectId = [string](& az ad signed-in-user show --query id -o tsv 2>$null)
+                if ([string]::IsNullOrWhiteSpace($callerObjectId)) {
+                    $callerObjectId = $null
+                }
+            }
+            catch {
+                $callerObjectId = $null
+            }
+
+            if (-not $callerObjectId) {
+                Write-Warning "Could not determine current user's object ID. Assign Storage Blob Data Contributor manually."
+            }
         }
     }
 
@@ -1234,7 +1262,7 @@ try {
             # Deploy function app code via az CLI zip deployment (Flex Consumption
             # uses a Kudu-lite pipeline that packages and uploads to blob storage)
             Write-Host "  Deploying function app code via zip deployment..." -ForegroundColor Gray
-            $zipPath = Join-Path ([System.IO.Path]::GetTempPath()) 'funcapp-deploy.zip'
+            $zipPath = Join-Path ([System.IO.Path]::GetTempPath()) ('funcapp-deploy-' + [guid]::NewGuid().ToString('N') + '.zip')
             if (Test-Path $zipPath) { Remove-Item $zipPath -Force }
 
             Push-Location $functionAppDir
@@ -1244,15 +1272,68 @@ try {
                 Pop-Location
             }
 
-            az functionapp deployment source config-zip `
-                --src $zipPath `
-                --name $FunctionAppName `
-                --resource-group $ResourceGroupName `
-                --output none
-            if ($LASTEXITCODE -ne 0) {
-                throw "Function App zip deployment failed (exit code $LASTEXITCODE)."
+            try {
+                $maxAttempts = 3
+                $deployed = $false
+                for ($attempt = 1; $attempt -le $maxAttempts; $attempt++) {
+                    $deployOutput = @(az functionapp deployment source config-zip `
+                        --src $zipPath `
+                        --name $FunctionAppName `
+                        --resource-group $ResourceGroupName `
+                        --output none 2>&1)
+
+                    $deployText = (($deployOutput | ForEach-Object {
+                        if ($_ -is [System.Management.Automation.ErrorRecord]) {
+                            $_.Exception.Message
+                        }
+                        else {
+                            [string]$_
+                        }
+                    }) -join [Environment]::NewLine).Trim()
+
+                    if (-not [string]::IsNullOrWhiteSpace($deployText)) {
+                        foreach ($line in ($deployText -split "`r?`n")) {
+                            if ([string]::IsNullOrWhiteSpace($line)) {
+                                continue
+                            }
+
+                            if ($line -match '^WARNING:\s*(.+)') {
+                                Write-Host ("  Deployment status: {0}" -f $Matches[1]) -ForegroundColor Gray
+                            }
+                            else {
+                                Write-Host ("  {0}" -f $line) -ForegroundColor Gray
+                            }
+                        }
+                    }
+
+                    if ($LASTEXITCODE -eq 0) {
+                        $deployed = $true
+                        break
+                    }
+
+                    if ($deployText -match 'Deployment was partially successful') {
+                        Write-Warning 'Function App zip deployment reported partial success without retained logs. Continuing and relying on host readiness validation.'
+                        $deployed = $true
+                        break
+                    }
+
+                    if ($attempt -lt $maxAttempts -and $deployText -match 'BadGatewayConnection|Bad Gateway') {
+                        Write-Warning ("Function App zip deployment hit a transient gateway error (attempt {0}/{1}). Retrying..." -f $attempt, $maxAttempts)
+                        Start-Sleep -Seconds (5 * $attempt)
+                        continue
+                    }
+
+                    throw "Function App zip deployment failed (exit code $LASTEXITCODE)."
+                }
+
+                if (-not $deployed) {
+                    throw "Function App zip deployment failed for '$FunctionAppName' after $maxAttempts attempt(s)."
+                }
             }
-            Remove-Item $zipPath -Force -ErrorAction SilentlyContinue
+            finally {
+                Remove-Item $zipPath -Force -ErrorAction SilentlyContinue
+            }
+
             Write-Host "  Function App deployed successfully" -ForegroundColor Green
         }
     }

--- a/azure/Invoke-DashboardPipeline.ps1
+++ b/azure/Invoke-DashboardPipeline.ps1
@@ -72,6 +72,61 @@ param(
 $ErrorActionPreference = 'Stop'
 $ProgressPreference = 'SilentlyContinue'
 
+function Resolve-PipelineExecutionHostDescriptor {
+    [CmdletBinding()]
+    [OutputType([pscustomobject])]
+    param()
+
+    foreach ($environmentVariableName in @(
+        'WEBSITE_INSTANCE_ID'
+        'WEBSITE_HOSTNAME'
+        'WEBSITE_SITE_NAME'
+        'FUNCTIONS_WORKER_RUNTIME'
+        'FUNCTIONS_EXTENSION_VERSION'
+        'FUNCTIONS_WORKER_DIRECTORY'
+        'FUNCTIONS_APPLICATION_DIRECTORY'
+    )) {
+        $environmentValue = [System.Environment]::GetEnvironmentVariable($environmentVariableName)
+        if (-not [string]::IsNullOrWhiteSpace([string]$environmentValue)) {
+            return [PSCustomObject]@{
+                Name = 'FunctionApp'
+                Evidence = $environmentVariableName
+            }
+        }
+    }
+
+    foreach ($environmentVariableName in @(
+        'AUTOMATION_ASSET_ACCOUNTID'
+        'AZUREPS_HOST_ENVIRONMENT'
+    )) {
+        $environmentValue = [System.Environment]::GetEnvironmentVariable($environmentVariableName)
+        if (-not [string]::IsNullOrWhiteSpace([string]$environmentValue)) {
+            return [PSCustomObject]@{
+                Name = 'Automation'
+                Evidence = $environmentVariableName
+            }
+        }
+    }
+
+    $psPrivateMetadataVariable = Get-Variable -Name PSPrivateMetadata -Scope Global -ErrorAction SilentlyContinue
+    if ($null -ne $psPrivateMetadataVariable) {
+        $psPrivateMetadata = $psPrivateMetadataVariable.Value
+        $jobIdProperty = if ($null -ne $psPrivateMetadata) { $psPrivateMetadata.PSObject.Properties['JobId'] } else { $null }
+        $jobId = if ($null -ne $jobIdProperty) { [string]$jobIdProperty.Value } else { '' }
+        if (-not [string]::IsNullOrWhiteSpace($jobId)) {
+            return [PSCustomObject]@{
+                Name = 'Automation'
+                Evidence = 'PSPrivateMetadata.JobId'
+            }
+        }
+    }
+
+    return [PSCustomObject]@{
+        Name = 'Unknown'
+        Evidence = $null
+    }
+}
+
 # =============================================================================
 # CONSTANTS
 # =============================================================================
@@ -96,6 +151,14 @@ $Script:BlobAccessTiers = @{
 $Script:DashboardBlobName = 'VulnerabilityDashboard.html'
 $Script:DashboardAssetsDirectoryName = ([System.IO.Path]::GetFileNameWithoutExtension($Script:DashboardBlobName) + '.assets')
 $Script:DashboardHostedAssetFileNames = @('dashboard.css', 'dashboard.js', 'pako.js', 'chart.js', 'pdf-export.bundle.js', 'payload.json.gz')
+$Script:PipelineControlBlobName = '_diagnostics/ExportAndGenerate.control.json'
+$Script:PipelineStatusBlobName = '_diagnostics/ExportAndGenerate.status.json'
+$Script:PipelineRunId = [guid]::NewGuid().ToString('N')
+$Script:PipelineStartedOnUtc = [datetime]::UtcNow
+$Script:PipelineCurrentStage = 'Initializing'
+$Script:PipelineCurrentStageMessage = 'Initializing pipeline.'
+$Script:PipelineExecutionHostDescriptor = Resolve-PipelineExecutionHostDescriptor
+$Script:PipelineExecutionHost = [string]$Script:PipelineExecutionHostDescriptor.Name
 
 $Script:LibraryConfig = @{
     ChartJs = @{
@@ -224,8 +287,12 @@ function Test-IsAzureHostedEnvironment {
 
     foreach ($environmentVariableName in @(
         'WEBSITE_INSTANCE_ID'
+        'WEBSITE_HOSTNAME'
+        'WEBSITE_SITE_NAME'
         'FUNCTIONS_WORKER_RUNTIME'
         'FUNCTIONS_EXTENSION_VERSION'
+        'FUNCTIONS_WORKER_DIRECTORY'
+        'FUNCTIONS_APPLICATION_DIRECTORY'
         'AUTOMATION_ASSET_ACCOUNTID'
         'AZUREPS_HOST_ENVIRONMENT'
     )) {
@@ -8203,13 +8270,22 @@ function Write-JsonValueToWriter {
     }
 
     if ($Value -is [System.Management.Automation.PSObject]) {
-        $psProperties = @($Value.PSObject.Properties | Where-Object { $_.MemberType -eq [System.Management.Automation.PSMemberTypes]::NoteProperty })
-        if ($psProperties.Count -gt 0) {
-            $Writer.WriteStartObject()
-            foreach ($property in $psProperties) {
-                $Writer.WritePropertyName([string]$property.Name)
-                Write-JsonValueToWriter -Writer $Writer -Value $property.Value
+        $wroteNoteProperties = $false
+        foreach ($property in $Value.PSObject.Properties) {
+            if ($property.MemberType -ne [System.Management.Automation.PSMemberTypes]::NoteProperty) {
+                continue
             }
+
+            if (-not $wroteNoteProperties) {
+                $Writer.WriteStartObject()
+                $wroteNoteProperties = $true
+            }
+
+            $Writer.WritePropertyName([string]$property.Name)
+            Write-JsonValueToWriter -Writer $Writer -Value $property.Value
+        }
+
+        if ($wroteNoteProperties) {
             $Writer.WriteEndObject()
             return
         }
@@ -8305,6 +8381,93 @@ function Write-JsonValueToWriter {
     }
 
     $Writer.WriteValue($Value.ToString())
+}
+
+function Get-NormalizedLookupPropertyValue {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $false)]
+        [AllowNull()]
+        [object]$Value,
+
+        [Parameter(Mandatory = $true)]
+        [string]$Name
+    )
+
+    if ($null -eq $Value) {
+        return $null
+    }
+
+    if ($Value -is [System.Collections.IDictionary]) {
+        return $Value[$Name]
+    }
+
+    $property = $Value.PSObject.Properties[$Name]
+    if ($null -ne $property) {
+        return $property.Value
+    }
+
+    return $null
+}
+
+function Write-NormalizedDeviceMachineInfoToWriter {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [Newtonsoft.Json.JsonTextWriter]$Writer,
+
+        [Parameter(Mandatory = $false)]
+        [AllowNull()]
+        [object]$MachineInfo
+    )
+
+    if ($null -eq $MachineInfo) {
+        $Writer.WriteNull()
+        return
+    }
+
+    $Writer.WriteStartObject()
+    foreach ($propertyName in @('ip', 'eip', 'u', 'hs', 'rs', 'el', 'dv', 'mb', 'aad', 'ls', 'fs')) {
+        $Writer.WritePropertyName($propertyName)
+        Write-JsonValueToWriter -Writer $Writer -Value (Get-NormalizedLookupPropertyValue -Value $MachineInfo -Name $propertyName)
+    }
+    $Writer.WriteEndObject()
+}
+
+function Write-NormalizedDeviceLookupsToWriter {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '')]
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [Newtonsoft.Json.JsonTextWriter]$Writer,
+
+        [Parameter(Mandatory = $false)]
+        [AllowNull()]
+        [object]$Devices
+    )
+
+    if ($null -eq $Devices) {
+        $Writer.WriteNull()
+        return
+    }
+
+    $Writer.WriteStartArray()
+    foreach ($device in $Devices) {
+        if ($null -eq $device) {
+            $Writer.WriteNull()
+            continue
+        }
+
+        $Writer.WriteStartObject()
+        foreach ($propertyName in @('id', 'n', 'g', 'o', 'ov', 't')) {
+            $Writer.WritePropertyName($propertyName)
+            Write-JsonValueToWriter -Writer $Writer -Value (Get-NormalizedLookupPropertyValue -Value $device -Name $propertyName)
+        }
+        $Writer.WritePropertyName('m')
+        Write-NormalizedDeviceMachineInfoToWriter -Writer $Writer -MachineInfo (Get-NormalizedLookupPropertyValue -Value $device -Name 'm')
+        $Writer.WriteEndObject()
+    }
+    $Writer.WriteEndArray()
 }
 
 function Open-JsonArrayFileWriter {
@@ -8614,6 +8777,56 @@ function Read-CompactJsonReaderValue {
     }
 }
 
+function Open-CompactJsonArrayReader {
+    [CmdletBinding()]
+    [OutputType([pscustomobject])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Path
+    )
+
+    $resolvedPath = [System.IO.Path]::GetFullPath($Path)
+    $streamReader = [System.IO.StreamReader]::new($resolvedPath, [System.Text.Encoding]::UTF8)
+    $jsonReader = [Newtonsoft.Json.JsonTextReader]::new($streamReader)
+    if (-not $jsonReader.Read() -or $jsonReader.TokenType -ne [Newtonsoft.Json.JsonToken]::StartArray) {
+        $jsonReader.Dispose()
+        $streamReader.Dispose()
+        throw "Expected JSON array in '$resolvedPath'."
+    }
+
+    return [PSCustomObject]@{
+        Path = $resolvedPath
+        StreamReader = $streamReader
+        JsonReader = $jsonReader
+    }
+}
+
+function Read-NextCompactJsonArrayValue {
+    [CmdletBinding()]
+    [OutputType([pscustomobject])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [pscustomobject]$ReaderState
+    )
+
+    $jsonReader = $ReaderState.JsonReader
+    while ($jsonReader.Read()) {
+        if ($jsonReader.TokenType -eq [Newtonsoft.Json.JsonToken]::EndArray) {
+            return [PSCustomObject]@{
+                HasValue = $false
+                Value = $null
+            }
+        }
+
+        return [PSCustomObject]@{
+            HasValue = $true
+            Value = (Read-CompactJsonReaderValue -Reader $jsonReader)
+        }
+    }
+
+    throw "Unexpected end of compact JSON array '$($ReaderState.Path)'."
+}
+
 function Skip-JsonReaderValue {
     [CmdletBinding()]
     param(
@@ -8846,73 +9059,9 @@ function Get-DashboardEmbeddedPayloadTempPath {
     return $tempPayloadPath
 }
 
-function Get-EmbeddedDashboardPayloadVulnCount {
+function Get-DashboardEmbeddedPayloadInspection {
     [CmdletBinding()]
-    [OutputType([int])]
-    param(
-        [Parameter(Mandatory = $true)]
-        [string]$Path
-    )
-
-    $resolvedPath = Resolve-Path -LiteralPath $Path -ErrorAction Stop
-    $content = Get-Content -LiteralPath $resolvedPath -Raw
-    $dataFormat = Get-DashboardHtmlScriptContent -Html $content -ScriptId 'dataFormat'
-    if ($dataFormat -eq 'external-compressed') {
-        $dashboardConfigJson = Get-DashboardHtmlScriptContent -Html $content -ScriptId 'dashboardConfig'
-        if ([string]::IsNullOrWhiteSpace($dashboardConfigJson)) {
-            throw "Unable to locate dashboardConfig metadata in '$Path'."
-        }
-
-        $dashboardConfig = $dashboardConfigJson | ConvertFrom-Json -Depth 20
-        $payloadUrl = [string]$dashboardConfig.payloadUrl
-        if ([string]::IsNullOrWhiteSpace($payloadUrl)) {
-            throw "dashboardConfig in '$Path' does not define payloadUrl."
-        }
-
-        $htmlDirectory = Split-Path -Path $resolvedPath -Parent
-        $payloadRelativePath = $payloadUrl.Replace('/', '\')
-        $payloadPath = [System.IO.Path]::GetFullPath((Join-Path $htmlDirectory $payloadRelativePath))
-        return (Get-CompressedPayloadVulnCount -Path $payloadPath)
-    }
-
-    $startMarker = '<script id="vulnsData" type="application/json">'
-    $endMarker = '</script>'
-    $startIndex = $content.IndexOf($startMarker)
-    if ($startIndex -lt 0) {
-        throw "Unable to locate embedded vulnerability payload in '$Path'."
-    }
-
-    $payloadStart = $startIndex + $startMarker.Length
-    $payloadEnd = $content.IndexOf($endMarker, $payloadStart)
-    if ($payloadEnd -lt 0) {
-        throw "Unable to locate payload terminator in '$Path'."
-    }
-
-    $base64 = ($content.Substring($payloadStart, $payloadEnd - $payloadStart) -replace '\s+', '')
-    $bytes = [Convert]::FromBase64String($base64)
-    $stream = $null
-    $gzip = $null
-    $reader = $null
-    $jsonReader = $null
-
-    try {
-        $stream = [System.IO.MemoryStream]::new($bytes)
-        $gzip = [System.IO.Compression.GZipStream]::new($stream, [System.IO.Compression.CompressionMode]::Decompress)
-        $reader = [System.IO.StreamReader]::new($gzip, [System.Text.Encoding]::UTF8)
-        $jsonReader = [Newtonsoft.Json.JsonTextReader]::new($reader)
-        return (Get-PayloadVulnCountFromJsonReader -Reader $jsonReader -Path $Path)
-    }
-    finally {
-        if ($jsonReader) { $jsonReader.Close() }
-        elseif ($reader) { $reader.Dispose() }
-        elseif ($gzip) { $gzip.Dispose() }
-        elseif ($stream) { $stream.Dispose() }
-    }
-}
-
-function Get-DashboardPayloadGzipSha256 {
-    [CmdletBinding()]
-    [OutputType([string])]
+    [OutputType([pscustomobject])]
     param(
         [Parameter(Mandatory = $true)]
         [string]$Path
@@ -8937,7 +9086,12 @@ function Get-DashboardPayloadGzipSha256 {
         $htmlDirectory = Split-Path -Path $resolvedPath -Parent
         $payloadRelativePath = $payloadUrl.Replace('/', '\')
         $payloadPath = [System.IO.Path]::GetFullPath((Join-Path $htmlDirectory $payloadRelativePath))
-        return (Get-FileSha256Hex -Path $payloadPath)
+        return [PSCustomObject]@{
+            DataFormat = $dataFormat
+            PayloadPath = $payloadPath
+            PayloadRowCount = (Get-CompressedPayloadVulnCount -Path $payloadPath)
+            PayloadSha256 = (Get-FileSha256Hex -Path $payloadPath)
+        }
     }
 
     $startMarker = '<script id="vulnsData" type="application/json">'
@@ -8955,8 +9109,54 @@ function Get-DashboardPayloadGzipSha256 {
 
     $base64 = ($content.Substring($payloadStart, $payloadEnd - $payloadStart) -replace '\s+', '')
     $bytes = [Convert]::FromBase64String($base64)
-    $hashBytes = [System.Security.Cryptography.SHA256]::HashData($bytes)
-    return ([System.BitConverter]::ToString($hashBytes)).Replace('-', '').ToLowerInvariant()
+    $stream = $null
+    $gzip = $null
+    $reader = $null
+    $jsonReader = $null
+
+    try {
+        $stream = [System.IO.MemoryStream]::new($bytes, $false)
+        $gzip = [System.IO.Compression.GZipStream]::new($stream, [System.IO.Compression.CompressionMode]::Decompress)
+        $reader = [System.IO.StreamReader]::new($gzip, [System.Text.Encoding]::UTF8)
+        $jsonReader = [Newtonsoft.Json.JsonTextReader]::new($reader)
+        $payloadRowCount = Get-PayloadVulnCountFromJsonReader -Reader $jsonReader -Path $Path
+    }
+    finally {
+        if ($jsonReader) { $jsonReader.Close() }
+        elseif ($reader) { $reader.Dispose() }
+        elseif ($gzip) { $gzip.Dispose() }
+        elseif ($stream) { $stream.Dispose() }
+    }
+
+    $payloadSha256 = ([System.BitConverter]::ToString([System.Security.Cryptography.SHA256]::HashData($bytes))).Replace('-', '').ToLowerInvariant()
+    return [PSCustomObject]@{
+        DataFormat = $dataFormat
+        PayloadPath = $null
+        PayloadRowCount = $payloadRowCount
+        PayloadSha256 = $payloadSha256
+    }
+}
+
+function Get-EmbeddedDashboardPayloadVulnCount {
+    [CmdletBinding()]
+    [OutputType([int])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Path
+    )
+
+    return [int](Get-DashboardEmbeddedPayloadInspection -Path $Path).PayloadRowCount
+}
+
+function Get-DashboardPayloadGzipSha256 {
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Path
+    )
+
+    return [string](Get-DashboardEmbeddedPayloadInspection -Path $Path).PayloadSha256
 }
 
 function Get-NormalizedAuditDecimalString {
@@ -9142,7 +9342,12 @@ function Write-CombinedPayloadLookupsValue {
         else {
             $lookupValue = $Lookups.PSObject.Properties[$lookupPropertyName].Value
         }
-        Write-JsonValueToWriter -Writer $Writer -Value $lookupValue
+        if ($lookupPropertyName -eq 'devices') {
+            Write-NormalizedDeviceLookupsToWriter -Writer $Writer -Devices $lookupValue
+        }
+        else {
+            Write-JsonValueToWriter -Writer $Writer -Value $lookupValue
+        }
     }
     $Writer.WriteEndObject()
 }
@@ -10395,6 +10600,255 @@ function Get-VulnerabilityPayloadFingerprintSourceFileSet {
     return [System.IO.FileInfo[]]$files.ToArray()
 }
 
+function Get-NormalizedVulnColumnCacheFingerprint {
+        [CmdletBinding()]
+        [OutputType([string])]
+        param(
+            [Parameter(Mandatory = $true)]
+            [string]$BasePath,
+
+            [Parameter(Mandatory = $false)]
+            [switch]$SkipObservedWindowMerge
+        )
+
+        if (-not (Sync-VulnContentStoreSidecar -BasePath $BasePath)) {
+            return $null
+        }
+
+        $files = [System.Collections.Generic.List[System.IO.FileInfo]]::new()
+        foreach ($file in @(Get-VulnerabilityPayloadFingerprintSourceFileSet -BasePath $BasePath -SkipObservedWindowMerge:$SkipObservedWindowMerge)) {
+            if ($null -ne $file) {
+                $files.Add($file)
+            }
+        }
+
+        if ($files.Count -eq 0) {
+            return $null
+        }
+
+        $builder = [System.Text.StringBuilder]::new()
+        [void]$builder.AppendLine('dashboard-vuln-column-cache-v1')
+        [void]$builder.AppendLine(('SkipObservedWindowMerge=' + ($SkipObservedWindowMerge -eq $true)))
+        foreach ($file in @($files | Sort-Object FullName -Unique)) {
+            $hash = Get-FileSha256Hex -Path $file.FullName
+            [void]$builder.Append($file.FullName).Append('|')
+            [void]$builder.Append($file.Length).Append('|')
+            [void]$builder.Append($file.LastWriteTimeUtc.Ticks).Append('|')
+            [void]$builder.AppendLine($hash)
+        }
+
+    $fingerprintBytes = [System.Text.Encoding]::UTF8.GetBytes($builder.ToString())
+    $fingerprintHash = [System.Security.Cryptography.SHA256]::HashData($fingerprintBytes)
+    return ([System.BitConverter]::ToString($fingerprintHash)).Replace('-', '').ToLowerInvariant()
+}
+
+function Get-NormalizedVulnColumnCacheDirectoryPath {
+        [CmdletBinding()]
+        [OutputType([string])]
+        param(
+            [Parameter(Mandatory = $true)]
+            [string]$BasePath,
+
+            [Parameter(Mandatory = $true)]
+            [string]$Fingerprint,
+
+            [Parameter(Mandatory = $false)]
+            [switch]$Create
+        )
+
+    $cacheDirectory = Get-DashboardCacheDirectory -BasePath $BasePath -ChildPath 'vuln-columns' -Create:$Create
+    return Join-Path $cacheDirectory ("columns-{0}" -f $Fingerprint)
+}
+
+function Get-NormalizedVulnColumnCacheManifestPath {
+        [CmdletBinding()]
+        [OutputType([string])]
+        param(
+            [Parameter(Mandatory = $true)]
+            [string]$BasePath,
+
+            [Parameter(Mandatory = $true)]
+            [string]$Fingerprint,
+
+            [Parameter(Mandatory = $false)]
+            [switch]$Create
+        )
+
+    $cacheDirectory = Get-DashboardCacheDirectory -BasePath $BasePath -ChildPath 'vuln-columns' -Create:$Create
+    return Join-Path $cacheDirectory ("columns-{0}.json" -f $Fingerprint)
+}
+
+function Get-NormalizedVulnColumnCacheColumnPaths {
+        [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '', Justification = 'Internal helper intentionally returns the full set of normalized vulnerability column paths.')]
+        [CmdletBinding()]
+        [OutputType([hashtable])]
+        param(
+            [Parameter(Mandatory = $true)]
+            [string]$DirectoryPath
+        )
+
+        $paths = [ordered]@{}
+        foreach ($columnName in @('d', 'c', 's', 'v', 'f', 'l', 'ua', 'u', 'dp', 'rp', 'iv')) {
+            $paths[$columnName] = Join-Path $DirectoryPath ($columnName + '.json')
+        }
+
+    return $paths
+}
+
+function Clear-StaleNormalizedVulnColumnCache {
+        [CmdletBinding()]
+        param(
+            [Parameter(Mandatory = $true)]
+            [string]$BasePath,
+
+            [Parameter(Mandatory = $false)]
+            [string[]]$KeepPaths = @()
+        )
+
+        $cacheDirectory = Get-DashboardCacheDirectory -BasePath $BasePath -ChildPath 'vuln-columns'
+        if (-not (Test-Path -LiteralPath $cacheDirectory -PathType Container)) {
+            return
+        }
+
+        $normalizedKeepPaths = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+        foreach ($keepPath in @($KeepPaths)) {
+            if (-not [string]::IsNullOrWhiteSpace($keepPath)) {
+                [void]$normalizedKeepPaths.Add([System.IO.Path]::GetFullPath($keepPath))
+            }
+        }
+
+    foreach ($cacheItem in @(Get-ChildItem -Path $cacheDirectory -Force -ErrorAction SilentlyContinue)) {
+        if ($normalizedKeepPaths.Contains($cacheItem.FullName)) {
+            continue
+        }
+
+        Remove-Item -LiteralPath $cacheItem.FullName -Recurse -Force -ErrorAction SilentlyContinue
+    }
+}
+
+function Get-NormalizedVulnColumnCacheEntry {
+        [CmdletBinding()]
+        [OutputType([pscustomobject])]
+        param(
+            [Parameter(Mandatory = $true)]
+            [string]$BasePath,
+
+            [Parameter(Mandatory = $false)]
+            [switch]$SkipObservedWindowMerge
+        )
+
+        $fingerprint = Get-NormalizedVulnColumnCacheFingerprint -BasePath $BasePath -SkipObservedWindowMerge:$SkipObservedWindowMerge
+        if ([string]::IsNullOrWhiteSpace($fingerprint)) {
+            return $null
+        }
+
+        $columnDirectoryPath = Get-NormalizedVulnColumnCacheDirectoryPath -BasePath $BasePath -Fingerprint $fingerprint -Create
+        $manifestPath = Get-NormalizedVulnColumnCacheManifestPath -BasePath $BasePath -Fingerprint $fingerprint -Create
+        if ((-not (Test-Path -LiteralPath $columnDirectoryPath -PathType Container)) -or (-not (Test-Path -LiteralPath $manifestPath -PathType Leaf))) {
+            return $null
+        }
+
+        $columnPaths = Get-NormalizedVulnColumnCacheColumnPaths -DirectoryPath $columnDirectoryPath
+        foreach ($columnPath in $columnPaths.Values) {
+            if (-not (Test-Path -LiteralPath ([string]$columnPath) -PathType Leaf)) {
+                return $null
+            }
+        }
+
+        $manifest = Read-NormalizedPayloadManifest -Path $manifestPath
+        if ($null -eq $manifest) {
+            return $null
+        }
+
+        if ([string]$manifest.Fingerprint -ne $fingerprint) {
+            return $null
+        }
+
+    Clear-StaleNormalizedVulnColumnCache -BasePath $BasePath -KeepPaths @($columnDirectoryPath, $manifestPath)
+    return [PSCustomObject]@{
+        Fingerprint = $fingerprint
+        ColumnDirectoryPath = $columnDirectoryPath
+        ColumnPaths = $columnPaths
+        ManifestPath = $manifestPath
+        Manifest = $manifest
+    }
+}
+
+function Publish-NormalizedVulnColumnCache {
+        [CmdletBinding()]
+        [OutputType([pscustomobject])]
+        param(
+            [Parameter(Mandatory = $true)]
+            [string]$BasePath,
+
+            [Parameter(Mandatory = $true)]
+            [hashtable]$VulnColumnPaths,
+
+            [Parameter(Mandatory = $true)]
+            [int]$VulnCount,
+
+            [Parameter(Mandatory = $true)]
+            [object[]]$Dates,
+
+            [Parameter(Mandatory = $false)]
+            [object]$Quality,
+
+            [Parameter(Mandatory = $false)]
+            [switch]$SkipObservedWindowMerge,
+
+            [Parameter(Mandatory = $false)]
+            [int]$InventoryTupleCount = 0
+        )
+
+        $fingerprint = Get-NormalizedVulnColumnCacheFingerprint -BasePath $BasePath -SkipObservedWindowMerge:$SkipObservedWindowMerge
+        if ([string]::IsNullOrWhiteSpace($fingerprint)) {
+            return $null
+        }
+
+        $columnDirectoryPath = Get-NormalizedVulnColumnCacheDirectoryPath -BasePath $BasePath -Fingerprint $fingerprint -Create
+        $manifestPath = Get-NormalizedVulnColumnCacheManifestPath -BasePath $BasePath -Fingerprint $fingerprint -Create
+        $existingEntry = Get-NormalizedVulnColumnCacheEntry -BasePath $BasePath -SkipObservedWindowMerge:$SkipObservedWindowMerge
+        if ($existingEntry -and ([string]$existingEntry.Fingerprint -eq $fingerprint)) {
+            return $existingEntry
+        }
+
+        if (-not (Test-Path -LiteralPath $columnDirectoryPath -PathType Container)) {
+            [void](New-Item -Path $columnDirectoryPath -ItemType Directory -Force)
+        }
+
+        $cacheColumnPaths = Get-NormalizedVulnColumnCacheColumnPaths -DirectoryPath $columnDirectoryPath
+        foreach ($columnName in @($cacheColumnPaths.Keys)) {
+            $sourcePath = [string]$VulnColumnPaths[$columnName]
+            $destinationPath = [string]$cacheColumnPaths[$columnName]
+            if ([string]::IsNullOrWhiteSpace($sourcePath) -or -not (Test-Path -LiteralPath $sourcePath -PathType Leaf)) {
+                return $null
+            }
+
+            Copy-Item -LiteralPath $sourcePath -Destination $destinationPath -Force
+        }
+
+        $manifest = [ordered]@{
+            Version = 'dashboard-vuln-column-cache-v1'
+            Fingerprint = $fingerprint
+            GeneratedOnUtc = (Get-Date).ToUniversalTime().ToString('o')
+            VulnCount = $VulnCount
+            Dates = @($Dates)
+            Quality = $Quality
+            SkipObservedWindowMerge = ($SkipObservedWindowMerge -eq $true)
+            InventoryTupleCount = $InventoryTupleCount
+        }
+        Write-NormalizedPayloadManifest -Path $manifestPath -Manifest $manifest | Out-Null
+
+    Clear-StaleNormalizedVulnColumnCache -BasePath $BasePath -KeepPaths @($columnDirectoryPath, $manifestPath)
+    return [PSCustomObject]@{
+        Fingerprint = $fingerprint
+        ColumnDirectoryPath = $columnDirectoryPath
+        ColumnPaths = $cacheColumnPaths
+        ManifestPath = $manifestPath
+        Manifest = [PSCustomObject]$manifest
+    }
+}
+
 function Get-DashboardPayloadCacheFingerprint {
     [CmdletBinding()]
     [OutputType([string])]
@@ -11031,6 +11485,308 @@ function Get-NormalizationContext {
     }
 }
 
+function ConvertTo-NormalizedLookupRecord {
+    [CmdletBinding()]
+    [OutputType([pscustomobject])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [object]$Lookups,
+
+        [Parameter(Mandatory = $true)]
+        [int]$NoTagsIdx
+    )
+
+    return [PSCustomObject]@{
+        vendors = $Lookups.vendors
+        severities = $Lookups.severities
+        exploitLevels = $Lookups.exploitLevels
+        groups = $Lookups.groups
+        platforms = $Lookups.platforms
+        tags = $Lookups.tags
+        updates = $Lookups.updates
+        versions = $Lookups.versions
+        dates = $Lookups.dates
+        diskPaths = $Lookups.diskPaths
+        regPaths = $Lookups.regPaths
+        affSoftware = $Lookups.affSoftware
+        batchTitles = $Lookups.batchTitles
+        devices = $Lookups.devices
+        inventory = $Lookups.inventory
+        software = $Lookups.software
+        cves = $Lookups.cves
+        noTagsIdx = $NoTagsIdx
+    }
+}
+
+function Restore-ContentStoreNormalizedLookupsFromColumnCache {
+    [CmdletBinding()]
+    [OutputType([pscustomobject])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$DataPath,
+
+        [Parameter(Mandatory = $true)]
+        [hashtable]$Machines,
+
+        [Parameter(Mandatory = $false)]
+        [hashtable]$AdvancedHuntingData = @{},
+
+        [Parameter(Mandatory = $false)]
+        [hashtable]$AdvancedHuntingDeviceUsers = @{},
+
+        [Parameter(Mandatory = $false)]
+        [hashtable]$AdvancedHuntingInventoryData = @{},
+
+        [Parameter(Mandatory = $false)]
+        [hashtable]$NvdCveData = @{},
+
+        [Parameter(Mandatory = $false)]
+        [object[]]$CachedDates = @()
+    )
+
+    $dictionaryPath = Get-VulnContentDictionaryPath -BasePath $DataPath
+    if (-not (Test-Path -LiteralPath $dictionaryPath -PathType Leaf)) {
+        throw "Content dictionary '$dictionaryPath' was not found."
+    }
+
+    Compress-NormalizationMachineLookup -Machines $Machines | Out-Null
+
+    $context = Get-NormalizationContext
+    $context.Machines = $Machines
+    $context.AdvancedHuntingData = $AdvancedHuntingData
+    $context.AdvancedHuntingDeviceUsers = $AdvancedHuntingDeviceUsers
+    $context.AdvancedHuntingInventoryData = $AdvancedHuntingInventoryData
+    $context.NvdCveData = $NvdCveData
+
+    foreach ($cachedDate in @($CachedDates)) {
+        $dateText = [string]$cachedDate
+        if ([string]::IsNullOrWhiteSpace($dateText)) {
+            continue
+        }
+
+        if (-not $context.Indexes.dates.ContainsKey($dateText)) {
+            $context.Indexes.dates[$dateText] = $context.Lookups.dates.Count
+            $context.Lookups.dates.Add($dateText)
+        }
+    }
+
+    $dictionary = Read-VulnContentDictionary -Path $dictionaryPath
+    foreach ($deviceProfile in @($dictionary.deviceProfiles)) {
+        Add-NormalizedDevice `
+            -DeviceId ([string]$deviceProfile.id) `
+            -DeviceName ([string]$deviceProfile.n) `
+            -GroupName ([string]$deviceProfile.g) `
+            -OsPlatform ([string]$deviceProfile.o) `
+            -OsVersion ([string]$deviceProfile.ov) `
+            -MachineTags $(if ($deviceProfile.t) { @($deviceProfile.t) } else { @() }) `
+            -Context $context | Out-Null
+    }
+
+    foreach ($contentTemplate in @($dictionary.contentTemplates)) {
+        Resolve-NormalizedContentLookup `
+            -SoftwareVendor ([string]$contentTemplate.sv) `
+            -SoftwareName ([string]$contentTemplate.sn) `
+            -RecommendationReference ([string]$contentTemplate.rr) `
+            -CveId ([string]$contentTemplate.c) `
+            -CvssScore $contentTemplate.sc `
+            -SeverityLevel ([string]$contentTemplate.sev) `
+            -ExploitabilityLevel ([string]$contentTemplate.ex) `
+            -CveUrl ([string]$contentTemplate.bu) `
+            -CveBatchTitle ([string]$contentTemplate.bt) `
+            -RecommendedSecurityUpdate ([string]$contentTemplate.ru) `
+            -RecommendedSecurityUpdateId ([string]$contentTemplate.rid) `
+            -RecommendedSecurityUpdateUrl ([string]$contentTemplate.url) `
+            -SoftwareVersion ([string]$contentTemplate.ver) `
+            -DiskPaths @($contentTemplate.dp) `
+            -RegistryPaths @($contentTemplate.rp) `
+            -SecurityUpdateAvailable ($contentTemplate.ua -eq $true) `
+            -Context $context | Out-Null
+    }
+
+    $lookups = $context.Lookups
+    $tagIndex = $context.Indexes.tags
+    $noTagsLabel = '(No Tags)'
+    if ($context.HasNoTags -and -not $tagIndex.ContainsKey($noTagsLabel)) {
+        $tagIndex[$noTagsLabel] = $lookups.tags.Count
+        $lookups.tags.Add($noTagsLabel)
+    }
+    $noTagsIdx = if ($tagIndex.ContainsKey($noTagsLabel)) { $tagIndex[$noTagsLabel] } else { -1 }
+
+    Update-NormalizedAffectedSoftwareLookup -Lookups $lookups
+
+    return [PSCustomObject]@{
+        Lookups = (ConvertTo-NormalizedLookupRecord -Lookups $lookups -NoTagsIdx $noTagsIdx)
+        Quality = [PSCustomObject]@{
+            FirstLastSwappedCount = 0
+        }
+        Context = $context
+    }
+}
+
+function Restore-NormalizedVulnColumnPathsFromCache {
+    [CmdletBinding()]
+    [OutputType([pscustomobject])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [hashtable]$CachedColumnPaths,
+
+        [Parameter(Mandatory = $true)]
+        [pscustomobject]$RestoredLookupsResult,
+
+        [Parameter(Mandatory = $true)]
+        [string]$OutputDirectoryPath,
+
+        [Parameter(Mandatory = $false)]
+        [int]$CachedInventoryTupleCount = 0
+    )
+
+    $context = $RestoredLookupsResult.Context
+    $currentInventoryTupleCount = if ($null -ne $context -and $null -ne $context.AdvancedHuntingInventoryData) { $context.AdvancedHuntingInventoryData.Count } else { 0 }
+    if (($CachedInventoryTupleCount -eq 0) -and ($currentInventoryTupleCount -eq 0)) {
+        return [PSCustomObject]@{
+            ColumnPaths = $CachedColumnPaths
+            RefreshedInventoryColumn = $false
+            RowCount = 0
+        }
+    }
+
+    if ($null -eq $context) {
+        throw 'Restored lookup result does not contain the normalization context needed to refresh cached inventory columns.'
+    }
+
+    $resolvedOutputDirectoryPath = [System.IO.Path]::GetFullPath($OutputDirectoryPath)
+    if (Test-Path -LiteralPath $resolvedOutputDirectoryPath -PathType Container) {
+        Remove-Item -LiteralPath $resolvedOutputDirectoryPath -Recurse -Force -ErrorAction SilentlyContinue
+    }
+    [void](New-Item -Path $resolvedOutputDirectoryPath -ItemType Directory -Force)
+
+    $inventoryColumnPath = Join-Path $resolvedOutputDirectoryPath 'iv.json'
+    $inventoryColumnWriter = [PSCustomObject]@{
+        Path = $inventoryColumnPath
+        StreamWriter = [System.IO.StreamWriter]::new($inventoryColumnPath, $false, [System.Text.UTF8Encoding]::new($false))
+        Buffer = [System.Text.StringBuilder]::new(131072)
+        HasValue = $false
+    }
+    $inventoryColumnWriter.StreamWriter.Write('[')
+
+    $readerStates = [System.Collections.Generic.List[System.IDisposable]]::new()
+    $deviceReaderState = $null
+    $softwareReaderState = $null
+    $versionReaderState = $null
+
+    try {
+        foreach ($requiredColumnName in @('d', 's', 'v')) {
+            $columnPath = [string]$CachedColumnPaths[$requiredColumnName]
+            if ([string]::IsNullOrWhiteSpace($columnPath) -or -not (Test-Path -LiteralPath $columnPath -PathType Leaf)) {
+                throw "Cached normalized vulnerability column '$requiredColumnName' was not found."
+            }
+        }
+
+        $deviceReaderState = Open-CompactJsonArrayReader -Path ([string]$CachedColumnPaths['d'])
+        $softwareReaderState = Open-CompactJsonArrayReader -Path ([string]$CachedColumnPaths['s'])
+        $versionReaderState = Open-CompactJsonArrayReader -Path ([string]$CachedColumnPaths['v'])
+        [void]$readerStates.Add($deviceReaderState.JsonReader)
+        [void]$readerStates.Add($deviceReaderState.StreamReader)
+        [void]$readerStates.Add($softwareReaderState.JsonReader)
+        [void]$readerStates.Add($softwareReaderState.StreamReader)
+        [void]$readerStates.Add($versionReaderState.JsonReader)
+        [void]$readerStates.Add($versionReaderState.StreamReader)
+
+        $lookups = $context.Lookups
+        $rowCount = 0
+        while ($true) {
+            $deviceValueState = Read-NextCompactJsonArrayValue -ReaderState $deviceReaderState
+            $softwareValueState = Read-NextCompactJsonArrayValue -ReaderState $softwareReaderState
+            $versionValueState = Read-NextCompactJsonArrayValue -ReaderState $versionReaderState
+
+            if ((-not $deviceValueState.HasValue) -and (-not $softwareValueState.HasValue) -and (-not $versionValueState.HasValue)) {
+                break
+            }
+
+            if ((-not $deviceValueState.HasValue) -or (-not $softwareValueState.HasValue) -or (-not $versionValueState.HasValue)) {
+                throw 'Cached normalized vulnerability columns d/s/v have mismatched lengths.'
+            }
+
+            $deviceId = $null
+            $softwareVendor = ''
+            $softwareName = ''
+            $softwareVersion = ''
+
+            if ($null -ne $deviceValueState.Value) {
+                $deviceIndex = [int]$deviceValueState.Value
+                if ($deviceIndex -ge 0 -and $deviceIndex -lt $lookups.devices.Count) {
+                    $deviceEntry = $lookups.devices[$deviceIndex]
+                    $deviceId = if ($deviceEntry.PSObject.Properties['id']) { [string]$deviceEntry.id } else { $null }
+                }
+            }
+
+            if ($null -ne $softwareValueState.Value) {
+                $softwareIndex = [int]$softwareValueState.Value
+                if ($softwareIndex -ge 0 -and $softwareIndex -lt $lookups.software.Count) {
+                    $softwareEntry = $lookups.software[$softwareIndex]
+                    $softwareName = if ($softwareEntry.PSObject.Properties['n']) { [string]$softwareEntry.n } else { '' }
+                    if ($softwareEntry.PSObject.Properties['v'] -and $null -ne $softwareEntry.v) {
+                        $vendorIndex = [int]$softwareEntry.v
+                        if ($vendorIndex -ge 0 -and $vendorIndex -lt $lookups.vendors.Count) {
+                            $softwareVendor = [string]$lookups.vendors[$vendorIndex]
+                        }
+                    }
+                }
+            }
+
+            if ($null -ne $versionValueState.Value) {
+                $versionIndex = [int]$versionValueState.Value
+                if ($versionIndex -ge 0 -and $versionIndex -lt $lookups.versions.Count) {
+                    $softwareVersion = [string]$lookups.versions[$versionIndex]
+                }
+            }
+
+            $inventoryValue = Resolve-NormalizedInventoryLookup `
+                -DeviceId $deviceId `
+                -SoftwareVendor $softwareVendor `
+                -SoftwareName $softwareName `
+                -SoftwareVersion $softwareVersion `
+                -Context $context
+            Write-CompactColumnFileValue -WriterState $inventoryColumnWriter -Value $inventoryValue
+
+            $rowCount++
+            if (($rowCount % 100000) -eq 0) {
+                if ($inventoryColumnWriter.Buffer.Length -gt 0) {
+                    $inventoryColumnWriter.StreamWriter.Write($inventoryColumnWriter.Buffer.ToString())
+                    [void]$inventoryColumnWriter.Buffer.Clear()
+                }
+                $inventoryColumnWriter.StreamWriter.Flush()
+            }
+        }
+    }
+    finally {
+        foreach ($disposable in $readerStates) {
+            $disposable.Dispose()
+        }
+
+        if ($inventoryColumnWriter.StreamWriter) {
+            if ($inventoryColumnWriter.Buffer.Length -gt 0) {
+                $inventoryColumnWriter.StreamWriter.Write($inventoryColumnWriter.Buffer.ToString())
+                [void]$inventoryColumnWriter.Buffer.Clear()
+            }
+            $inventoryColumnWriter.StreamWriter.Write(']')
+            $inventoryColumnWriter.StreamWriter.Dispose()
+            $inventoryColumnWriter.StreamWriter = $null
+        }
+    }
+
+    $restoredColumnPaths = [ordered]@{}
+    foreach ($columnName in @('d', 'c', 's', 'v', 'f', 'l', 'ua', 'u', 'dp', 'rp', 'iv')) {
+        $restoredColumnPaths[$columnName] = if ($columnName -eq 'iv') { $inventoryColumnPath } else { [string]$CachedColumnPaths[$columnName] }
+    }
+
+    return [PSCustomObject]@{
+        ColumnPaths = $restoredColumnPaths
+        RefreshedInventoryColumn = $true
+        RowCount = $rowCount
+    }
+}
+
 function Write-CompactVulnRecordJson {
     param(
         [Parameter(Mandatory = $true)]
@@ -11212,6 +11968,74 @@ function Get-JsonElementPropertyValue {
     return Convert-JsonElementToScalarValue -Element $property
 }
 
+function Compress-NormalizationMachineLookup {
+    [CmdletBinding()]
+    [OutputType([hashtable])]
+    param(
+        [Parameter(Mandatory = $false)]
+        [AllowNull()]
+        [hashtable]$Machines
+    )
+
+    if ($null -eq $Machines -or $Machines.Count -eq 0) {
+        return @{}
+    }
+
+    foreach ($deviceId in @($Machines.Keys)) {
+        $machine = $Machines[$deviceId]
+        if ($null -eq $machine) {
+            $Machines.Remove($deviceId)
+            continue
+        }
+
+        if ($machine -is [System.Array] -and $machine.Length -ge 10) {
+            continue
+        }
+
+        $ip = $machine.PSObject.Properties['lastIpAddress']?.Value
+        $externalIp = $machine.PSObject.Properties['lastExternalIpAddress']?.Value
+        $healthStatus = $machine.PSObject.Properties['healthStatus']?.Value
+        $riskScore = $machine.PSObject.Properties['riskScore']?.Value
+        $exposureLevel = $machine.PSObject.Properties['exposureLevel']?.Value
+        $deviceValue = $machine.PSObject.Properties['deviceValue']?.Value
+        $managedBy = $machine.PSObject.Properties['managedBy']?.Value
+        $isAadJoined = $machine.PSObject.Properties['isAadJoined']?.Value
+        $lastSeen = $machine.PSObject.Properties['lastSeen']?.Value
+        $firstSeen = $machine.PSObject.Properties['firstSeen']?.Value
+
+        if (
+            $null -eq $ip -and
+            $null -eq $externalIp -and
+            $null -eq $healthStatus -and
+            $null -eq $riskScore -and
+            $null -eq $exposureLevel -and
+            $null -eq $deviceValue -and
+            $null -eq $managedBy -and
+            $null -eq $isAadJoined -and
+            $null -eq $lastSeen -and
+            $null -eq $firstSeen
+        ) {
+            $Machines.Remove($deviceId)
+            continue
+        }
+
+        $Machines[$deviceId] = [object[]]@(
+            $ip,
+            $externalIp,
+            $healthStatus,
+            $riskScore,
+            $exposureLevel,
+            $deviceValue,
+            $managedBy,
+            $isAadJoined,
+            $lastSeen,
+            $firstSeen
+        )
+    }
+
+    return $Machines
+}
+
 function Add-NormalizedDevice {
     param(
         $DeviceId,
@@ -11244,6 +12068,7 @@ function Add-NormalizedDevice {
 
     if (-not $deviceIndex.ContainsKey($deviceKey)) {
         $machine = if (-not [string]::IsNullOrWhiteSpace($DeviceId)) { $Context.Machines[$DeviceId] } else { $null }
+        $machineTuple = if ($machine -is [System.Array] -and $machine.Length -ge 10) { $machine } else { $null }
         $machineUsers = [string[]]@()
         if ($null -ne $Context.AdvancedHuntingDeviceUsers -and -not [string]::IsNullOrWhiteSpace($DeviceId)) {
             $rawMachineUsers = $Context.AdvancedHuntingDeviceUsers[[string]$DeviceId]
@@ -11256,18 +12081,16 @@ function Add-NormalizedDevice {
             }
         }
 
-        $resolvedGroupName = if ($machine) { $machine.PSObject.Properties['rbacGroupName']?.Value } else { $GroupName }
+        $resolvedGroupName = $GroupName
         if ([string]::IsNullOrWhiteSpace([string]$resolvedGroupName)) {
             $resolvedGroupName = if ([string]::IsNullOrWhiteSpace([string]$GroupName)) { '(none)' } else { $GroupName }
         }
         $groupIdx = Get-OrCreateIndex -value $resolvedGroupName -list $lookups.groups -indexMap $groupIndex
 
-        $osPlat = if ($machine) { $machine.PSObject.Properties['osPlatform']?.Value } else { $OsPlatform }
+        $osPlat = $OsPlatform
         $platIdx = Get-OrCreateIndex -value $osPlat -list $lookups.platforms -indexMap $platformIndex
 
-        $effectiveTags = if ($machine -and $machine.PSObject.Properties['machineTags']?.Value) { $machine.machineTags }
-                        elseif ($MachineTags) { $MachineTags }
-                        else { @() }
+        $effectiveTags = if ($MachineTags) { $MachineTags } else { @() }
         $tagIndices = [System.Collections.Generic.List[int]]::new()
         foreach ($tag in $effectiveTags) {
             $tagIdx = Get-OrCreateIndex -value $tag -list $lookups.tags -indexMap $tagIndex
@@ -11279,18 +12102,18 @@ function Add-NormalizedDevice {
 
         $machineInfo = $null
         if ($machine -or $machineUsers.Count -gt 0) {
-            $machineLastSeen = if ($machine) { $machine.PSObject.Properties['lastSeen']?.Value } else { $null }
-            $machineFirstSeen = if ($machine) { $machine.PSObject.Properties['firstSeen']?.Value } else { $null }
+            $machineLastSeen = if ($machineTuple) { $machineTuple[8] } elseif ($machine) { $machine.PSObject.Properties['lastSeen']?.Value } else { $null }
+            $machineFirstSeen = if ($machineTuple) { $machineTuple[9] } elseif ($machine) { $machine.PSObject.Properties['firstSeen']?.Value } else { $null }
             $machineInfo = [PSCustomObject]@{
-                ip = if ($machine) { $machine.PSObject.Properties['lastIpAddress']?.Value } else { $null }
-                eip = if ($machine) { $machine.PSObject.Properties['lastExternalIpAddress']?.Value } else { $null }
+                ip = if ($machineTuple) { $machineTuple[0] } elseif ($machine) { $machine.PSObject.Properties['lastIpAddress']?.Value } else { $null }
+                eip = if ($machineTuple) { $machineTuple[1] } elseif ($machine) { $machine.PSObject.Properties['lastExternalIpAddress']?.Value } else { $null }
                 u = if ($machineUsers.Count -gt 0) { @($machineUsers) } else { $null }
-                hs = if ($machine) { $machine.PSObject.Properties['healthStatus']?.Value } else { $null }
-                rs = if ($machine) { $machine.PSObject.Properties['riskScore']?.Value } else { $null }
-                el = if ($machine) { $machine.PSObject.Properties['exposureLevel']?.Value } else { $null }
-                dv = if ($machine) { $machine.PSObject.Properties['deviceValue']?.Value } else { $null }
-                mb = if ($machine) { $machine.PSObject.Properties['managedBy']?.Value } else { $null }
-                aad = if ($machine) { $machine.PSObject.Properties['isAadJoined']?.Value } else { $null }
+                hs = if ($machineTuple) { $machineTuple[2] } elseif ($machine) { $machine.PSObject.Properties['healthStatus']?.Value } else { $null }
+                rs = if ($machineTuple) { $machineTuple[3] } elseif ($machine) { $machine.PSObject.Properties['riskScore']?.Value } else { $null }
+                el = if ($machineTuple) { $machineTuple[4] } elseif ($machine) { $machine.PSObject.Properties['exposureLevel']?.Value } else { $null }
+                dv = if ($machineTuple) { $machineTuple[5] } elseif ($machine) { $machine.PSObject.Properties['deviceValue']?.Value } else { $null }
+                mb = if ($machineTuple) { $machineTuple[6] } elseif ($machine) { $machine.PSObject.Properties['managedBy']?.Value } else { $null }
+                aad = if ($machineTuple) { $machineTuple[7] } elseif ($machine) { $machine.PSObject.Properties['isAadJoined']?.Value } else { $null }
                 ls = Get-NormalizationCachedYmdDate -Context $Context -DateValue $machineLastSeen
                 fs = Get-NormalizationCachedYmdDate -Context $Context -DateValue $machineFirstSeen
             }
@@ -11298,10 +12121,10 @@ function Add-NormalizedDevice {
 
         $lookups.devices.Add([PSCustomObject]@{
             id = $DeviceId
-            n = if ($machine) { $machine.PSObject.Properties['computerDnsName']?.Value } elseif ($DeviceName) { $DeviceName } else { '(no machine data)' }
+            n = if ($DeviceName) { $DeviceName } elseif ($machine -and -not $machineTuple) { $machine.PSObject.Properties['computerDnsName']?.Value } else { '(no machine data)' }
             g = $groupIdx
             o = $platIdx
-            ov = if ($machine) { $machine.PSObject.Properties['osVersion']?.Value } else { $OsVersion }
+            ov = if ($OsVersion) { $OsVersion } elseif ($machine -and -not $machineTuple) { $machine.PSObject.Properties['osVersion']?.Value } else { $null }
             t = $tagIndices
             m = $machineInfo
         })
@@ -12158,6 +12981,8 @@ function Invoke-ContentStoreNormalization {
     $contentTemplates = @($dictionary.contentTemplates)
     $deviceProfileCount = $deviceProfiles.Count
     $contentTemplateCount = $contentTemplates.Count
+    $deviceProfileIds = [string[]]::new($deviceProfileCount)
+    $contentInventoryKeys = [object[]]::new($contentTemplateCount)
     $deviceLookupIndices = New-Object 'System.Int32[]' $deviceProfileCount
     $deviceOnboardedFlags = New-Object 'System.Boolean[]' $deviceProfileCount
     $contentLookupCache = New-Object 'System.Object[]' $contentTemplateCount
@@ -12168,6 +12993,7 @@ function Invoke-ContentStoreNormalization {
 
     for ($deviceProfileIndexValue = 0; $deviceProfileIndexValue -lt $deviceProfileCount; $deviceProfileIndexValue++) {
         $deviceProfile = $deviceProfiles[$deviceProfileIndexValue]
+        $deviceProfileIds[$deviceProfileIndexValue] = [string]$deviceProfile.id
         $machineTags = if ($deviceProfile.t) { @($deviceProfile.t) } else { @() }
         $deviceLookupIndices[$deviceProfileIndexValue] = Add-NormalizedDevice `
             -DeviceId ([string]$deviceProfile.id) `
@@ -12178,10 +13004,23 @@ function Invoke-ContentStoreNormalization {
             -MachineTags $machineTags `
             -Context $Context
         $deviceOnboardedFlags[$deviceProfileIndexValue] = ($deviceProfile.ob -eq $true)
+        $deviceProfiles[$deviceProfileIndexValue] = $null
+    }
+
+    $deviceProfiles = $deviceProfileIds
+
+    $dictionaryDeviceProfilesProperty = if ($null -ne $dictionary) { $dictionary.PSObject.Properties['deviceProfiles'] } else { $null }
+    if ($null -ne $dictionaryDeviceProfilesProperty) {
+        $dictionaryDeviceProfilesProperty.Value = @()
     }
 
     for ($contentTemplateIndexValue = 0; $contentTemplateIndexValue -lt $contentTemplateCount; $contentTemplateIndexValue++) {
         $contentTemplate = $contentTemplates[$contentTemplateIndexValue]
+        $contentInventoryKeys[$contentTemplateIndexValue] = [object[]]@(
+            [string]$contentTemplate.sv,
+            [string]$contentTemplate.sn,
+            [string]$contentTemplate.ver
+        )
 
         $contentLookupCache[$contentTemplateIndexValue] = Resolve-NormalizedContentLookup `
             -SoftwareVendor ([string]$contentTemplate.sv) `
@@ -12201,6 +13040,15 @@ function Invoke-ContentStoreNormalization {
             -RegistryPaths @($contentTemplate.rp) `
             -SecurityUpdateAvailable ($contentTemplate.ua -eq $true) `
             -Context $Context
+
+        $contentTemplates[$contentTemplateIndexValue] = $null
+    }
+
+    $contentTemplates = $contentInventoryKeys
+
+    $dictionaryContentTemplatesProperty = if ($null -ne $dictionary) { $dictionary.PSObject.Properties['contentTemplates'] } else { $null }
+    if ($null -ne $dictionaryContentTemplatesProperty) {
+        $dictionaryContentTemplatesProperty.Value = @()
     }
 
     try {
@@ -12324,7 +13172,7 @@ function Invoke-ContentStoreNormalization {
 
                             $contentLookup = $contentLookupCache[$contentTemplateIndexValue]
                             $contentTemplate = $contentTemplates[$contentTemplateIndexValue]
-                            $deviceProfile = $deviceProfiles[$deviceProfileIndexValue]
+                            $deviceProfileId = $deviceProfiles[$deviceProfileIndexValue]
                             $compactRecord[0] = $deviceLookupIndices[$deviceProfileIndexValue]
                             $compactRecord[1] = $contentLookup.cve
                             $compactRecord[2] = $contentLookup.sw
@@ -12336,10 +13184,10 @@ function Invoke-ContentStoreNormalization {
                             $compactRecord[8] = $contentLookup.dp
                             $compactRecord[9] = $contentLookup.rp
                             $compactRecord[10] = Resolve-NormalizedInventoryLookup `
-                                -DeviceId ([string]$deviceProfile.id) `
-                                -SoftwareVendor ([string]$contentTemplate.sv) `
-                                -SoftwareName ([string]$contentTemplate.sn) `
-                                -SoftwareVersion ([string]$contentTemplate.ver) `
+                                -DeviceId ([string]$deviceProfileId) `
+                                -SoftwareVendor ([string]$contentTemplate[0]) `
+                                -SoftwareName ([string]$contentTemplate[1]) `
+                                -SoftwareVersion ([string]$contentTemplate[2]) `
                                 -Context $Context
 
                             if ($columnStates) {
@@ -12470,7 +13318,7 @@ function Invoke-ContentStoreNormalization {
 
                                     $contentLookup = $contentLookupCache[$ctv]
                                     $contentTemplate = $contentTemplates[$ctv]
-                                    $deviceProfile = $deviceProfiles[$dpv]
+                                    $deviceProfileId = $deviceProfiles[$dpv]
                                     $compactRecord[0] = $deviceLookupIndices[$dpv]
                                     $compactRecord[1] = $contentLookup.cve
                                     $compactRecord[2] = $contentLookup.sw
@@ -12482,10 +13330,10 @@ function Invoke-ContentStoreNormalization {
                                     $compactRecord[8] = $contentLookup.dp
                                     $compactRecord[9] = $contentLookup.rp
                                     $compactRecord[10] = Resolve-NormalizedInventoryLookup `
-                                        -DeviceId ([string]$deviceProfile.id) `
-                                        -SoftwareVendor ([string]$contentTemplate.sv) `
-                                        -SoftwareName ([string]$contentTemplate.sn) `
-                                        -SoftwareVersion ([string]$contentTemplate.ver) `
+                                        -DeviceId ([string]$deviceProfileId) `
+                                        -SoftwareVendor ([string]$contentTemplate[0]) `
+                                        -SoftwareName ([string]$contentTemplate[1]) `
+                                        -SoftwareVersion ([string]$contentTemplate[2]) `
                                         -Context $Context
 
                                     if ($columnStates) {
@@ -12561,6 +13409,45 @@ function Invoke-ContentStoreNormalization {
         }
 
         Sync-NormalizedVulnWriter -WriterState $writerState
+
+        # Payload finalization only needs the compact lookup collections. Release
+        # the much larger content-store scaffolding first so hosted Automation
+        # does not carry that transient state into lookup serialization.
+        foreach ($transientArray in @($deviceProfiles, $contentTemplates, $deviceLookupIndices, $deviceOnboardedFlags, $contentLookupCache)) {
+            if ($null -ne $transientArray) {
+                [System.Array]::Clear($transientArray, 0, $transientArray.Length)
+            }
+        }
+
+        if ($null -ne $refPaths) {
+            $refPaths.Clear()
+        }
+
+        $Context.Machines = @{}
+        $Context.AdvancedHuntingData = @{}
+        $Context.AdvancedHuntingDeviceUsers = @{}
+        $Context.AdvancedHuntingInventoryData = @{}
+        $Context.NvdCveData = @{}
+
+        $dateValueCacheProperty = $Context.PSObject.Properties['DateValueCache']
+        if ($null -ne $dateValueCacheProperty -and $null -ne $dateValueCacheProperty.Value) {
+            $dateValueCacheProperty.Value.Clear()
+        }
+
+        $dictionary = $null
+        $deviceProfiles = $null
+        $contentTemplates = $null
+        $deviceLookupIndices = $null
+        $deviceOnboardedFlags = $null
+        $contentLookupCache = $null
+        $refPaths = $null
+
+        if (-not [string]::IsNullOrWhiteSpace($PayloadOutputPath)) {
+            Invoke-FullGarbageCollection
+            if (Get-Command -Name Write-MemoryUsage -ErrorAction SilentlyContinue) {
+                $null = Write-MemoryUsage -Label 'Pre-PayloadClose'
+            }
+        }
     }
     finally {
         if ($writerState) {
@@ -13433,6 +14320,7 @@ function ConvertTo-NormalizedData {
 
     Write-Information '  Normalizing data structure...' -InformationAction Continue
     Write-Information ("  Normalization inputs: {0} machine(s), {1} Advanced Hunting CVE(s), {2} device user row(s), {3} inventory tuple(s), {4} NVD CVE(s)" -f $Machines.Count, $AdvancedHuntingData.Count, $AdvancedHuntingDeviceUsers.Count, $AdvancedHuntingInventoryData.Count, $NvdCveData.Count) -InformationAction Continue
+    Compress-NormalizationMachineLookup -Machines $Machines | Out-Null
     $context = Get-NormalizationContext
     $context.Machines = $Machines
     $context.AdvancedHuntingData = $AdvancedHuntingData
@@ -13572,26 +14460,7 @@ function ConvertTo-NormalizedData {
     Update-NormalizedAffectedSoftwareLookup -Lookups $lookups
 
     return @{
-        Lookups = [PSCustomObject]@{
-            vendors = $lookups.vendors
-            severities = $lookups.severities
-            exploitLevels = $lookups.exploitLevels
-            groups = $lookups.groups
-            platforms = $lookups.platforms
-            tags = $lookups.tags
-            updates = $lookups.updates
-            versions = $lookups.versions
-            dates = $lookups.dates
-            diskPaths = $lookups.diskPaths
-            regPaths = $lookups.regPaths
-            affSoftware = $lookups.affSoftware
-            batchTitles = $lookups.batchTitles
-            devices = $lookups.devices
-            inventory = $lookups.inventory
-            software = $lookups.software
-            cves = $lookups.cves
-            noTagsIdx = $noTagsIdx
-        }
+        Lookups = (ConvertTo-NormalizedLookupRecord -Lookups $lookups -NoTagsIdx $noTagsIdx)
         Quality = [PSCustomObject]@{
             FirstLastSwappedCount = $firstLastSwappedCount
         }
@@ -13624,6 +14493,90 @@ function Write-MemoryUsage {
     $gcHeapMB     = [math]::Round([System.GC]::GetTotalMemory($false) / 1MB, 1)
     $prefix = if ($Label) { "[$Label] " } else { "" }
     Write-Output "  ${prefix}Memory — Working set: ${workingSetMB}MB  |  GC heap: ${gcHeapMB}MB"
+}
+
+function Set-PipelineExecutionStage {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '', Justification = 'Internal helper only updates in-memory pipeline stage state for status reporting.')]
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Stage,
+
+        [Parameter(Mandatory = $true)]
+        [string]$Message
+    )
+
+    $Script:PipelineCurrentStage = $Stage
+    $Script:PipelineCurrentStageMessage = $Message
+}
+
+function Write-PipelineExecutionStatus {
+    [CmdletBinding()]
+    [OutputType([bool])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$AccountName,
+
+        [Parameter(Mandatory = $true)]
+        [string]$StorageToken,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateSet('running', 'succeeded', 'failed')]
+        [string]$Status,
+
+        [Parameter(Mandatory = $false)]
+        [string]$Stage = $Script:PipelineCurrentStage,
+
+        [Parameter(Mandatory = $false)]
+        [string]$Message = $Script:PipelineCurrentStageMessage,
+
+        [Parameter(Mandatory = $false)]
+        [hashtable]$AdditionalProperties = @{}
+    )
+
+    if ([string]::IsNullOrWhiteSpace($AccountName) -or [string]::IsNullOrWhiteSpace($StorageToken)) {
+        return $false
+    }
+
+    $statusFilePath = Join-Path ([System.IO.Path]::GetTempPath()) ("pipeline-status-{0}.json" -f $Script:PipelineRunId)
+
+    try {
+        $statusDocument = [ordered]@{
+            version = 1
+            runId = $Script:PipelineRunId
+            executionHost = $Script:PipelineExecutionHost
+            executionHostEvidence = if ($null -ne $Script:PipelineExecutionHostDescriptor) { [string]$Script:PipelineExecutionHostDescriptor.Evidence } else { $null }
+            status = $Status
+            stage = $Stage
+            message = $Message
+            startedOnUtc = $Script:PipelineStartedOnUtc.ToString('o')
+            updatedOnUtc = ([datetime]::UtcNow).ToString('o')
+            storageAccountName = $AccountName
+            dashboardDeliveryMode = if ([string]::IsNullOrWhiteSpace($DashboardDeliveryMode)) { $null } else { $DashboardDeliveryMode }
+            includeAdvancedHunting = [bool]$IncludeAdvancedHunting
+            useExistingExportsOnly = [bool]$UseExistingExportsOnly
+            exportTarget = $Export
+        }
+
+        if ($Status -ne 'running') {
+            $statusDocument.completedOnUtc = ([datetime]::UtcNow).ToString('o')
+        }
+
+        foreach ($key in $AdditionalProperties.Keys) {
+            $statusDocument[$key] = $AdditionalProperties[$key]
+        }
+
+        $statusDocument | ConvertTo-Json -Depth 12 | Set-Content -LiteralPath $statusFilePath -Encoding utf8
+        Set-BlobContent -AccountName $AccountName -Container $Script:BlobContainers.Dashboards -BlobName $Script:PipelineStatusBlobName -SourcePath $statusFilePath -StorageToken $StorageToken -ContentType 'application/json' -AccessTier $Script:BlobAccessTiers.Dashboards
+        return $true
+    }
+    catch {
+        Write-Verbose ("Pipeline status write failed: {0}" -f $_.Exception.Message)
+        return $false
+    }
+    finally {
+        Remove-Item -LiteralPath $statusFilePath -Force -ErrorAction SilentlyContinue
+    }
 }
 
 # =============================================================================
@@ -13870,6 +14823,45 @@ function Get-BlobContent {
     Invoke-RestMethod -Uri $uri -Headers $headers -Method Get -OutFile $DestinationPath
 }
 
+function Get-BlobTextContent {
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$AccountName,
+
+        [Parameter(Mandatory = $true)]
+        [string]$Container,
+
+        [Parameter(Mandatory = $true)]
+        [string]$BlobName,
+
+        [Parameter(Mandatory = $true)]
+        [string]$StorageToken
+    )
+
+    $downloadPath = Join-Path ([System.IO.Path]::GetTempPath()) ("blob-text-{0}.tmp" -f [guid]::NewGuid().ToString('N'))
+    try {
+        Get-BlobContent -AccountName $AccountName -Container $Container -BlobName $BlobName -DestinationPath $downloadPath -StorageToken $StorageToken
+        if (-not (Test-Path -LiteralPath $downloadPath -PathType Leaf)) {
+            return $null
+        }
+
+        return (Get-Content -LiteralPath $downloadPath -Raw)
+    }
+    catch {
+        $statusCode = Get-BlobErrorStatusCode -ErrorRecord $_
+        if ($statusCode -eq 404) {
+            return $null
+        }
+
+        throw
+    }
+    finally {
+        Remove-Item -LiteralPath $downloadPath -Force -ErrorAction SilentlyContinue
+    }
+}
+
 function Set-BlobContent {
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '')]
     [CmdletBinding()]
@@ -13981,6 +14973,47 @@ function Remove-Blob {
             throw "Failed to delete blob '$BlobName' from '$Container': $_"
         }
     }
+}
+
+function Get-PipelineExecutionControlSettings {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '', Justification = 'Internal helper reads the full pipeline control settings document.')]
+    [CmdletBinding()]
+    [OutputType([object])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$AccountName,
+
+        [Parameter(Mandatory = $true)]
+        [string]$StorageToken
+    )
+
+    $content = Get-BlobTextContent -AccountName $AccountName -Container $Script:BlobContainers.Dashboards -BlobName $Script:PipelineControlBlobName -StorageToken $StorageToken
+    if ([string]::IsNullOrWhiteSpace($content)) {
+        return $null
+    }
+
+    try {
+        $control = $content | ConvertFrom-Json -Depth 12
+    }
+    catch {
+        Write-Warning ("Ignoring invalid pipeline control blob '{0}': {1}" -f $Script:PipelineControlBlobName, $_.Exception.Message)
+        return $null
+    }
+
+    if ($control.PSObject.Properties['notAfterUtc'] -and -not [string]::IsNullOrWhiteSpace([string]$control.notAfterUtc)) {
+        try {
+            if (([datetimeoffset]$control.notAfterUtc).UtcDateTime -lt [datetime]::UtcNow) {
+                Write-Output ("  Ignoring expired pipeline control blob '{0}'." -f $Script:PipelineControlBlobName)
+                return $null
+            }
+        }
+        catch {
+            Write-Warning ("Ignoring pipeline control blob with invalid notAfterUtc value: {0}" -f $_.Exception.Message)
+            return $null
+        }
+    }
+
+    return $control
 }
 
 # =============================================================================
@@ -14191,6 +15224,7 @@ function Export-ToStaticWebApp {
 $tempRoot = $null
 
 try {
+    Set-PipelineExecutionStage -Stage 'Authentication' -Message 'Authenticating with managed identity and resolving configuration.'
     Write-Output "========================================"
     Write-Output "  Vulnerability Dashboard Pipeline"
     Write-Output "========================================"
@@ -14238,6 +15272,13 @@ try {
 
     Write-Output "  Acquiring tokens..."
     $storageToken = Get-PlainToken -ResourceUrl 'https://storage.azure.com/'
+
+    $pipelineExecutionControl = Get-PipelineExecutionControlSettings -AccountName $StorageAccountName -StorageToken $storageToken
+    if ($null -ne $pipelineExecutionControl -and $pipelineExecutionControl.PSObject.Properties['useExistingExportsOnly']) {
+        $UseExistingExportsOnly = [bool]$pipelineExecutionControl.useExistingExportsOnly
+        Write-Output ("  Control blob override: UseExistingExportsOnly = {0}" -f $UseExistingExportsOnly)
+    }
+
     if ($UseExistingExportsOnly) {
         $mdeHeaders = $null
         Write-Output "  Stress mode enabled: using existing exports from blob storage only"
@@ -14262,6 +15303,8 @@ try {
     # -----------------------------------------------------------------
     # Stage B: Download historical data from blob storage
     # -----------------------------------------------------------------
+    Set-PipelineExecutionStage -Stage 'DownloadHistoricalData' -Message 'Downloading historical exports and dashboard templates from blob storage.'
+    [void](Write-PipelineExecutionStatus -AccountName $StorageAccountName -StorageToken $storageToken -Status 'running')
     Write-Output "`n--- Stage B: Download historical data ---"
 
     $tempBasePath = $null
@@ -14406,6 +15449,8 @@ try {
     # -----------------------------------------------------------------
     # Stage C: Export fresh MDE data
     # -----------------------------------------------------------------
+    Set-PipelineExecutionStage -Stage 'ExportFreshMdeData' -Message $(if ($UseExistingExportsOnly) { 'Reusing existing export blobs without calling the MDE APIs.' } else { 'Exporting fresh vulnerability, machine, and Advanced Hunting data from MDE APIs.' })
+    [void](Write-PipelineExecutionStatus -AccountName $StorageAccountName -StorageToken $storageToken -Status 'running')
     Write-Output "`n--- Stage C: Export fresh MDE data ---"
 
     if ($UseExistingExportsOnly) {
@@ -14481,6 +15526,8 @@ try {
     # -----------------------------------------------------------------
     # Stage D: Generate dashboard
     # -----------------------------------------------------------------
+    Set-PipelineExecutionStage -Stage 'GenerateDashboard' -Message 'Generating the dashboard artifacts from the normalized export data.'
+    [void](Write-PipelineExecutionStatus -AccountName $StorageAccountName -StorageToken $storageToken -Status 'running')
     Write-Output "`n--- Stage D: Generate dashboard ---"
 
     $tempVulnsPath = Join-Path -Path $tempRoot -ChildPath 'vulns.json'
@@ -14674,6 +15721,8 @@ try {
     # -----------------------------------------------------------------
     # Stage E: Export results
     # -----------------------------------------------------------------
+    Set-PipelineExecutionStage -Stage 'ExportResults' -Message ("Uploading dashboard and export artifacts using export target '{0}'." -f $Export)
+    [void](Write-PipelineExecutionStatus -AccountName $StorageAccountName -StorageToken $storageToken -Status 'running')
     Write-Output "`n--- Stage E: Export ($Export) ---"
 
     switch ($Export) {
@@ -14718,6 +15767,15 @@ try {
         }
     }
 
+    Set-PipelineExecutionStage -Stage 'Completed' -Message 'Pipeline completed successfully.'
+    [void](Write-PipelineExecutionStatus -AccountName $StorageAccountName -StorageToken $storageToken -Status 'succeeded' -AdditionalProperties @{
+            vulnerabilities = [int]$vulnCount
+            devices = [int]$deviceCount
+            cves = [int]$cveCount
+            dashboardSizeMb = [math]::Round([double]$finalSize, 2)
+            dashboardBlobName = $Script:DashboardBlobName
+        })
+
     # -----------------------------------------------------------------
     # Cleanup
     # -----------------------------------------------------------------
@@ -14741,6 +15799,13 @@ try {
     Write-Output "  Completed: $(([datetime]::UtcNow).ToString('yyyy-MM-dd HH:mm:ss')) UTC"
 }
 catch {
+    if (-not [string]::IsNullOrWhiteSpace($StorageAccountName) -and -not [string]::IsNullOrWhiteSpace($storageToken)) {
+        [void](Write-PipelineExecutionStatus -AccountName $StorageAccountName -StorageToken $storageToken -Status 'failed' -AdditionalProperties @{
+                error = [string]$_
+                stackTrace = [string]$_.ScriptStackTrace
+            })
+    }
+
     Write-Output "========================================"
     Write-Output "  Pipeline Failed!"
     Write-Output "========================================"

--- a/azure/Upload-Templates.ps1
+++ b/azure/Upload-Templates.ps1
@@ -29,12 +29,9 @@
     Author: Nathan McNulty
     
     Prerequisites:
-    - Az.Accounts module
-    - Authenticated Azure session (Connect-AzAccount)
+    - Authenticated Azure session via Connect-AzAccount or az login
     - Storage Blob Data Contributor role on the storage account
 #>
-
-#Requires -Modules Az.Accounts
 
 [CmdletBinding()]
 param(
@@ -49,6 +46,72 @@ param(
 )
 
 $ErrorActionPreference = 'Stop'
+
+function ConvertTo-PlainTextToken {
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [System.Security.SecureString]$Token
+    )
+
+    $tokenPointer = [System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($Token)
+    try {
+        return [System.Runtime.InteropServices.Marshal]::PtrToStringBSTR($tokenPointer)
+    }
+    finally {
+        [System.Runtime.InteropServices.Marshal]::ZeroFreeBSTR($tokenPointer)
+    }
+}
+
+function Get-StorageAccessToken {
+    [CmdletBinding()]
+    [OutputType([string])]
+    param()
+
+    $getAzAccessTokenCommand = Get-Command -Name 'Get-AzAccessToken' -ErrorAction SilentlyContinue
+    if ($null -ne $getAzAccessTokenCommand) {
+        $hasAzContext = $true
+        $getAzContextCommand = Get-Command -Name 'Get-AzContext' -ErrorAction SilentlyContinue
+        if ($null -ne $getAzContextCommand) {
+            try {
+                $azContext = Get-AzContext -ErrorAction Stop
+                $hasAzContext = ($null -ne $azContext -and $null -ne $azContext.Account)
+            }
+            catch {
+                $hasAzContext = $false
+            }
+        }
+
+        if ($hasAzContext) {
+            try {
+                $tokenResponse = Get-AzAccessToken -ResourceUrl 'https://storage.azure.com/' -AsSecureString -ErrorAction Stop
+                return ConvertTo-PlainTextToken -Token $tokenResponse.Token
+            }
+            catch {
+                Write-Verbose "Az PowerShell token acquisition failed: $_"
+            }
+        }
+    }
+
+    if ($null -ne (Get-Command -Name 'az' -CommandType Application -ErrorAction SilentlyContinue)) {
+        try {
+            $azAccessToken = (& az 'account' 'get-access-token' '--resource' 'https://storage.azure.com/' '--query' 'accessToken' '-o' 'tsv' 2>&1 | Out-String)
+            if ($LASTEXITCODE -eq 0 -and -not [string]::IsNullOrWhiteSpace($azAccessToken)) {
+                return $azAccessToken.Trim()
+            }
+
+            if ($LASTEXITCODE -ne 0 -and -not [string]::IsNullOrWhiteSpace($azAccessToken)) {
+                Write-Verbose ("Azure CLI token acquisition failed: {0}" -f $azAccessToken.Trim())
+            }
+        }
+        catch {
+            Write-Verbose "Azure CLI token acquisition failed: $_"
+        }
+    }
+
+    throw "No Azure Storage token source available. Run Connect-AzAccount or az login, then retry."
+}
 
 # Resolve templates path
 if (-not $TemplatesPath) {
@@ -68,10 +131,7 @@ $templateFiles = @(
 
 # Get bearer token for blob storage
 Write-Host "Authenticating to Azure Storage..." -ForegroundColor Cyan
-$tokenResponse = Get-AzAccessToken -ResourceUrl 'https://storage.azure.com/' -AsSecureString
-$ssPtr = [System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($tokenResponse.Token)
-try { $storageToken = [System.Runtime.InteropServices.Marshal]::PtrToStringBSTR($ssPtr) }
-finally { [System.Runtime.InteropServices.Marshal]::ZeroFreeBSTR($ssPtr) }
+$storageToken = Get-StorageAccessToken
 
 $baseUrl = "https://$StorageAccountName.blob.core.windows.net"
 $blobApiVersion = '2021-12-02'

--- a/build/Invoke-AzureDeploymentValidation.ps1
+++ b/build/Invoke-AzureDeploymentValidation.ps1
@@ -27,6 +27,9 @@ param(
     [int]$FunctionExecutionTimeoutMinutes = 25,
 
     [Parameter(Mandatory = $false)]
+    [string]$FunctionExecutionDatasetPath,
+
+    [Parameter(Mandatory = $false)]
     [switch]$SkipFunctionExecution
 )
 
@@ -36,6 +39,142 @@ $ErrorActionPreference = 'Stop'
 $buildRoot = $PSScriptRoot
 $repoRoot = Split-Path -Path $buildRoot -Parent
 $setupScriptPath = Join-Path $repoRoot 'Setup-AzureResources.ps1'
+$script:FunctionExecutionControlBlobName = '_diagnostics/ExportAndGenerate.control.json'
+$script:FunctionExecutionStatusContainerName = 'dashboards'
+$script:FunctionExecutionStatusBlobName = '_diagnostics/ExportAndGenerate.status.json'
+
+function Get-ValidationTimestampText {
+    [CmdletBinding()]
+    [OutputType([string])]
+    param()
+
+    return (Get-Date).ToUniversalTime().ToString('u')
+}
+
+function Write-ValidationLogLine {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Message,
+
+        [Parameter(Mandatory = $false)]
+        [string]$ForegroundColor = 'Gray'
+    )
+
+    if ([string]::IsNullOrWhiteSpace($Message)) {
+        return
+    }
+
+    foreach ($line in ($Message -split "`r?`n")) {
+        if ([string]::IsNullOrWhiteSpace($line)) {
+            continue
+        }
+
+        if ($line -match '^\[(?:\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}Z|\d{4}-\d{2}-\d{2}T[^\]]+)\]\s') {
+            Write-Host $line -ForegroundColor $ForegroundColor
+            continue
+        }
+
+        Write-Host ("[{0}] {1}" -f (Get-ValidationTimestampText), $line) -ForegroundColor $ForegroundColor
+    }
+}
+
+function Get-ValidationStreamMessageText {
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory = $false)]
+        [AllowNull()]
+        $Record
+    )
+
+    if ($null -eq $Record) {
+        return $null
+    }
+
+    if ($Record -is [System.Management.Automation.InformationRecord]) {
+        return [string]$Record.MessageData
+    }
+
+    if ($Record -is [System.Management.Automation.WarningRecord]) {
+        return ("WARNING: {0}" -f $Record.Message)
+    }
+
+    if ($Record -is [System.Management.Automation.VerboseRecord]) {
+        return ("VERBOSE: {0}" -f $Record.Message)
+    }
+
+    if ($Record -is [System.Management.Automation.DebugRecord]) {
+        return ("DEBUG: {0}" -f $Record.Message)
+    }
+
+    if ($Record -is [System.Management.Automation.ErrorRecord]) {
+        if (-not [string]::IsNullOrWhiteSpace([string]$Record.Exception.Message)) {
+            return ("ERROR: {0}" -f $Record.Exception.Message)
+        }
+
+        return ("ERROR: {0}" -f ($Record | Out-String).Trim())
+    }
+
+    return ($Record | Out-String).TrimEnd()
+}
+
+function Get-ValidationStreamForegroundColor {
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory = $false)]
+        [AllowNull()]
+        $Record
+    )
+
+    if ($Record -is [System.Management.Automation.WarningRecord]) {
+        return 'Yellow'
+    }
+
+    if ($Record -is [System.Management.Automation.ErrorRecord]) {
+        return 'Red'
+    }
+
+    if ($Record -is [System.Management.Automation.DebugRecord]) {
+        return 'DarkGray'
+    }
+
+    return 'Gray'
+}
+
+function Invoke-TimestampedCommand {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [scriptblock]$ScriptBlock,
+
+        [Parameter(Mandatory = $false)]
+        [string]$FailureDescription = 'Command'
+    )
+
+    $previousLastExitCode = $global:LASTEXITCODE
+    $commandExitCode = 0
+    try {
+        $global:LASTEXITCODE = 0
+
+        foreach ($record in (& $ScriptBlock 6>&1 5>&1 4>&1 3>&1)) {
+            $message = Get-ValidationStreamMessageText -Record $record
+            if (-not [string]::IsNullOrWhiteSpace($message)) {
+                Write-ValidationLogLine -Message $message -ForegroundColor (Get-ValidationStreamForegroundColor -Record $record)
+            }
+        }
+
+        $commandExitCode = $global:LASTEXITCODE
+    }
+    finally {
+        $global:LASTEXITCODE = $previousLastExitCode
+    }
+
+    if ($commandExitCode -ne 0) {
+        throw ("{0} failed with exit code {1}." -f $FailureDescription, $commandExitCode)
+    }
+}
 
 function Invoke-AzCliJson {
     [CmdletBinding()]
@@ -223,6 +362,228 @@ function Resolve-DashboardDeliveryMode {
     return 'Auto'
 }
 
+function Get-DatasetFiles {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '', Justification = 'Internal helper intentionally returns a collection of dataset files.')]
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Path
+    )
+
+    return @(
+        Get-ChildItem -LiteralPath $Path -File |
+            Where-Object {
+                $_.Name -match '\.json(\.gz)?$' -and
+                $_.Name -notin @(
+                    '.synthetic-progress.json',
+                    '.synthetic-progress.json.gz',
+                    'stress-validation-report.json',
+                    'stress-validation-report.json.gz'
+                )
+            } |
+            Sort-Object -Property Name
+    )
+}
+
+function Resolve-FunctionExecutionDatasetPath {
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory = $false)]
+        [AllowEmptyString()]
+        [string]$RequestedPath
+    )
+
+    $candidatePath = $RequestedPath
+    if ([string]::IsNullOrWhiteSpace($candidatePath)) {
+        $defaultPath = Join-Path $repoRoot 'exports'
+        if (Test-Path -LiteralPath $defaultPath -PathType Container) {
+            $candidatePath = $defaultPath
+        }
+    }
+
+    if ([string]::IsNullOrWhiteSpace($candidatePath)) {
+        return $null
+    }
+
+    $resolvedPath = if ([System.IO.Path]::IsPathRooted($candidatePath)) {
+        [System.IO.Path]::GetFullPath($candidatePath)
+    }
+    else {
+        [System.IO.Path]::GetFullPath((Join-Path -Path $repoRoot -ChildPath $candidatePath))
+    }
+
+    if (-not (Test-Path -LiteralPath $resolvedPath -PathType Container)) {
+        throw "Function execution dataset path not found: $resolvedPath"
+    }
+
+    return $resolvedPath
+}
+
+function Clear-BlobContainer {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$AccountName,
+
+        [Parameter(Mandatory = $true)]
+        [string]$ContainerName
+    )
+
+    $blobs = @(Invoke-AzCliJson -Arguments @(
+        'storage', 'blob', 'list',
+        '--account-name', $AccountName,
+        '--container-name', $ContainerName,
+        '--auth-mode', 'login',
+        '-o', 'json'
+    ))
+
+    foreach ($blob in @($blobs)) {
+        if ($null -eq $blob -or [string]::IsNullOrWhiteSpace([string]$blob.name)) {
+            continue
+        }
+
+        & az storage blob delete --account-name $AccountName --container-name $ContainerName --name ([string]$blob.name) --auth-mode login --output none | Out-Null
+        if ($LASTEXITCODE -ne 0) {
+            throw "Failed to delete blob '$([string]$blob.name)' from container '$ContainerName'."
+        }
+    }
+}
+
+function Set-FunctionAppAppSettings {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '', Justification = 'Internal helper updates a coordinated set of Function App settings during scripted validation.')]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '', Justification = 'Internal helper accepts multiple settings by design.')]
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$FunctionAppName,
+
+        [Parameter(Mandatory = $true)]
+        [string]$FunctionResourceGroup,
+
+        [Parameter(Mandatory = $true)]
+        [string[]]$Settings
+    )
+
+    if (@($Settings).Count -eq 0) {
+        return
+    }
+
+    & az functionapp config appsettings set --name $FunctionAppName --resource-group $FunctionResourceGroup --settings @($Settings) --output none | Out-Null
+    if ($LASTEXITCODE -ne 0) {
+        throw ("Failed to update Function App app settings: {0}" -f (@($Settings) -join ', '))
+    }
+}
+
+function Restore-FunctionAppSettingValue {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$FunctionAppName,
+
+        [Parameter(Mandatory = $true)]
+        [string]$FunctionResourceGroup,
+
+        [Parameter(Mandatory = $true)]
+        [string]$SettingName,
+
+        [Parameter(Mandatory = $false)]
+        [AllowNull()]
+        [string]$OriginalValue
+    )
+
+    if ($null -eq $OriginalValue) {
+        & az functionapp config appsettings delete --name $FunctionAppName --resource-group $FunctionResourceGroup --setting-names $SettingName --output none | Out-Null
+        if ($LASTEXITCODE -ne 0) {
+            throw ("Failed to delete Function App app setting '{0}'." -f $SettingName)
+        }
+
+        return
+    }
+
+    Set-FunctionAppAppSettings -FunctionAppName $FunctionAppName -FunctionResourceGroup $FunctionResourceGroup -Settings @(("{0}={1}" -f $SettingName, $OriginalValue))
+}
+
+function Restart-FunctionAppInstance {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '', Justification = 'Internal helper restarts the Function App as part of scripted validation setup.')]
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$FunctionAppName,
+
+        [Parameter(Mandatory = $true)]
+        [string]$FunctionResourceGroup,
+
+        [Parameter(Mandatory = $false)]
+        [string]$Reason = 'apply updated app settings'
+    )
+
+    Write-ValidationLogLine -Message ("Restarting Function App '{0}' to {1}..." -f $FunctionAppName, $Reason)
+    & az functionapp restart --name $FunctionAppName --resource-group $FunctionResourceGroup --output none | Out-Null
+    if ($LASTEXITCODE -ne 0) {
+        throw ("Failed to restart Function App '{0}'." -f $FunctionAppName)
+    }
+}
+
+function Refresh-FunctionExecutionTemplates {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseApprovedVerbs', '', Justification = 'Internal helper refreshes template blobs for validation without exposing a public command surface.')]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '', Justification = 'Internal helper refreshes a set of template assets by design.')]
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$StorageAccountName
+    )
+
+    $uploadScriptPath = Join-Path $repoRoot 'azure\Upload-Templates.ps1'
+    if (-not (Test-Path -LiteralPath $uploadScriptPath -PathType Leaf)) {
+        throw "Upload-Templates.ps1 not found: $uploadScriptPath"
+    }
+
+    Write-ValidationLogLine -Message ("Refreshing dashboard templates in storage account '{0}'..." -f $StorageAccountName)
+    Invoke-TimestampedCommand -ScriptBlock { & $uploadScriptPath -StorageAccountName $StorageAccountName }
+}
+
+function Seed-ExportsContainer {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseApprovedVerbs', '', Justification = 'Internal helper prepares the Function App exports container for execution validation.')]
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$AccountName,
+
+        [Parameter(Mandatory = $true)]
+        [string]$DatasetPath
+    )
+
+    $datasetFiles = @(Get-DatasetFiles -Path $DatasetPath)
+    if ($datasetFiles.Count -eq 0) {
+        throw "Function execution dataset '$DatasetPath' does not contain any export files."
+    }
+
+    $missingFiles = [System.Collections.Generic.List[string]]::new()
+    foreach ($requiredName in @('Machines_Current.json.gz', 'VulnContentDictionary.json.gz', 'VulnCurrentRefs.json.gz')) {
+        if (-not (Test-Path -LiteralPath (Join-Path -Path $DatasetPath -ChildPath $requiredName) -PathType Leaf)) {
+            $missingFiles.Add($requiredName) | Out-Null
+        }
+    }
+
+    if (@(Get-ChildItem -LiteralPath $DatasetPath -Filter 'VulnHistoryRefs_*.json.gz' -File -ErrorAction SilentlyContinue).Count -eq 0) {
+        $missingFiles.Add('VulnHistoryRefs_*.json.gz') | Out-Null
+    }
+
+    if ($missingFiles.Count -gt 0) {
+        throw ("Function execution dataset is incomplete. Missing required file(s): {0}" -f ($missingFiles -join ', '))
+    }
+
+    Clear-BlobContainer -AccountName $AccountName -ContainerName 'exports'
+    foreach ($file in $datasetFiles) {
+        $contentType = if ($file.Name.EndsWith('.gz')) { 'application/gzip' } else { 'application/json' }
+        & az storage blob upload --account-name $AccountName --container-name exports --name $file.Name --file $file.FullName --content-type $contentType --auth-mode login --overwrite --output none | Out-Null
+        if ($LASTEXITCODE -ne 0) {
+            throw "Failed to upload '$($file.Name)' to the Function App exports container."
+        }
+    }
+}
+
 function Invoke-FunctionAdminRequest {
     [CmdletBinding()]
     param(
@@ -287,11 +648,16 @@ function Wait-FunctionHostReady {
         [int]$TimeoutMinutes = 10
     )
 
+    Write-ValidationLogLine -Message ("Waiting for Function App host readiness on '{0}'..." -f $HostName)
+
     $deadline = [datetime]::UtcNow.AddMinutes($TimeoutMinutes)
+    $stopwatch = [System.Diagnostics.Stopwatch]::StartNew()
+    $lastHeartbeatSecond = -30
     while ([datetime]::UtcNow -lt $deadline) {
         try {
             $response = Invoke-FunctionAdminRequest -Method Get -HostName $HostName -MasterKey $MasterKey -Path 'admin/host/status'
             if ($null -ne $response -and $response.StatusCode -ge 200 -and $response.StatusCode -lt 300) {
+                Write-ValidationLogLine -Message ("Function App host is ready after {0:N1}s." -f $stopwatch.Elapsed.TotalSeconds) -ForegroundColor Green
                 return
             }
         }
@@ -299,10 +665,135 @@ function Wait-FunctionHostReady {
             Write-Verbose ("Function host not ready yet: {0}" -f $_.Exception.Message)
         }
 
+        $elapsedWholeSeconds = [Math]::Floor($stopwatch.Elapsed.TotalSeconds)
+        if (($lastHeartbeatSecond + 30) -le $elapsedWholeSeconds) {
+            Write-ValidationLogLine -Message ("Still waiting for Function App host readiness ({0}s elapsed)." -f $elapsedWholeSeconds)
+            $lastHeartbeatSecond = $elapsedWholeSeconds
+        }
+
         Start-Sleep -Seconds 10
     }
 
     throw "Timed out waiting for Function App host '$HostName' to become ready."
+}
+
+function Wait-FunctionAdminFunctionReady {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$HostName,
+
+        [Parameter(Mandatory = $true)]
+        [string]$MasterKey,
+
+        [Parameter(Mandatory = $false)]
+        [string]$FunctionName = 'ExportAndGenerate',
+
+        [Parameter(Mandatory = $false)]
+        [int]$TimeoutMinutes = 5
+    )
+
+    Write-ValidationLogLine -Message ("Waiting for admin function definition '{0}' on '{1}'..." -f $FunctionName, $HostName)
+
+    $deadline = [datetime]::UtcNow.AddMinutes($TimeoutMinutes)
+    $stopwatch = [System.Diagnostics.Stopwatch]::StartNew()
+    $lastHeartbeatSecond = -30
+    while ([datetime]::UtcNow -lt $deadline) {
+        try {
+            $response = Invoke-FunctionAdminRequest -Method Get -HostName $HostName -MasterKey $MasterKey -Path 'admin/functions'
+            if ($null -ne $response -and $response.StatusCode -ge 200 -and $response.StatusCode -lt 300) {
+                $definitions = @([string]$response.Content | ConvertFrom-Json -Depth 20)
+                $matchingDefinition = @(
+                    $definitions | Where-Object {
+                        $name = if ($_.PSObject.Properties['name']) { [string]$_.name } else { '' }
+                        $configName = if ($_.PSObject.Properties['config'] -and $_.config -and $_.config.PSObject.Properties['name']) { [string]$_.config.name } else { '' }
+                        ($name -eq $FunctionName) -or
+                        ($name -like "*/$FunctionName") -or
+                        ($configName -eq $FunctionName)
+                    }
+                ) | Select-Object -First 1
+
+                if ($null -ne $matchingDefinition) {
+                    Write-ValidationLogLine -Message ("Admin function definition '{0}' is ready after {1:N1}s." -f $FunctionName, $stopwatch.Elapsed.TotalSeconds) -ForegroundColor Green
+                    return
+                }
+            }
+        }
+        catch {
+            Write-Verbose ("Function definition not ready yet: {0}" -f $_.Exception.Message)
+        }
+
+        $elapsedWholeSeconds = [Math]::Floor($stopwatch.Elapsed.TotalSeconds)
+        if (($lastHeartbeatSecond + 30) -le $elapsedWholeSeconds) {
+            Write-ValidationLogLine -Message ("Still waiting for admin function definition '{0}' ({1}s elapsed)." -f $FunctionName, $elapsedWholeSeconds)
+            $lastHeartbeatSecond = $elapsedWholeSeconds
+        }
+
+        Start-Sleep -Seconds 10
+    }
+
+    throw "Timed out waiting for Function App admin definition '$FunctionName' on host '$HostName'."
+}
+
+function Start-FunctionExecution {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '', Justification = 'Internal helper triggers a Function App execution as part of scripted validation.')]
+    [CmdletBinding()]
+    [OutputType([datetime])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$HostName,
+
+        [Parameter(Mandatory = $true)]
+        [string]$MasterKey,
+
+        [Parameter(Mandatory = $false)]
+        [int]$TimeoutMinutes = 5
+    )
+
+    Write-ValidationLogLine -Message 'Invoking Function App admin endpoint...'
+
+    $deadline = [datetime]::UtcNow.AddMinutes($TimeoutMinutes)
+    $lastFailure = $null
+    $stopwatch = [System.Diagnostics.Stopwatch]::StartNew()
+    $lastHeartbeatSecond = -30
+    while ([datetime]::UtcNow -lt $deadline) {
+        try {
+            $response = Invoke-FunctionAdminRequest -Method Post -HostName $HostName -MasterKey $MasterKey -Path 'admin/functions/ExportAndGenerate' -Body '{}'
+            if ($null -ne $response -and $response.StatusCode -ge 200 -and $response.StatusCode -lt 300) {
+                $startedUtc = [datetime]::UtcNow
+                Write-ValidationLogLine -Message ("Function App execution accepted at {0}." -f $startedUtc.ToString('o')) -ForegroundColor Green
+                return $startedUtc
+            }
+
+            $lastFailure = 'Function admin invocation returned no response.'
+        }
+        catch {
+            $lastFailure = $_.Exception.Message
+        }
+
+        $elapsedWholeSeconds = [Math]::Floor($stopwatch.Elapsed.TotalSeconds)
+        if (($lastHeartbeatSecond + 30) -le $elapsedWholeSeconds) {
+            $message = if ([string]::IsNullOrWhiteSpace($lastFailure)) {
+                'Function admin invocation has not succeeded yet.'
+            }
+            else {
+                "Function admin invocation still waiting: $lastFailure"
+            }
+
+            Write-ValidationLogLine -Message ("{0} ({1}s elapsed)." -f $message, $elapsedWholeSeconds)
+            $lastHeartbeatSecond = $elapsedWholeSeconds
+        }
+
+        Start-Sleep -Seconds 10
+        Wait-FunctionHostReady -HostName $HostName -MasterKey $MasterKey -TimeoutMinutes 2
+        Wait-FunctionAdminFunctionReady -HostName $HostName -MasterKey $MasterKey -TimeoutMinutes 2
+    }
+
+    if (-not [string]::IsNullOrWhiteSpace($lastFailure)) {
+        throw "Function App execution did not start successfully. $lastFailure"
+    }
+
+    throw 'Function App execution did not start successfully before timeout.'
 }
 
 function Invoke-FunctionTraceCleanup {
@@ -425,10 +916,16 @@ function Get-BlobLastModifiedUtc {
     [OutputType([datetime])]
     param(
         [Parameter(Mandatory = $true)]
-        [string]$StorageAccountName
+        [string]$StorageAccountName,
+
+        [Parameter(Mandatory = $false)]
+        [string]$ContainerName = 'dashboards',
+
+        [Parameter(Mandatory = $false)]
+        [string]$BlobName = 'VulnerabilityDashboard.html'
     )
 
-    $output = & az storage blob show --auth-mode login --account-name $StorageAccountName --container-name dashboards --name VulnerabilityDashboard.html --query properties.lastModified -o tsv 2>$null
+    $output = & az storage blob show --auth-mode login --account-name $StorageAccountName --container-name $ContainerName --name $BlobName --query properties.lastModified -o tsv 2>$null
     if ($LASTEXITCODE -ne 0) {
         return $null
     }
@@ -439,6 +936,229 @@ function Get-BlobLastModifiedUtc {
     }
 
     return ([datetimeoffset]$text).UtcDateTime
+}
+
+function Get-BlobTextContent {
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$StorageAccountName,
+
+        [Parameter(Mandatory = $true)]
+        [string]$ContainerName,
+
+        [Parameter(Mandatory = $true)]
+        [string]$BlobName
+    )
+
+    $downloadPath = Join-Path ([System.IO.Path]::GetTempPath()) ("validation-blob-{0}.tmp" -f [guid]::NewGuid().ToString('N'))
+    try {
+        & az storage blob download --auth-mode login --account-name $StorageAccountName --container-name $ContainerName --name $BlobName --file $downloadPath --output none 2>$null | Out-Null
+        if ($LASTEXITCODE -ne 0 -or -not (Test-Path -LiteralPath $downloadPath -PathType Leaf)) {
+            return $null
+        }
+
+        return (Get-Content -LiteralPath $downloadPath -Raw)
+    }
+    finally {
+        Remove-Item -LiteralPath $downloadPath -Force -ErrorAction SilentlyContinue
+    }
+}
+
+function Get-FunctionExecutionStatus {
+    [CmdletBinding()]
+    [OutputType([object])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$StorageAccountName
+    )
+
+    $content = Get-BlobTextContent -StorageAccountName $StorageAccountName -ContainerName $script:FunctionExecutionStatusContainerName -BlobName $script:FunctionExecutionStatusBlobName
+    if ([string]::IsNullOrWhiteSpace($content)) {
+        return $null
+    }
+
+    try {
+        return ($content | ConvertFrom-Json -Depth 20)
+    }
+    catch {
+        return [PSCustomObject]@{
+            rawContent = $content
+        }
+    }
+}
+
+function Get-FunctionExecutionStatusSummaryText {
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory = $false)]
+        [AllowNull()]
+        $StatusDocument
+    )
+
+    if ($null -eq $StatusDocument) {
+        return 'none'
+    }
+
+    if ($StatusDocument.PSObject.Properties['rawContent']) {
+        return 'unparsed-status-blob'
+    }
+
+    $statusText = if ($StatusDocument.PSObject.Properties['status']) { [string]$StatusDocument.status } else { 'unknown' }
+    $stageText = if ($StatusDocument.PSObject.Properties['stage']) { [string]$StatusDocument.stage } else { 'unknown' }
+    $messageText = if ($StatusDocument.PSObject.Properties['message']) { [string]$StatusDocument.message } else { '' }
+    if ([string]::IsNullOrWhiteSpace($messageText)) {
+        return ("{0}/{1}" -f $statusText, $stageText)
+    }
+
+    return ("{0}/{1}: {2}" -f $statusText, $stageText, $messageText)
+}
+
+function Set-FunctionExecutionControlBlob {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '', Justification = 'Internal helper writes a short-lived control blob for scripted Function App validation.')]
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$StorageAccountName,
+
+        [Parameter(Mandatory = $true)]
+        [bool]$UseExistingExportsOnly,
+
+        [Parameter(Mandatory = $false)]
+        [int]$ExpiresInMinutes = 30
+    )
+
+    $controlDocument = [ordered]@{
+        version = 1
+        source = 'Invoke-AzureDeploymentValidation'
+        createdOnUtc = ([datetime]::UtcNow).ToString('o')
+        notAfterUtc = ([datetime]::UtcNow.AddMinutes($ExpiresInMinutes)).ToString('o')
+        useExistingExportsOnly = $UseExistingExportsOnly
+    }
+
+    $controlFilePath = Join-Path ([System.IO.Path]::GetTempPath()) ("function-control-{0}.json" -f [guid]::NewGuid().ToString('N'))
+    try {
+        $controlDocument | ConvertTo-Json -Depth 10 | Set-Content -LiteralPath $controlFilePath -Encoding utf8
+        & az storage blob upload --auth-mode login --account-name $StorageAccountName --container-name $script:FunctionExecutionStatusContainerName --name $script:FunctionExecutionControlBlobName --file $controlFilePath --content-type application/json --overwrite --output none | Out-Null
+        if ($LASTEXITCODE -ne 0) {
+            throw ("Failed to upload Function App execution control blob '{0}'." -f $script:FunctionExecutionControlBlobName)
+        }
+    }
+    finally {
+        Remove-Item -LiteralPath $controlFilePath -Force -ErrorAction SilentlyContinue
+    }
+}
+
+function Remove-FunctionExecutionControlBlob {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '', Justification = 'Internal helper removes a short-lived control blob created for scripted Function App validation.')]
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$StorageAccountName
+    )
+
+    & az storage blob delete --auth-mode login --account-name $StorageAccountName --container-name $script:FunctionExecutionStatusContainerName --name $script:FunctionExecutionControlBlobName --output none 2>$null | Out-Null
+}
+
+function Get-FunctionExecutionActivity {
+    [CmdletBinding()]
+    [OutputType([object])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$ResourceId,
+
+        [Parameter(Mandatory = $true)]
+        [datetime]$StartTimeUtc,
+
+        [Parameter(Mandatory = $true)]
+        [datetime]$EndTimeUtc
+    )
+
+    $metrics = Invoke-AzCliJson -Arguments @(
+        'monitor', 'metrics', 'list',
+        '--resource', $ResourceId,
+        '--start-time', $StartTimeUtc.ToString('o'),
+        '--end-time', $EndTimeUtc.ToString('o'),
+        '--interval', 'PT1M',
+        '--aggregation', 'Total',
+        '--metrics', 'OnDemandFunctionExecutionCount',
+        '-o', 'json'
+    )
+
+    $totalCount = 0.0
+    $latestTimestampUtc = $null
+
+    foreach ($metric in @($metrics.value)) {
+        foreach ($series in @($metric.timeseries)) {
+            foreach ($dataPoint in @($series.data)) {
+                if ($null -eq $dataPoint.total) {
+                    continue
+                }
+
+                $pointTotal = [double]$dataPoint.total
+                if ($pointTotal -le 0) {
+                    continue
+                }
+
+                $totalCount += $pointTotal
+                $pointTimestampUtc = ([datetimeoffset]$dataPoint.timeStamp).UtcDateTime
+                if ($null -eq $latestTimestampUtc -or $pointTimestampUtc -gt $latestTimestampUtc) {
+                    $latestTimestampUtc = $pointTimestampUtc
+                }
+            }
+        }
+    }
+
+    return [PSCustomObject]@{
+        total_count = [int][math]::Round($totalCount, 0)
+        latest_timestamp_utc = $latestTimestampUtc
+    }
+}
+
+function Get-FunctionTraceAccessState {
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$HostName,
+
+        [Parameter(Mandatory = $true)]
+        [string]$MasterKey
+    )
+
+    $headers = @{ 'x-functions-key' = $MasterKey }
+    $sawMissing = $false
+    foreach ($path in @(
+        'admin/vfs/tmp/FunctionsData/ExportAndGenerate.trace.log',
+        'admin/vfs/home/site/diagnostics/ExportAndGenerate.trace.log',
+        'admin/vfs/tmp/FunctionsData/FunctionProfile.trace.log',
+        'admin/vfs/home/site/diagnostics/FunctionProfile.trace.log'
+    )) {
+        try {
+            $null = Invoke-WebRequest -Method Get -Uri "https://$HostName/$path" -Headers $headers -ErrorAction Stop
+            return 'Accessible'
+        }
+        catch {
+            $response = $_.Exception.Response
+            if ($null -eq $response) {
+                return 'Unavailable'
+            }
+
+            switch ([int]$response.StatusCode) {
+                403 { return 'Forbidden' }
+                404 { $sawMissing = $true; continue }
+                default { return ("HTTP {0}" -f [int]$response.StatusCode) }
+            }
+        }
+    }
+
+    if ($sawMissing) {
+        return 'Missing'
+    }
+
+    return 'Unavailable'
 }
 
 function Invoke-FunctionExecutionValidation {
@@ -455,7 +1175,17 @@ function Invoke-FunctionExecutionValidation {
         [string]$StorageAccountName,
 
         [Parameter(Mandatory = $true)]
-        [int]$TimeoutMinutes
+        [string]$DashboardDeliveryMode,
+
+        [Parameter(Mandatory = $true)]
+        [int]$TimeoutMinutes,
+
+        [Parameter(Mandatory = $false)]
+        [switch]$UseExistingExportsOnly,
+
+        [Parameter(Mandatory = $false)]
+        [AllowEmptyString()]
+        [string]$DatasetPath
     )
 
     $hostName = Invoke-AzCliText -Arguments @(
@@ -463,6 +1193,13 @@ function Invoke-FunctionExecutionValidation {
         '--name', $FunctionAppName,
         '--resource-group', $FunctionResourceGroup,
         '--query', 'properties.defaultHostName',
+        '-o', 'tsv'
+    )
+    $functionResourceId = Invoke-AzCliText -Arguments @(
+        'functionapp', 'show',
+        '--name', $FunctionAppName,
+        '--resource-group', $FunctionResourceGroup,
+        '--query', 'id',
         '-o', 'tsv'
     )
 
@@ -474,73 +1211,209 @@ function Invoke-FunctionExecutionValidation {
     )).masterKey
 
     $originalTraceSetting = Get-FunctionAppSettingValue -FunctionAppName $FunctionAppName -FunctionResourceGroup $FunctionResourceGroup -SettingName 'PIPELINE_FILE_TRACE_ENABLED'
+    $originalUseExistingExportsOnlySetting = Get-FunctionAppSettingValue -FunctionAppName $FunctionAppName -FunctionResourceGroup $FunctionResourceGroup -SettingName 'USE_EXISTING_EXPORTS_ONLY'
+    $originalStorageAccountNameSetting = Get-FunctionAppSettingValue -FunctionAppName $FunctionAppName -FunctionResourceGroup $FunctionResourceGroup -SettingName 'STORAGE_ACCOUNT_NAME'
+    $originalDashboardDeliveryModeSetting = Get-FunctionAppSettingValue -FunctionAppName $FunctionAppName -FunctionResourceGroup $FunctionResourceGroup -SettingName 'DASHBOARD_DELIVERY_MODE'
+    $originalIncludeAdvancedHuntingSetting = Get-FunctionAppSettingValue -FunctionAppName $FunctionAppName -FunctionResourceGroup $FunctionResourceGroup -SettingName 'INCLUDE_ADVANCED_HUNTING'
     $beforeBlobUtc = Get-BlobLastModifiedUtc -StorageAccountName $StorageAccountName
 
     try {
-        & az functionapp config appsettings set --name $FunctionAppName --resource-group $FunctionResourceGroup --settings 'PIPELINE_FILE_TRACE_ENABLED=true' --output none | Out-Null
-        if ($LASTEXITCODE -ne 0) {
-            throw 'Failed to enable PIPELINE_FILE_TRACE_ENABLED for Function App execution validation.'
+        $settingsToApply = [System.Collections.Generic.List[string]]::new()
+        $settingsToApply.Add(("STORAGE_ACCOUNT_NAME={0}" -f $StorageAccountName)) | Out-Null
+        $settingsToApply.Add(("DASHBOARD_DELIVERY_MODE={0}" -f $DashboardDeliveryMode)) | Out-Null
+        $settingsToApply.Add('INCLUDE_ADVANCED_HUNTING=true') | Out-Null
+        $settingsToApply.Add('PIPELINE_FILE_TRACE_ENABLED=true') | Out-Null
+        if ($UseExistingExportsOnly) {
+            $settingsToApply.Add('USE_EXISTING_EXPORTS_ONLY=true') | Out-Null
+        }
+
+        Write-ValidationLogLine -Message 'Applying Function App execution settings...'
+        Set-FunctionAppAppSettings -FunctionAppName $FunctionAppName -FunctionResourceGroup $FunctionResourceGroup -Settings @($settingsToApply)
+        Restart-FunctionAppInstance -FunctionAppName $FunctionAppName -FunctionResourceGroup $FunctionResourceGroup -Reason 'apply execution validation settings'
+
+        Refresh-FunctionExecutionTemplates -StorageAccountName $StorageAccountName
+        Write-ValidationLogLine -Message ("Clearing dashboard container in storage account '{0}'..." -f $StorageAccountName)
+        Clear-BlobContainer -AccountName $StorageAccountName -ContainerName 'dashboards'
+        $beforeBlobUtc = $null
+
+        if ($UseExistingExportsOnly) {
+            if (-not [string]::IsNullOrWhiteSpace($DatasetPath)) {
+                Write-ValidationLogLine -Message ("Seeding Function App exports from local dataset: {0}" -f $DatasetPath)
+                Seed-ExportsContainer -AccountName $StorageAccountName -DatasetPath $DatasetPath
+            }
+            else {
+                Write-ValidationLogLine -Message 'USE_EXISTING_EXPORTS_ONLY execution validation is reusing whatever export blobs already exist in storage. Pass -FunctionExecutionDatasetPath for deterministic validation input.' -ForegroundColor Yellow
+            }
+
+            Write-ValidationLogLine -Message 'Uploading short-lived execution control blob to force seeded-export mode during validation...'
+            Set-FunctionExecutionControlBlob -StorageAccountName $StorageAccountName -UseExistingExportsOnly $true
         }
 
         Wait-FunctionHostReady -HostName $hostName -MasterKey $masterKey -TimeoutMinutes 10
+        Wait-FunctionAdminFunctionReady -HostName $hostName -MasterKey $masterKey -TimeoutMinutes 5
         Invoke-FunctionTraceCleanup -HostName $hostName -MasterKey $masterKey
 
-        $invokeStartedUtc = [datetime]::UtcNow
-        $null = Invoke-FunctionAdminRequest -Method Post -HostName $hostName -MasterKey $masterKey -Path 'admin/functions/ExportAndGenerate' -Body '{}'
+        $traceAccessState = Get-FunctionTraceAccessState -HostName $hostName -MasterKey $masterKey
+        if ($traceAccessState -ne 'Accessible') {
+            Write-ValidationLogLine -Message ("Function trace files are not directly readable via admin VFS ({0}). Falling back to Azure Monitor execution metrics and dashboard blob polling." -f $traceAccessState) -ForegroundColor Yellow
+        }
+
+        $invokeStartedUtc = Start-FunctionExecution -HostName $hostName -MasterKey $masterKey -TimeoutMinutes 5
+        Write-ValidationLogLine -Message ("Waiting for a fresh dashboard blob write until {0}." -f $invokeStartedUtc.AddMinutes($TimeoutMinutes).ToString('o'))
 
         $deadlineUtc = $invokeStartedUtc.AddMinutes($TimeoutMinutes)
         $events = @()
         $terminalStatus = $null
         $blobUpdated = $false
         $finalBlobUtc = $beforeBlobUtc
+        $completionSource = $null
+        $waitStopwatch = [System.Diagnostics.Stopwatch]::StartNew()
+        $lastHeartbeatSecond = -60
+        $executionActivity = $null
+        $lastExecutionMetricPollUtc = [datetime]::MinValue
+        $latestPipelineStatus = $null
+        $latestPipelineStatusBlobUtc = $null
 
         while ([datetime]::UtcNow -lt $deadlineUtc) {
+            $nowUtc = [datetime]::UtcNow
+
             $content = Get-FunctionTraceContent -HostName $hostName -MasterKey $masterKey
             if (-not [string]::IsNullOrWhiteSpace($content)) {
                 $events = @(ConvertTo-FunctionTraceEvent -Content $content -NotBeforeUtc $invokeStartedUtc)
                 $terminalStatus = Get-FunctionTraceTerminalStatus -Events $events
             }
 
+            if ($nowUtc -ge $lastExecutionMetricPollUtc.AddSeconds(60)) {
+                $executionActivity = Get-FunctionExecutionActivity -ResourceId $functionResourceId -StartTimeUtc $invokeStartedUtc.AddMinutes(-1) -EndTimeUtc $nowUtc
+                $lastExecutionMetricPollUtc = $nowUtc
+            }
+
+            $statusBlobUtc = Get-BlobLastModifiedUtc -StorageAccountName $StorageAccountName -ContainerName $script:FunctionExecutionStatusContainerName -BlobName $script:FunctionExecutionStatusBlobName
+            if ($null -ne $statusBlobUtc -and ($null -eq $latestPipelineStatusBlobUtc -or $statusBlobUtc -gt $latestPipelineStatusBlobUtc)) {
+                $statusDocument = Get-FunctionExecutionStatus -StorageAccountName $StorageAccountName
+                if ($null -ne $statusDocument) {
+                    $latestPipelineStatus = $statusDocument
+                    $latestPipelineStatusBlobUtc = $statusBlobUtc
+                }
+            }
+
             $finalBlobUtc = Get-BlobLastModifiedUtc -StorageAccountName $StorageAccountName
             $blobUpdated = ($null -ne $finalBlobUtc -and $finalBlobUtc -ge $invokeStartedUtc.AddSeconds(-5))
 
             if ($terminalStatus -eq 'Failed') {
+                Write-ValidationLogLine -Message 'Function App trace reported pipeline failure.' -ForegroundColor Red
                 break
             }
 
-            if ($terminalStatus -eq 'Completed' -and $blobUpdated) {
+            if ($blobUpdated) {
+                Write-ValidationLogLine -Message ("Function App wrote dashboard blob at {0}." -f $finalBlobUtc.ToString('o')) -ForegroundColor Green
+                $completionSource = if ($terminalStatus -eq 'Completed') { 'trace-and-blob' } else { 'blob-write' }
                 break
+            }
+
+            if ($null -ne $latestPipelineStatus -and $latestPipelineStatus.PSObject.Properties['status'] -and [string]$latestPipelineStatus.status -eq 'failed') {
+                Write-ValidationLogLine -Message ("Function execution status blob reported failure: {0}" -f (Get-FunctionExecutionStatusSummaryText -StatusDocument $latestPipelineStatus)) -ForegroundColor Red
+                break
+            }
+
+            $elapsedWholeSeconds = [Math]::Floor($waitStopwatch.Elapsed.TotalSeconds)
+            if (($lastHeartbeatSecond + 60) -le $elapsedWholeSeconds) {
+                $lastTraceMessage = if ($events.Count -gt 0) {
+                    [string]$events[-1].message
+                }
+                else {
+                    'no trace events yet'
+                }
+                $blobText = if ($null -eq $finalBlobUtc) { 'none' } else { $finalBlobUtc.ToString('o') }
+                $terminalText = if ([string]::IsNullOrWhiteSpace([string]$terminalStatus)) { 'Running' } else { $terminalStatus }
+                $executionCount = if ($null -ne $executionActivity -and $executionActivity.PSObject.Properties['total_count']) { [int]$executionActivity.total_count } else { 0 }
+                $executionTimestampText = if ($null -ne $executionActivity -and $executionActivity.PSObject.Properties['latest_timestamp_utc'] -and $null -ne $executionActivity.latest_timestamp_utc) {
+                    ([datetime]$executionActivity.latest_timestamp_utc).ToString('o')
+                }
+                else {
+                    'none'
+                }
+                $pipelineStatusText = Get-FunctionExecutionStatusSummaryText -StatusDocument $latestPipelineStatus
+
+                Write-ValidationLogLine -Message ("Function execution heartbeat: {0}s elapsed; terminalStatus={1}; dashboardBlob={2}; executionCount={3}; latestExecutionMetric={4}; traceAccess={5}; pipelineStatus={6}; lastTrace={7}" -f $elapsedWholeSeconds, $terminalText, $blobText, $executionCount, $executionTimestampText, $traceAccessState, $pipelineStatusText, $lastTraceMessage)
+                $lastHeartbeatSecond = $elapsedWholeSeconds
             }
 
             Start-Sleep -Seconds 15
         }
 
+        $executionActivity = Get-FunctionExecutionActivity -ResourceId $functionResourceId -StartTimeUtc $invokeStartedUtc.AddMinutes(-1) -EndTimeUtc ([datetime]::UtcNow)
+
         if ($terminalStatus -eq 'Failed') {
             throw 'Function App trace reported pipeline failure.'
         }
 
-        if ($terminalStatus -ne 'Completed') {
-            throw 'Function App did not report Pipeline Complete! before timeout.'
+        if ($null -ne $latestPipelineStatus -and $latestPipelineStatus.PSObject.Properties['status'] -and [string]$latestPipelineStatus.status -eq 'failed') {
+            $pipelineStatusText = Get-FunctionExecutionStatusSummaryText -StatusDocument $latestPipelineStatus
+            $pipelineErrorText = if ($latestPipelineStatus.PSObject.Properties['error']) { [string]$latestPipelineStatus.error } else { $null }
+            if ([string]::IsNullOrWhiteSpace($pipelineErrorText)) {
+                throw ("Function App status blob reported failure. {0}" -f $pipelineStatusText)
+            }
+
+            throw ("Function App status blob reported failure. {0}. Error: {1}" -f $pipelineStatusText, $pipelineErrorText)
         }
 
         if (-not $blobUpdated) {
-            throw 'Function App completed trace did not coincide with a fresh dashboard blob write.'
+            $executionCount = if ($null -ne $executionActivity -and $executionActivity.PSObject.Properties['total_count']) { [int]$executionActivity.total_count } else { 0 }
+            $executionTimestampText = if ($null -ne $executionActivity -and $executionActivity.PSObject.Properties['latest_timestamp_utc'] -and $null -ne $executionActivity.latest_timestamp_utc) {
+                ([datetime]$executionActivity.latest_timestamp_utc).ToString('o')
+            }
+            else {
+                $null
+            }
+            $pipelineStatusText = Get-FunctionExecutionStatusSummaryText -StatusDocument $latestPipelineStatus
+
+            if ($terminalStatus -eq 'Completed') {
+                throw 'Function App completed trace did not coincide with a fresh dashboard blob write.'
+            }
+
+            if ($executionCount -gt 0) {
+                $executionDetail = if ([string]::IsNullOrWhiteSpace($executionTimestampText)) {
+                    ("Function App executed {0} time(s) according to Azure Monitor" -f $executionCount)
+                }
+                else {
+                    ("Function App executed {0} time(s) according to Azure Monitor (latest metric timestamp {1})" -f $executionCount, $executionTimestampText)
+                }
+
+                if ($traceAccessState -eq 'Forbidden') {
+                    throw ("{0}, but no dashboard blob was written before timeout and admin VFS trace access is forbidden on this Flex app. Latest pipeline status: {1}" -f $executionDetail, $pipelineStatusText)
+                }
+
+                throw ("{0}, but no dashboard blob was written before timeout. Latest pipeline status: {1}" -f $executionDetail, $pipelineStatusText)
+            }
+
+            throw ("Function App did not write a fresh dashboard blob before timeout. Latest pipeline status: {0}" -f $pipelineStatusText)
         }
 
         return [PSCustomObject]@{
             hostName = $hostName
             invocationStartedUtc = $invokeStartedUtc.ToString('o')
             dashboardBlobLastModifiedUtc = $finalBlobUtc.ToString('o')
-            terminalStatus = $terminalStatus
+            executionMode = if ($UseExistingExportsOnly) { 'existing-exports-only' } else { 'live-export' }
+            executionDatasetPath = if ([string]::IsNullOrWhiteSpace($DatasetPath)) { $null } else { $DatasetPath }
+            terminalStatus = if ([string]::IsNullOrWhiteSpace([string]$terminalStatus)) { 'BlobUpdatedWithoutTerminalTrace' } else { $terminalStatus }
+            completionSource = $completionSource
+            traceAccessState = $traceAccessState
+            executionCount = if ($null -ne $executionActivity -and $executionActivity.PSObject.Properties['total_count']) { [int]$executionActivity.total_count } else { 0 }
+            latestExecutionMetricUtc = if ($null -ne $executionActivity -and $executionActivity.PSObject.Properties['latest_timestamp_utc'] -and $null -ne $executionActivity.latest_timestamp_utc) { ([datetime]$executionActivity.latest_timestamp_utc).ToString('o') } else { $null }
+            pipelineStatus = $latestPipelineStatus
             recentTraceEvents = @($events | Select-Object -Last 12)
         }
     }
     finally {
-        if ($null -eq $originalTraceSetting) {
-            & az functionapp config appsettings delete --name $FunctionAppName --resource-group $FunctionResourceGroup --setting-names PIPELINE_FILE_TRACE_ENABLED --output none | Out-Null
-        }
-        else {
-            & az functionapp config appsettings set --name $FunctionAppName --resource-group $FunctionResourceGroup --settings ("PIPELINE_FILE_TRACE_ENABLED={0}" -f $originalTraceSetting) --output none | Out-Null
+        Restore-FunctionAppSettingValue -FunctionAppName $FunctionAppName -FunctionResourceGroup $FunctionResourceGroup -SettingName 'PIPELINE_FILE_TRACE_ENABLED' -OriginalValue $originalTraceSetting
+        Restore-FunctionAppSettingValue -FunctionAppName $FunctionAppName -FunctionResourceGroup $FunctionResourceGroup -SettingName 'STORAGE_ACCOUNT_NAME' -OriginalValue $originalStorageAccountNameSetting
+        Restore-FunctionAppSettingValue -FunctionAppName $FunctionAppName -FunctionResourceGroup $FunctionResourceGroup -SettingName 'DASHBOARD_DELIVERY_MODE' -OriginalValue $originalDashboardDeliveryModeSetting
+        Restore-FunctionAppSettingValue -FunctionAppName $FunctionAppName -FunctionResourceGroup $FunctionResourceGroup -SettingName 'INCLUDE_ADVANCED_HUNTING' -OriginalValue $originalIncludeAdvancedHuntingSetting
+
+        if ($UseExistingExportsOnly) {
+            Remove-FunctionExecutionControlBlob -StorageAccountName $StorageAccountName
+            Restore-FunctionAppSettingValue -FunctionAppName $FunctionAppName -FunctionResourceGroup $FunctionResourceGroup -SettingName 'USE_EXISTING_EXPORTS_ONLY' -OriginalValue $originalUseExistingExportsOnlySetting
         }
     }
 }
@@ -565,9 +1438,9 @@ else {
 }
 $effectiveDashboardDeliveryMode = Resolve-DashboardDeliveryMode -AutomationAccountName $AutomationAccountName -FunctionAppName $FunctionAppName -SubscriptionId $subscriptionId -AutomationResourceGroup $automationResourceGroup -FunctionResourceGroup $functionResourceGroup -RequestedDashboardDeliveryMode $DashboardDeliveryMode
 
-Write-Output 'Regenerating Azure deployment artifacts locally...'
-& (Join-Path $buildRoot 'azure\Build-Runbook.ps1')
-& (Join-Path $buildRoot 'azure\Build-FunctionApp.ps1')
+Write-ValidationLogLine -Message 'Regenerating Azure deployment artifacts locally...' -ForegroundColor Cyan
+Invoke-TimestampedCommand -FailureDescription 'Runbook build' -ScriptBlock { & (Join-Path $buildRoot 'azure\Build-Runbook.ps1') }
+Invoke-TimestampedCommand -FailureDescription 'Function App build' -ScriptBlock { & (Join-Path $buildRoot 'azure\Build-FunctionApp.ps1') }
 
 $setupCommonParameters = @{
     SkipMdePermissions = $SkipMdePermissions
@@ -579,11 +1452,11 @@ if ($ResourceGroupName) {
     $setupCommonParameters.ResourceGroupName = $ResourceGroupName
 }
 
-Write-Output 'Validating Azure Automation deployment...'
-& $setupScriptPath @setupCommonParameters -AutomationAccountName $AutomationAccountName
+Write-ValidationLogLine -Message 'Validating Azure Automation deployment...' -ForegroundColor Cyan
+Invoke-TimestampedCommand -FailureDescription 'Azure Automation deployment validation' -ScriptBlock { & $setupScriptPath @setupCommonParameters -AutomationAccountName $AutomationAccountName }
 
-Write-Output 'Validating Azure Function App deployment...'
-& $setupScriptPath @setupCommonParameters -ComputeType FunctionApp -FunctionAppName $FunctionAppName
+Write-ValidationLogLine -Message 'Validating Azure Function App deployment...' -ForegroundColor Cyan
+Invoke-TimestampedCommand -FailureDescription 'Azure Function App deployment validation' -ScriptBlock { & $setupScriptPath @setupCommonParameters -ComputeType FunctionApp -FunctionAppName $FunctionAppName }
 
 $functionExecutionResult = $null
 if (-not $SkipFunctionExecution) {
@@ -592,8 +1465,13 @@ if (-not $SkipFunctionExecution) {
         throw "STORAGE_ACCOUNT_NAME is not configured on Function App '$FunctionAppName'."
     }
 
-    Write-Output 'Validating Function App execution...'
-    $functionExecutionResult = Invoke-FunctionExecutionValidation -FunctionAppName $FunctionAppName -FunctionResourceGroup $functionResourceGroup -StorageAccountName $storageAccountName -TimeoutMinutes $FunctionExecutionTimeoutMinutes
+    $resolvedFunctionExecutionDatasetPath = $null
+    if ($SkipMdePermissions) {
+        $resolvedFunctionExecutionDatasetPath = Resolve-FunctionExecutionDatasetPath -RequestedPath $FunctionExecutionDatasetPath
+    }
+
+    Write-ValidationLogLine -Message 'Validating Function App execution...' -ForegroundColor Cyan
+    $functionExecutionResult = Invoke-FunctionExecutionValidation -FunctionAppName $FunctionAppName -FunctionResourceGroup $functionResourceGroup -StorageAccountName $storageAccountName -DashboardDeliveryMode $effectiveDashboardDeliveryMode -TimeoutMinutes $FunctionExecutionTimeoutMinutes -UseExistingExportsOnly:$SkipMdePermissions -DatasetPath $resolvedFunctionExecutionDatasetPath
 }
 
 $result = [PSCustomObject]@{
@@ -606,5 +1484,5 @@ $result = [PSCustomObject]@{
     functionExecution = $functionExecutionResult
 }
 
-Write-Output 'Azure deployment validation completed successfully.'
+Write-ValidationLogLine -Message 'Azure deployment validation completed successfully.' -ForegroundColor Green
 $result

--- a/build/README.md
+++ b/build/README.md
@@ -32,11 +32,15 @@ This directory contains maintainer-facing build, validation, import, and packagi
 .\build\Invoke-LiveDashboardDryRun.ps1 -UseExistingAzContext
 
 # Rebuild locally, redeploy Azure Automation + Function App, and execute both live validation paths
-.\build\Invoke-AzureDeploymentValidation.ps1 -AutomationAccountName aa-defender-reporting -FunctionAppName func-defender-reporting -SkipMdePermissions
+.\build\Invoke-AzureDeploymentValidation.ps1 -AutomationAccountName aa-defender-reporting -FunctionAppName func-defender-reporting -SkipMdePermissions -FunctionExecutionDatasetPath .\exports
 
 # Build the same Azure release zip used by the release workflow
 .\build\Build-AzureReleasePackage.ps1
 ```
+
+When `-SkipMdePermissions` is paired with Function App execution validation, pass `-FunctionExecutionDatasetPath <dataset>` so the script can reseed the Function App exports container before invocation. Use `-SkipFunctionExecution` only when you intentionally want deployment validation without the final Function App run.
+
+During seeded Function App validation, the script now writes a short-lived control blob at `dashboards/_diagnostics/ExportAndGenerate.control.json` and polls the runtime status blob at `dashboards/_diagnostics/ExportAndGenerate.status.json`. This makes Flex Consumption execution diagnosable even when admin VFS access and built-in log streaming are unavailable.
 
 ## User-facing scripts
 

--- a/build/azure/runbook-source.ps1
+++ b/build/azure/runbook-source.ps1
@@ -72,6 +72,61 @@ param(
 $ErrorActionPreference = 'Stop'
 $ProgressPreference = 'SilentlyContinue'
 
+function Resolve-PipelineExecutionHostDescriptor {
+    [CmdletBinding()]
+    [OutputType([pscustomobject])]
+    param()
+
+    foreach ($environmentVariableName in @(
+        'WEBSITE_INSTANCE_ID'
+        'WEBSITE_HOSTNAME'
+        'WEBSITE_SITE_NAME'
+        'FUNCTIONS_WORKER_RUNTIME'
+        'FUNCTIONS_EXTENSION_VERSION'
+        'FUNCTIONS_WORKER_DIRECTORY'
+        'FUNCTIONS_APPLICATION_DIRECTORY'
+    )) {
+        $environmentValue = [System.Environment]::GetEnvironmentVariable($environmentVariableName)
+        if (-not [string]::IsNullOrWhiteSpace([string]$environmentValue)) {
+            return [PSCustomObject]@{
+                Name = 'FunctionApp'
+                Evidence = $environmentVariableName
+            }
+        }
+    }
+
+    foreach ($environmentVariableName in @(
+        'AUTOMATION_ASSET_ACCOUNTID'
+        'AZUREPS_HOST_ENVIRONMENT'
+    )) {
+        $environmentValue = [System.Environment]::GetEnvironmentVariable($environmentVariableName)
+        if (-not [string]::IsNullOrWhiteSpace([string]$environmentValue)) {
+            return [PSCustomObject]@{
+                Name = 'Automation'
+                Evidence = $environmentVariableName
+            }
+        }
+    }
+
+    $psPrivateMetadataVariable = Get-Variable -Name PSPrivateMetadata -Scope Global -ErrorAction SilentlyContinue
+    if ($null -ne $psPrivateMetadataVariable) {
+        $psPrivateMetadata = $psPrivateMetadataVariable.Value
+        $jobIdProperty = if ($null -ne $psPrivateMetadata) { $psPrivateMetadata.PSObject.Properties['JobId'] } else { $null }
+        $jobId = if ($null -ne $jobIdProperty) { [string]$jobIdProperty.Value } else { '' }
+        if (-not [string]::IsNullOrWhiteSpace($jobId)) {
+            return [PSCustomObject]@{
+                Name = 'Automation'
+                Evidence = 'PSPrivateMetadata.JobId'
+            }
+        }
+    }
+
+    return [PSCustomObject]@{
+        Name = 'Unknown'
+        Evidence = $null
+    }
+}
+
 # =============================================================================
 # CONSTANTS
 # =============================================================================
@@ -96,6 +151,14 @@ $Script:BlobAccessTiers = @{
 $Script:DashboardBlobName = 'VulnerabilityDashboard.html'
 $Script:DashboardAssetsDirectoryName = ([System.IO.Path]::GetFileNameWithoutExtension($Script:DashboardBlobName) + '.assets')
 $Script:DashboardHostedAssetFileNames = @('dashboard.css', 'dashboard.js', 'pako.js', 'chart.js', 'pdf-export.bundle.js', 'payload.json.gz')
+$Script:PipelineControlBlobName = '_diagnostics/ExportAndGenerate.control.json'
+$Script:PipelineStatusBlobName = '_diagnostics/ExportAndGenerate.status.json'
+$Script:PipelineRunId = [guid]::NewGuid().ToString('N')
+$Script:PipelineStartedOnUtc = [datetime]::UtcNow
+$Script:PipelineCurrentStage = 'Initializing'
+$Script:PipelineCurrentStageMessage = 'Initializing pipeline.'
+$Script:PipelineExecutionHostDescriptor = Resolve-PipelineExecutionHostDescriptor
+$Script:PipelineExecutionHost = [string]$Script:PipelineExecutionHostDescriptor.Name
 
 $Script:LibraryConfig = @{
     ChartJs = @{
@@ -150,6 +213,90 @@ function Write-MemoryUsage {
     $gcHeapMB     = [math]::Round([System.GC]::GetTotalMemory($false) / 1MB, 1)
     $prefix = if ($Label) { "[$Label] " } else { "" }
     Write-Output "  ${prefix}Memory — Working set: ${workingSetMB}MB  |  GC heap: ${gcHeapMB}MB"
+}
+
+function Set-PipelineExecutionStage {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '', Justification = 'Internal helper only updates in-memory pipeline stage state for status reporting.')]
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Stage,
+
+        [Parameter(Mandatory = $true)]
+        [string]$Message
+    )
+
+    $Script:PipelineCurrentStage = $Stage
+    $Script:PipelineCurrentStageMessage = $Message
+}
+
+function Write-PipelineExecutionStatus {
+    [CmdletBinding()]
+    [OutputType([bool])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$AccountName,
+
+        [Parameter(Mandatory = $true)]
+        [string]$StorageToken,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateSet('running', 'succeeded', 'failed')]
+        [string]$Status,
+
+        [Parameter(Mandatory = $false)]
+        [string]$Stage = $Script:PipelineCurrentStage,
+
+        [Parameter(Mandatory = $false)]
+        [string]$Message = $Script:PipelineCurrentStageMessage,
+
+        [Parameter(Mandatory = $false)]
+        [hashtable]$AdditionalProperties = @{}
+    )
+
+    if ([string]::IsNullOrWhiteSpace($AccountName) -or [string]::IsNullOrWhiteSpace($StorageToken)) {
+        return $false
+    }
+
+    $statusFilePath = Join-Path ([System.IO.Path]::GetTempPath()) ("pipeline-status-{0}.json" -f $Script:PipelineRunId)
+
+    try {
+        $statusDocument = [ordered]@{
+            version = 1
+            runId = $Script:PipelineRunId
+            executionHost = $Script:PipelineExecutionHost
+            executionHostEvidence = if ($null -ne $Script:PipelineExecutionHostDescriptor) { [string]$Script:PipelineExecutionHostDescriptor.Evidence } else { $null }
+            status = $Status
+            stage = $Stage
+            message = $Message
+            startedOnUtc = $Script:PipelineStartedOnUtc.ToString('o')
+            updatedOnUtc = ([datetime]::UtcNow).ToString('o')
+            storageAccountName = $AccountName
+            dashboardDeliveryMode = if ([string]::IsNullOrWhiteSpace($DashboardDeliveryMode)) { $null } else { $DashboardDeliveryMode }
+            includeAdvancedHunting = [bool]$IncludeAdvancedHunting
+            useExistingExportsOnly = [bool]$UseExistingExportsOnly
+            exportTarget = $Export
+        }
+
+        if ($Status -ne 'running') {
+            $statusDocument.completedOnUtc = ([datetime]::UtcNow).ToString('o')
+        }
+
+        foreach ($key in $AdditionalProperties.Keys) {
+            $statusDocument[$key] = $AdditionalProperties[$key]
+        }
+
+        $statusDocument | ConvertTo-Json -Depth 12 | Set-Content -LiteralPath $statusFilePath -Encoding utf8
+        Set-BlobContent -AccountName $AccountName -Container $Script:BlobContainers.Dashboards -BlobName $Script:PipelineStatusBlobName -SourcePath $statusFilePath -StorageToken $StorageToken -ContentType 'application/json' -AccessTier $Script:BlobAccessTiers.Dashboards
+        return $true
+    }
+    catch {
+        Write-Verbose ("Pipeline status write failed: {0}" -f $_.Exception.Message)
+        return $false
+    }
+    finally {
+        Remove-Item -LiteralPath $statusFilePath -Force -ErrorAction SilentlyContinue
+    }
 }
 
 # =============================================================================
@@ -396,6 +543,45 @@ function Get-BlobContent {
     Invoke-RestMethod -Uri $uri -Headers $headers -Method Get -OutFile $DestinationPath
 }
 
+function Get-BlobTextContent {
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$AccountName,
+
+        [Parameter(Mandatory = $true)]
+        [string]$Container,
+
+        [Parameter(Mandatory = $true)]
+        [string]$BlobName,
+
+        [Parameter(Mandatory = $true)]
+        [string]$StorageToken
+    )
+
+    $downloadPath = Join-Path ([System.IO.Path]::GetTempPath()) ("blob-text-{0}.tmp" -f [guid]::NewGuid().ToString('N'))
+    try {
+        Get-BlobContent -AccountName $AccountName -Container $Container -BlobName $BlobName -DestinationPath $downloadPath -StorageToken $StorageToken
+        if (-not (Test-Path -LiteralPath $downloadPath -PathType Leaf)) {
+            return $null
+        }
+
+        return (Get-Content -LiteralPath $downloadPath -Raw)
+    }
+    catch {
+        $statusCode = Get-BlobErrorStatusCode -ErrorRecord $_
+        if ($statusCode -eq 404) {
+            return $null
+        }
+
+        throw
+    }
+    finally {
+        Remove-Item -LiteralPath $downloadPath -Force -ErrorAction SilentlyContinue
+    }
+}
+
 function Set-BlobContent {
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '')]
     [CmdletBinding()]
@@ -507,6 +693,47 @@ function Remove-Blob {
             throw "Failed to delete blob '$BlobName' from '$Container': $_"
         }
     }
+}
+
+function Get-PipelineExecutionControlSettings {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '', Justification = 'Internal helper reads the full pipeline control settings document.')]
+    [CmdletBinding()]
+    [OutputType([object])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$AccountName,
+
+        [Parameter(Mandatory = $true)]
+        [string]$StorageToken
+    )
+
+    $content = Get-BlobTextContent -AccountName $AccountName -Container $Script:BlobContainers.Dashboards -BlobName $Script:PipelineControlBlobName -StorageToken $StorageToken
+    if ([string]::IsNullOrWhiteSpace($content)) {
+        return $null
+    }
+
+    try {
+        $control = $content | ConvertFrom-Json -Depth 12
+    }
+    catch {
+        Write-Warning ("Ignoring invalid pipeline control blob '{0}': {1}" -f $Script:PipelineControlBlobName, $_.Exception.Message)
+        return $null
+    }
+
+    if ($control.PSObject.Properties['notAfterUtc'] -and -not [string]::IsNullOrWhiteSpace([string]$control.notAfterUtc)) {
+        try {
+            if (([datetimeoffset]$control.notAfterUtc).UtcDateTime -lt [datetime]::UtcNow) {
+                Write-Output ("  Ignoring expired pipeline control blob '{0}'." -f $Script:PipelineControlBlobName)
+                return $null
+            }
+        }
+        catch {
+            Write-Warning ("Ignoring pipeline control blob with invalid notAfterUtc value: {0}" -f $_.Exception.Message)
+            return $null
+        }
+    }
+
+    return $control
 }
 
 # =============================================================================
@@ -717,6 +944,7 @@ function Export-ToStaticWebApp {
 $tempRoot = $null
 
 try {
+    Set-PipelineExecutionStage -Stage 'Authentication' -Message 'Authenticating with managed identity and resolving configuration.'
     Write-Output "========================================"
     Write-Output "  Vulnerability Dashboard Pipeline"
     Write-Output "========================================"
@@ -764,6 +992,13 @@ try {
 
     Write-Output "  Acquiring tokens..."
     $storageToken = Get-PlainToken -ResourceUrl 'https://storage.azure.com/'
+
+    $pipelineExecutionControl = Get-PipelineExecutionControlSettings -AccountName $StorageAccountName -StorageToken $storageToken
+    if ($null -ne $pipelineExecutionControl -and $pipelineExecutionControl.PSObject.Properties['useExistingExportsOnly']) {
+        $UseExistingExportsOnly = [bool]$pipelineExecutionControl.useExistingExportsOnly
+        Write-Output ("  Control blob override: UseExistingExportsOnly = {0}" -f $UseExistingExportsOnly)
+    }
+
     if ($UseExistingExportsOnly) {
         $mdeHeaders = $null
         Write-Output "  Stress mode enabled: using existing exports from blob storage only"
@@ -788,6 +1023,8 @@ try {
     # -----------------------------------------------------------------
     # Stage B: Download historical data from blob storage
     # -----------------------------------------------------------------
+    Set-PipelineExecutionStage -Stage 'DownloadHistoricalData' -Message 'Downloading historical exports and dashboard templates from blob storage.'
+    [void](Write-PipelineExecutionStatus -AccountName $StorageAccountName -StorageToken $storageToken -Status 'running')
     Write-Output "`n--- Stage B: Download historical data ---"
 
     $tempBasePath = $null
@@ -932,6 +1169,8 @@ try {
     # -----------------------------------------------------------------
     # Stage C: Export fresh MDE data
     # -----------------------------------------------------------------
+    Set-PipelineExecutionStage -Stage 'ExportFreshMdeData' -Message $(if ($UseExistingExportsOnly) { 'Reusing existing export blobs without calling the MDE APIs.' } else { 'Exporting fresh vulnerability, machine, and Advanced Hunting data from MDE APIs.' })
+    [void](Write-PipelineExecutionStatus -AccountName $StorageAccountName -StorageToken $storageToken -Status 'running')
     Write-Output "`n--- Stage C: Export fresh MDE data ---"
 
     if ($UseExistingExportsOnly) {
@@ -1007,6 +1246,8 @@ try {
     # -----------------------------------------------------------------
     # Stage D: Generate dashboard
     # -----------------------------------------------------------------
+    Set-PipelineExecutionStage -Stage 'GenerateDashboard' -Message 'Generating the dashboard artifacts from the normalized export data.'
+    [void](Write-PipelineExecutionStatus -AccountName $StorageAccountName -StorageToken $storageToken -Status 'running')
     Write-Output "`n--- Stage D: Generate dashboard ---"
 
     $tempVulnsPath = Join-Path -Path $tempRoot -ChildPath 'vulns.json'
@@ -1200,6 +1441,8 @@ try {
     # -----------------------------------------------------------------
     # Stage E: Export results
     # -----------------------------------------------------------------
+    Set-PipelineExecutionStage -Stage 'ExportResults' -Message ("Uploading dashboard and export artifacts using export target '{0}'." -f $Export)
+    [void](Write-PipelineExecutionStatus -AccountName $StorageAccountName -StorageToken $storageToken -Status 'running')
     Write-Output "`n--- Stage E: Export ($Export) ---"
 
     switch ($Export) {
@@ -1244,6 +1487,15 @@ try {
         }
     }
 
+    Set-PipelineExecutionStage -Stage 'Completed' -Message 'Pipeline completed successfully.'
+    [void](Write-PipelineExecutionStatus -AccountName $StorageAccountName -StorageToken $storageToken -Status 'succeeded' -AdditionalProperties @{
+            vulnerabilities = [int]$vulnCount
+            devices = [int]$deviceCount
+            cves = [int]$cveCount
+            dashboardSizeMb = [math]::Round([double]$finalSize, 2)
+            dashboardBlobName = $Script:DashboardBlobName
+        })
+
     # -----------------------------------------------------------------
     # Cleanup
     # -----------------------------------------------------------------
@@ -1267,6 +1519,13 @@ try {
     Write-Output "  Completed: $(([datetime]::UtcNow).ToString('yyyy-MM-dd HH:mm:ss')) UTC"
 }
 catch {
+    if (-not [string]::IsNullOrWhiteSpace($StorageAccountName) -and -not [string]::IsNullOrWhiteSpace($storageToken)) {
+        [void](Write-PipelineExecutionStatus -AccountName $StorageAccountName -StorageToken $storageToken -Status 'failed' -AdditionalProperties @{
+                error = [string]$_
+                stackTrace = [string]$_.ScriptStackTrace
+            })
+    }
+
     Write-Output "========================================"
     Write-Output "  Pipeline Failed!"
     Write-Output "========================================"

--- a/docs/performance-baselines.md
+++ b/docs/performance-baselines.md
@@ -2,30 +2,51 @@
 
 This repository keeps the merge-tracked performance baseline as documentation instead of committing raw machine-local benchmark output.
 
-The raw result JSON files from the April 5, 2026 capture remain local-only under `.local/`.
+Use `.local\benchmark-history\benchmark-history.jsonl` for local longitudinal tracking across repeated benchmark captures. Only update this document after the dataset and command path are durable enough to serve as a merge-tracked baseline.
+
+The raw result JSON files from the April 5, 2026 capture remain local-only under `.local/`. The April 20, 2026 ad hoc hosted review captures remain local-only under `.local/perf-triage/`, and the April 20, 2026 durable benchmark series remains local-only under `.local/benchmark-series/benchmark-medium-v1-20260420-004103/`.
 
 ## Recorded baselines
 
-| Dataset | Command mode | Local | Runbook | Function App |
-| --- | --- | ---: | ---: | ---: |
-| `exports-synthetic` | `current-only` | `476.63s` | `250.45s` | `239.45s` |
-| `exports-synthetic-live` | `current-only` | `2081.27s` | `957.14s` | `683.21s` |
+| Dataset | Command mode | Local | Runbook | Function App headline | Function timing notes |
+| --- | --- | ---: | ---: | ---: | --- |
+| `benchmark-medium-v1` | `current-only` durable series, 3 captures | `137.28s to 139.19s` | `91.69s to 114.19s` | `41.37s to 42.18s` | `active-execution`; end-to-end `43.10s to 43.43s`; pickup delay `1.24s to 1.73s` |
+| `exports-synthetic` | `current-only` | `476.63s` | `250.45s` | `239.45s` | legacy `invoke-to-finish` |
+| `exports-synthetic-live` | `current-only` | `2081.27s` | `957.14s` | `683.21s` | legacy `invoke-to-finish` |
+| `review-synthetic-medium` | `current-only` Azure acceptance replay, 2 captures | `153.06s to 177.83s` | `96.94s to 105.19s` | `41.59s to 43.32s` | legacy `invoke-to-finish` |
+
+## Persistent local cache workflow
+
+| Dataset | Prime local run | Reuse after payload-cache eviction | Reuse elapsed delta | Normalize phase delta |
+| --- | ---: | ---: | ---: | ---: |
+| `benchmark-medium-v1` | `136.13s to 136.34s` | `45.44s to 45.49s` | `-90.90s to -90.66s` | `-87.92s to -84.95s` |
+| `review-synthetic-medium` | `136.17s to 167.08s` | `45.47s to 45.66s` | `-121.42s to -90.70s` | `-109.95s to -84.52s` |
 
 ## Resource summary
 
 | Dataset | Local peak RSS | Local peak private | Runbook peak WS | Runbook peak GC heap | Function peak WS | Function avg WS | Function execution units |
 | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| `benchmark-medium-v1` | `335179776 to 336478208` bytes | `236740608 to 238395392` bytes | `399.2 to 420.8 MB` | `88.8 to 105.4 MB` | `581.7 to 599.3 MB` | `581.7 to 599.3 MB` | `0.0` |
 | `exports-synthetic` | `966336512` bytes | `921878528` bytes | `569.5 MB` | `286.8 MB` | `1800.9 MB` | `1276.2 MB` | `504217600` |
 | `exports-synthetic-live` | `710160384` bytes | `616402944` bytes | `593.3 MB` | `298.2 MB` | `1029.2 MB` | `1029.2 MB` | `1172889600` |
+| `review-synthetic-medium` | `333520896 to 341286912` bytes | `236150784 to 242094080` bytes | `407.6 to 412.5 MB` | `85.2 to 95.0 MB` | `580.6 to 587.6 MB` | `580.2 to 587.6 MB` | `0.0` |
 
 ## Capture notes
 
-- Date captured: `2026-04-05`
-- Branch intent: current branch only, no `main` comparison
+- Date captured: `2026-04-05` for the original synthetic replay baselines.
+- Date captured: `2026-04-20` for the hosted `review-synthetic-medium` Azure acceptance replay.
+- Date captured: `2026-04-20` for the durable `benchmark-medium-v1` three-iteration hosted benchmark series.
+- Branch intent: current branch only, no `main` comparison.
 - Dataset shapes:
-  - `exports-synthetic`: original `20K` synthetic replay dataset
-  - `exports-synthetic-live`: shifted synthetic live-export dataset with a latest snapshot date of `2026-04-05`
-- The local benchmark harness now stages a private dataset copy before validation so raw datasets do not get mutated by sidecar regeneration during baseline capture.
+  - `benchmark-medium-v1`: standard durable benchmark dataset generated from the catalog entry in `tests/benchmark-datasets.json` with preset `BalancedMediumHeavy`, seed `20260322`, `120000` rows, and `1500` devices.
+  - `exports-synthetic`: original `20K` synthetic replay dataset.
+  - `exports-synthetic-live`: shifted synthetic live-export dataset with a latest snapshot date of `2026-04-05`.
+  - `review-synthetic-medium`: `BalancedMediumHeavy` review dataset with `120000` rows and `1500` devices, validated against Azure Automation `aa-defender-reporting` and Function App `func-defender-reporting-parallel-0404a`.
+- `benchmark-medium-v1` is now the standard durable dataset for merge-tracked baseline refreshes and supersedes `review-synthetic-medium` for future benchmark-series captures.
+- `benchmark-medium-v1` Function App headline timing now uses active execution time from the runtime status blob; end-to-end invocation time and pickup delay are recorded separately for queue and cold-start review.
+- The durable `benchmark-medium-v1` persistent local cache reuse pass was effectively stable across reruns (`45.44s` to `45.49s`) and is the preferred baseline for normalized-column cache reuse.
+- The hosted review baseline was captured twice on the same dataset and command path. This document records ranges because the cold local normalization pass moved more than the hosted paths across reruns.
+- The local benchmark harness stages a private dataset copy before validation so raw datasets do not get mutated by sidecar regeneration during baseline capture.
 
 ## Regenerating the baseline
 
@@ -41,4 +62,11 @@ Shifted live baseline:
 ```powershell
 $stamp = Get-Date -Format 'yyyyMMdd-HHmmss'
 pwsh -NoProfile -File .\tests\Measure-BranchVsMainBenchmark.ps1 -CurrentOnly -CurrentBaselineName 'current-live' -DatasetPath .\exports-synthetic-live -ResultsOutputPath (Join-Path $PWD ('.local\current-baseline-live-' + $stamp + '.json'))
+```
+
+Durable benchmark series:
+
+```powershell
+pwsh -NoProfile -File .\tests\New-BenchmarkDataset.ps1 -DatasetId benchmark-medium-v1
+pwsh -NoProfile -File .\tests\Invoke-BenchmarkSeries.ps1 -BenchmarkDatasetId benchmark-medium-v1 -Iterations 3 -IncludePersistentLocalWorkflow
 ```

--- a/docs/performance-gate-playbook.md
+++ b/docs/performance-gate-playbook.md
@@ -1,0 +1,64 @@
+﻿# Performance Gate Playbook
+
+This playbook keeps performance work measurable while preserving memory headroom for Azure Automation and Function App deployments.
+
+## Gate cadence
+
+| Gate | When | Command | Primary output | Review threshold |
+| --- | --- | --- | --- | --- |
+| Deterministic preflight | Every PR and before any perf run | `pwsh -NoProfile -File .\build\Invoke-RegressionValidation.ps1` | parser, ScriptAnalyzer, fixture smoke | Must pass |
+| Hot phase review | Every refactor that touches normalization, payload generation, validation, or Azure packaging | `pwsh -NoProfile -File .\tests\Invoke-HotPhaseReview.ps1 -DirectoryPath <dataset>` | `hot-phase-review.json`, stdout log, validation audit | Investigate generator or validation phases that regress by more than `5%` or materially shift relative ordering |
+| Synthetic benchmark | After a change that appears to improve or regress performance | `pwsh -NoProfile -File .\tests\Measure-BranchVsMainBenchmark.ps1 -CurrentOnly -DatasetPath <dataset> -ResultsOutputPath <path>` | branch benchmark JSON | Investigate local elapsed or peak memory regressions above `10%` |
+| Local history capture | After any benchmark you expect to compare again later | `pwsh -NoProfile -File .\tests\Record-BenchmarkHistory.ps1 -BenchmarkResultPath <path>` | `.local\benchmark-history\benchmark-history.jsonl`, `latest-summary.md` | Use for longitudinal local tracking; do not update merge-tracked docs for one-off review datasets |
+| Azure acceptance | Before merging perf-sensitive changes and before release packaging changes | `pwsh -NoProfile -File .\build\Invoke-AzureDeploymentValidation.ps1 -AutomationAccountName <name> -FunctionAppName <name>` | live Azure validation artifacts | Investigate runbook or Function App regressions above `10%`; investigate Function execution-unit growth above `15%` |
+| Baseline refresh | After an accepted improvement or a durable dataset change | update `docs/performance-baselines.md` and keep raw JSON under `.local/` | doc summary plus local raw artifacts | Capture only after the new behavior is accepted |
+
+## Dataset cadence
+
+- Use `tests/fixtures/legacy-migration` only for correctness smoke checks.
+- Use a smaller synthetic dataset for fast local hot-phase review while iterating.
+- Use `benchmark-medium-v1` as the standard durable benchmark dataset for merge-tracked baseline work.
+- Use ad hoc larger synthetic or shifted live synthetic datasets only for one-off investigation or stress review.
+- Always use Azure for the final large-dataset acceptance check because local results do not predict Function App memory or execution-unit behavior well enough.
+- When Azure acceptance runs with `-SkipMdePermissions`, pass `-FunctionExecutionDatasetPath <dataset>` so the Function App execution step reseeds deterministic exports before invocation.
+
+Standard benchmark dataset:
+- Dataset id: `benchmark-medium-v1`
+- Generator: `pwsh -NoProfile -File .\tests\New-BenchmarkDataset.ps1 -DatasetId benchmark-medium-v1`
+- Series capture: `pwsh -NoProfile -File .\tests\Invoke-BenchmarkSeries.ps1 -BenchmarkDatasetId benchmark-medium-v1 -Iterations 3 -IncludePersistentLocalWorkflow`
+- Shape: `BalancedMediumHeavy`, `1,500` devices, `120,000` vulnerability rows, seed `20260322`
+
+## Recommended workflow
+
+1. Run the deterministic preflight.
+2. Run `tests/Invoke-HotPhaseReview.ps1` on the representative local dataset you are using for the refactor.
+3. If validation dominates, run `tests/Invoke-ValidationModeComparison.ps1` to split package-only, force-full validation, and attested validation into separate measured runs.
+4. Review the top generator phases plus the audit `PhaseTimings` values from the hot-phase or validation-mode report.
+5. Make one focused change at a time and re-run the relevant local review command.
+6. Once the local review looks better, refresh `benchmark-medium-v1` if needed and capture a benchmark result with `tests/Measure-BranchVsMainBenchmark.ps1` or `tests/Invoke-BenchmarkSeries.ps1`.
+7. If the change is still favorable, validate the large dataset in Azure.
+8. Append the benchmark JSON to `.local` history with `tests/Record-BenchmarkHistory.ps1`.
+9. Record accepted durable baselines in `docs/performance-baselines.md` and keep raw JSON artifacts under `.local/`.
+
+Timing interpretation:
+- Azure Automation already tracks active execution time from job start to job end.
+- Function App benchmark summaries now treat `function_app.elapsed_seconds` as active execution time when the runtime status blob is available.
+- Function App invoke-to-finish time remains available as `function_app.end_to_end_elapsed_seconds` so queue delay and cold-start variance can still be reviewed separately.
+
+## Hot phase interpretation
+
+- If `Load source data` dominates, focus on source readers, decompression paths, and unnecessary materialization.
+- If `Normalize source data` dominates, focus on canonicalization, lookup creation, and repeated transforms.
+- If `Prepare normalized payload` dominates, focus on payload compression, fallback serialization, and cache publication churn.
+- If `Write dashboard` dominates, focus on payload embedding, split-assets behavior, and repeated template work.
+- If validation dominates as a whole, run `tests/Invoke-ValidationModeComparison.ps1` before changing audit logic so you can separate package cost from semantic replay cost.
+- If validation `Source signatures`, `Payload signatures`, or `Comparison` dominate, focus on attestation reuse, partition sizing, and unnecessary full semantic replays.
+
+## Artifact checklist
+
+- Keep raw review and benchmark output under `.local/`.
+- Use `.local\benchmark-history\benchmark-history.jsonl` for repeated local and Azure benchmark captures that are useful for trend review but not yet durable enough for merge-tracked documentation.
+- Treat `benchmark-medium-v1` as the durable baseline identity when you are updating merge-tracked baseline documentation.
+- Treat `dashboard-audit.json`, `stress-validation-report.json`, and `hot-phase-review.json` as the canonical local review artifacts.
+- Use the audit summary to explain why a validation run was slow before changing comparison logic.
+- Do not tighten CI thresholds until the same dataset and command path have been repeated enough times to understand normal variance.

--- a/src/powershell/Provisioning/Azure/AzureProvisioning.ps1
+++ b/src/powershell/Provisioning/Azure/AzureProvisioning.ps1
@@ -1,5 +1,28 @@
 ﻿# Source-first Azure provisioning helpers used by Setup-AzureResources.ps1.
 
+function Write-ProvisioningLogLine {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Message,
+
+        [Parameter(Mandatory = $false)]
+        [string]$ForegroundColor = 'Gray'
+    )
+
+    if ([string]::IsNullOrWhiteSpace($Message)) {
+        return
+    }
+
+    foreach ($line in ($Message -split "`r?`n")) {
+        if ([string]::IsNullOrWhiteSpace($line)) {
+            continue
+        }
+
+        Write-Host ("[{0}] {1}" -f (Get-Date).ToUniversalTime().ToString('u'), $line) -ForegroundColor $ForegroundColor
+    }
+}
+
 function Wait-WithPolling {
     <#
     .SYNOPSIS
@@ -20,14 +43,14 @@ function Wait-WithPolling {
     $stopwatch = [System.Diagnostics.Stopwatch]::StartNew()
     while ($stopwatch.Elapsed.TotalSeconds -lt $TimeoutSeconds) {
         if (& $Condition) {
-            Write-Host "  $Description - confirmed" -ForegroundColor Green
+            Write-ProvisioningLogLine -Message ("  {0} - confirmed" -f $Description) -ForegroundColor Green
             return $true
         }
-        Write-Host "  Waiting for $Description... ($([int]$stopwatch.Elapsed.TotalSeconds)s)" -ForegroundColor Gray
+        Write-ProvisioningLogLine -Message ("  Waiting for {0}... ({1}s)" -f $Description, [int]$stopwatch.Elapsed.TotalSeconds) -ForegroundColor Gray
         Start-Sleep -Seconds $IntervalSeconds
     }
     $stopwatch.Stop()
-    Write-Warning "$Description did not complete within ${TimeoutSeconds}s"
+    Write-Warning ("[{0}] {1} did not complete within {2}s" -f (Get-Date).ToUniversalTime().ToString('u'), $Description, $TimeoutSeconds)
     return $false
 }
 
@@ -50,13 +73,31 @@ function Invoke-ArmApi {
         [string]$Description = 'ARM API call'
     )
 
-    $params = @{
-        Path = $Path
-        Method = $Method
+    $requestUri = if ($Path -match '^https?://') {
+        $Path
     }
-    if ($Payload) { $params.Payload = $Payload }
+    elseif ($Path.StartsWith('/')) {
+        "https://management.azure.com$Path"
+    }
+    else {
+        "https://management.azure.com/$Path"
+    }
 
-    $response = Invoke-AzRestMethod @params
+    $params = @{
+        Uri = $requestUri
+        Method = $Method
+        Headers = @{
+            Authorization = "Bearer $(Get-ArmToken)"
+        }
+        ErrorAction = 'Stop'
+        SkipHttpErrorCheck = $true
+    }
+    if ($Payload) {
+        $params.ContentType = 'application/json'
+        $params.Body = $Payload
+    }
+
+    $response = Invoke-WebRequest @params
 
     if ($response.StatusCode -ge 200 -and $response.StatusCode -lt 300) {
         if ($response.Content) {
@@ -178,10 +219,33 @@ function Get-ArmToken {
         [string]$ResourceUrl = 'https://management.azure.com/'
     )
 
-    $tokenResponse = Get-AzAccessToken -ResourceUrl $ResourceUrl -AsSecureString
-    $ssPtr = [System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($tokenResponse.Token)
-    try { return [System.Runtime.InteropServices.Marshal]::PtrToStringBSTR($ssPtr) }
-    finally { [System.Runtime.InteropServices.Marshal]::ZeroFreeBSTR($ssPtr) }
+    try {
+        $tokenResponse = Get-AzAccessToken -ResourceUrl $ResourceUrl -AsSecureString -ErrorAction Stop
+        $ssPtr = [System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($tokenResponse.Token)
+        try { return [System.Runtime.InteropServices.Marshal]::PtrToStringBSTR($ssPtr) }
+        finally { [System.Runtime.InteropServices.Marshal]::ZeroFreeBSTR($ssPtr) }
+    }
+    catch {
+        Write-Verbose "Get-AzAccessToken failed for '$ResourceUrl': $_"
+    }
+
+    if ($null -ne (Get-Command -Name 'az' -CommandType Application -ErrorAction SilentlyContinue)) {
+        try {
+            $azAccessToken = (& az 'account' 'get-access-token' '--resource' $ResourceUrl '--query' 'accessToken' '-o' 'tsv' 2>&1 | Out-String)
+            if ($LASTEXITCODE -eq 0 -and -not [string]::IsNullOrWhiteSpace($azAccessToken)) {
+                return $azAccessToken.Trim()
+            }
+
+            if ($LASTEXITCODE -ne 0 -and -not [string]::IsNullOrWhiteSpace($azAccessToken)) {
+                Write-Verbose ("Azure CLI token acquisition failed for '{0}': {1}" -f $ResourceUrl, $azAccessToken.Trim())
+            }
+        }
+        catch {
+            Write-Verbose "Azure CLI token acquisition failed for '$ResourceUrl': $_"
+        }
+    }
+
+    throw "No Azure token source available for resource '$ResourceUrl'. Run Connect-AzAccount or az login, then retry."
 }
 
 function Get-JwtPayload {

--- a/src/powershell/Shared/Core/Core.ps1
+++ b/src/powershell/Shared/Core/Core.ps1
@@ -96,8 +96,12 @@ function Test-IsAzureHostedEnvironment {
 
     foreach ($environmentVariableName in @(
         'WEBSITE_INSTANCE_ID'
+        'WEBSITE_HOSTNAME'
+        'WEBSITE_SITE_NAME'
         'FUNCTIONS_WORKER_RUNTIME'
         'FUNCTIONS_EXTENSION_VERSION'
+        'FUNCTIONS_WORKER_DIRECTORY'
+        'FUNCTIONS_APPLICATION_DIRECTORY'
         'AUTOMATION_ASSET_ACCOUNTID'
         'AZUREPS_HOST_ENVIRONMENT'
     )) {

--- a/src/powershell/Shared/Dashboard/DashboardGeneration.ps1
+++ b/src/powershell/Shared/Dashboard/DashboardGeneration.ps1
@@ -259,13 +259,22 @@ function Write-JsonValueToWriter {
     }
 
     if ($Value -is [System.Management.Automation.PSObject]) {
-        $psProperties = @($Value.PSObject.Properties | Where-Object { $_.MemberType -eq [System.Management.Automation.PSMemberTypes]::NoteProperty })
-        if ($psProperties.Count -gt 0) {
-            $Writer.WriteStartObject()
-            foreach ($property in $psProperties) {
-                $Writer.WritePropertyName([string]$property.Name)
-                Write-JsonValueToWriter -Writer $Writer -Value $property.Value
+        $wroteNoteProperties = $false
+        foreach ($property in $Value.PSObject.Properties) {
+            if ($property.MemberType -ne [System.Management.Automation.PSMemberTypes]::NoteProperty) {
+                continue
             }
+
+            if (-not $wroteNoteProperties) {
+                $Writer.WriteStartObject()
+                $wroteNoteProperties = $true
+            }
+
+            $Writer.WritePropertyName([string]$property.Name)
+            Write-JsonValueToWriter -Writer $Writer -Value $property.Value
+        }
+
+        if ($wroteNoteProperties) {
             $Writer.WriteEndObject()
             return
         }
@@ -361,6 +370,93 @@ function Write-JsonValueToWriter {
     }
 
     $Writer.WriteValue($Value.ToString())
+}
+
+function Get-NormalizedLookupPropertyValue {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $false)]
+        [AllowNull()]
+        [object]$Value,
+
+        [Parameter(Mandatory = $true)]
+        [string]$Name
+    )
+
+    if ($null -eq $Value) {
+        return $null
+    }
+
+    if ($Value -is [System.Collections.IDictionary]) {
+        return $Value[$Name]
+    }
+
+    $property = $Value.PSObject.Properties[$Name]
+    if ($null -ne $property) {
+        return $property.Value
+    }
+
+    return $null
+}
+
+function Write-NormalizedDeviceMachineInfoToWriter {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [Newtonsoft.Json.JsonTextWriter]$Writer,
+
+        [Parameter(Mandatory = $false)]
+        [AllowNull()]
+        [object]$MachineInfo
+    )
+
+    if ($null -eq $MachineInfo) {
+        $Writer.WriteNull()
+        return
+    }
+
+    $Writer.WriteStartObject()
+    foreach ($propertyName in @('ip', 'eip', 'u', 'hs', 'rs', 'el', 'dv', 'mb', 'aad', 'ls', 'fs')) {
+        $Writer.WritePropertyName($propertyName)
+        Write-JsonValueToWriter -Writer $Writer -Value (Get-NormalizedLookupPropertyValue -Value $MachineInfo -Name $propertyName)
+    }
+    $Writer.WriteEndObject()
+}
+
+function Write-NormalizedDeviceLookupsToWriter {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '')]
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [Newtonsoft.Json.JsonTextWriter]$Writer,
+
+        [Parameter(Mandatory = $false)]
+        [AllowNull()]
+        [object]$Devices
+    )
+
+    if ($null -eq $Devices) {
+        $Writer.WriteNull()
+        return
+    }
+
+    $Writer.WriteStartArray()
+    foreach ($device in $Devices) {
+        if ($null -eq $device) {
+            $Writer.WriteNull()
+            continue
+        }
+
+        $Writer.WriteStartObject()
+        foreach ($propertyName in @('id', 'n', 'g', 'o', 'ov', 't')) {
+            $Writer.WritePropertyName($propertyName)
+            Write-JsonValueToWriter -Writer $Writer -Value (Get-NormalizedLookupPropertyValue -Value $device -Name $propertyName)
+        }
+        $Writer.WritePropertyName('m')
+        Write-NormalizedDeviceMachineInfoToWriter -Writer $Writer -MachineInfo (Get-NormalizedLookupPropertyValue -Value $device -Name 'm')
+        $Writer.WriteEndObject()
+    }
+    $Writer.WriteEndArray()
 }
 
 function Open-JsonArrayFileWriter {
@@ -670,6 +766,56 @@ function Read-CompactJsonReaderValue {
     }
 }
 
+function Open-CompactJsonArrayReader {
+    [CmdletBinding()]
+    [OutputType([pscustomobject])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Path
+    )
+
+    $resolvedPath = [System.IO.Path]::GetFullPath($Path)
+    $streamReader = [System.IO.StreamReader]::new($resolvedPath, [System.Text.Encoding]::UTF8)
+    $jsonReader = [Newtonsoft.Json.JsonTextReader]::new($streamReader)
+    if (-not $jsonReader.Read() -or $jsonReader.TokenType -ne [Newtonsoft.Json.JsonToken]::StartArray) {
+        $jsonReader.Dispose()
+        $streamReader.Dispose()
+        throw "Expected JSON array in '$resolvedPath'."
+    }
+
+    return [PSCustomObject]@{
+        Path = $resolvedPath
+        StreamReader = $streamReader
+        JsonReader = $jsonReader
+    }
+}
+
+function Read-NextCompactJsonArrayValue {
+    [CmdletBinding()]
+    [OutputType([pscustomobject])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [pscustomobject]$ReaderState
+    )
+
+    $jsonReader = $ReaderState.JsonReader
+    while ($jsonReader.Read()) {
+        if ($jsonReader.TokenType -eq [Newtonsoft.Json.JsonToken]::EndArray) {
+            return [PSCustomObject]@{
+                HasValue = $false
+                Value = $null
+            }
+        }
+
+        return [PSCustomObject]@{
+            HasValue = $true
+            Value = (Read-CompactJsonReaderValue -Reader $jsonReader)
+        }
+    }
+
+    throw "Unexpected end of compact JSON array '$($ReaderState.Path)'."
+}
+
 function Skip-JsonReaderValue {
     [CmdletBinding()]
     param(
@@ -902,73 +1048,9 @@ function Get-DashboardEmbeddedPayloadTempPath {
     return $tempPayloadPath
 }
 
-function Get-EmbeddedDashboardPayloadVulnCount {
+function Get-DashboardEmbeddedPayloadInspection {
     [CmdletBinding()]
-    [OutputType([int])]
-    param(
-        [Parameter(Mandatory = $true)]
-        [string]$Path
-    )
-
-    $resolvedPath = Resolve-Path -LiteralPath $Path -ErrorAction Stop
-    $content = Get-Content -LiteralPath $resolvedPath -Raw
-    $dataFormat = Get-DashboardHtmlScriptContent -Html $content -ScriptId 'dataFormat'
-    if ($dataFormat -eq 'external-compressed') {
-        $dashboardConfigJson = Get-DashboardHtmlScriptContent -Html $content -ScriptId 'dashboardConfig'
-        if ([string]::IsNullOrWhiteSpace($dashboardConfigJson)) {
-            throw "Unable to locate dashboardConfig metadata in '$Path'."
-        }
-
-        $dashboardConfig = $dashboardConfigJson | ConvertFrom-Json -Depth 20
-        $payloadUrl = [string]$dashboardConfig.payloadUrl
-        if ([string]::IsNullOrWhiteSpace($payloadUrl)) {
-            throw "dashboardConfig in '$Path' does not define payloadUrl."
-        }
-
-        $htmlDirectory = Split-Path -Path $resolvedPath -Parent
-        $payloadRelativePath = $payloadUrl.Replace('/', '\')
-        $payloadPath = [System.IO.Path]::GetFullPath((Join-Path $htmlDirectory $payloadRelativePath))
-        return (Get-CompressedPayloadVulnCount -Path $payloadPath)
-    }
-
-    $startMarker = '<script id="vulnsData" type="application/json">'
-    $endMarker = '</script>'
-    $startIndex = $content.IndexOf($startMarker)
-    if ($startIndex -lt 0) {
-        throw "Unable to locate embedded vulnerability payload in '$Path'."
-    }
-
-    $payloadStart = $startIndex + $startMarker.Length
-    $payloadEnd = $content.IndexOf($endMarker, $payloadStart)
-    if ($payloadEnd -lt 0) {
-        throw "Unable to locate payload terminator in '$Path'."
-    }
-
-    $base64 = ($content.Substring($payloadStart, $payloadEnd - $payloadStart) -replace '\s+', '')
-    $bytes = [Convert]::FromBase64String($base64)
-    $stream = $null
-    $gzip = $null
-    $reader = $null
-    $jsonReader = $null
-
-    try {
-        $stream = [System.IO.MemoryStream]::new($bytes)
-        $gzip = [System.IO.Compression.GZipStream]::new($stream, [System.IO.Compression.CompressionMode]::Decompress)
-        $reader = [System.IO.StreamReader]::new($gzip, [System.Text.Encoding]::UTF8)
-        $jsonReader = [Newtonsoft.Json.JsonTextReader]::new($reader)
-        return (Get-PayloadVulnCountFromJsonReader -Reader $jsonReader -Path $Path)
-    }
-    finally {
-        if ($jsonReader) { $jsonReader.Close() }
-        elseif ($reader) { $reader.Dispose() }
-        elseif ($gzip) { $gzip.Dispose() }
-        elseif ($stream) { $stream.Dispose() }
-    }
-}
-
-function Get-DashboardPayloadGzipSha256 {
-    [CmdletBinding()]
-    [OutputType([string])]
+    [OutputType([pscustomobject])]
     param(
         [Parameter(Mandatory = $true)]
         [string]$Path
@@ -993,7 +1075,12 @@ function Get-DashboardPayloadGzipSha256 {
         $htmlDirectory = Split-Path -Path $resolvedPath -Parent
         $payloadRelativePath = $payloadUrl.Replace('/', '\')
         $payloadPath = [System.IO.Path]::GetFullPath((Join-Path $htmlDirectory $payloadRelativePath))
-        return (Get-FileSha256Hex -Path $payloadPath)
+        return [PSCustomObject]@{
+            DataFormat = $dataFormat
+            PayloadPath = $payloadPath
+            PayloadRowCount = (Get-CompressedPayloadVulnCount -Path $payloadPath)
+            PayloadSha256 = (Get-FileSha256Hex -Path $payloadPath)
+        }
     }
 
     $startMarker = '<script id="vulnsData" type="application/json">'
@@ -1011,8 +1098,54 @@ function Get-DashboardPayloadGzipSha256 {
 
     $base64 = ($content.Substring($payloadStart, $payloadEnd - $payloadStart) -replace '\s+', '')
     $bytes = [Convert]::FromBase64String($base64)
-    $hashBytes = [System.Security.Cryptography.SHA256]::HashData($bytes)
-    return ([System.BitConverter]::ToString($hashBytes)).Replace('-', '').ToLowerInvariant()
+    $stream = $null
+    $gzip = $null
+    $reader = $null
+    $jsonReader = $null
+
+    try {
+        $stream = [System.IO.MemoryStream]::new($bytes, $false)
+        $gzip = [System.IO.Compression.GZipStream]::new($stream, [System.IO.Compression.CompressionMode]::Decompress)
+        $reader = [System.IO.StreamReader]::new($gzip, [System.Text.Encoding]::UTF8)
+        $jsonReader = [Newtonsoft.Json.JsonTextReader]::new($reader)
+        $payloadRowCount = Get-PayloadVulnCountFromJsonReader -Reader $jsonReader -Path $Path
+    }
+    finally {
+        if ($jsonReader) { $jsonReader.Close() }
+        elseif ($reader) { $reader.Dispose() }
+        elseif ($gzip) { $gzip.Dispose() }
+        elseif ($stream) { $stream.Dispose() }
+    }
+
+    $payloadSha256 = ([System.BitConverter]::ToString([System.Security.Cryptography.SHA256]::HashData($bytes))).Replace('-', '').ToLowerInvariant()
+    return [PSCustomObject]@{
+        DataFormat = $dataFormat
+        PayloadPath = $null
+        PayloadRowCount = $payloadRowCount
+        PayloadSha256 = $payloadSha256
+    }
+}
+
+function Get-EmbeddedDashboardPayloadVulnCount {
+    [CmdletBinding()]
+    [OutputType([int])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Path
+    )
+
+    return [int](Get-DashboardEmbeddedPayloadInspection -Path $Path).PayloadRowCount
+}
+
+function Get-DashboardPayloadGzipSha256 {
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Path
+    )
+
+    return [string](Get-DashboardEmbeddedPayloadInspection -Path $Path).PayloadSha256
 }
 
 function Get-NormalizedAuditDecimalString {
@@ -1198,7 +1331,12 @@ function Write-CombinedPayloadLookupsValue {
         else {
             $lookupValue = $Lookups.PSObject.Properties[$lookupPropertyName].Value
         }
-        Write-JsonValueToWriter -Writer $Writer -Value $lookupValue
+        if ($lookupPropertyName -eq 'devices') {
+            Write-NormalizedDeviceLookupsToWriter -Writer $Writer -Devices $lookupValue
+        }
+        else {
+            Write-JsonValueToWriter -Writer $Writer -Value $lookupValue
+        }
     }
     $Writer.WriteEndObject()
 }
@@ -2451,6 +2589,255 @@ function Get-VulnerabilityPayloadFingerprintSourceFileSet {
     return [System.IO.FileInfo[]]$files.ToArray()
 }
 
+function Get-NormalizedVulnColumnCacheFingerprint {
+        [CmdletBinding()]
+        [OutputType([string])]
+        param(
+            [Parameter(Mandatory = $true)]
+            [string]$BasePath,
+
+            [Parameter(Mandatory = $false)]
+            [switch]$SkipObservedWindowMerge
+        )
+
+        if (-not (Sync-VulnContentStoreSidecar -BasePath $BasePath)) {
+            return $null
+        }
+
+        $files = [System.Collections.Generic.List[System.IO.FileInfo]]::new()
+        foreach ($file in @(Get-VulnerabilityPayloadFingerprintSourceFileSet -BasePath $BasePath -SkipObservedWindowMerge:$SkipObservedWindowMerge)) {
+            if ($null -ne $file) {
+                $files.Add($file)
+            }
+        }
+
+        if ($files.Count -eq 0) {
+            return $null
+        }
+
+        $builder = [System.Text.StringBuilder]::new()
+        [void]$builder.AppendLine('dashboard-vuln-column-cache-v1')
+        [void]$builder.AppendLine(('SkipObservedWindowMerge=' + ($SkipObservedWindowMerge -eq $true)))
+        foreach ($file in @($files | Sort-Object FullName -Unique)) {
+            $hash = Get-FileSha256Hex -Path $file.FullName
+            [void]$builder.Append($file.FullName).Append('|')
+            [void]$builder.Append($file.Length).Append('|')
+            [void]$builder.Append($file.LastWriteTimeUtc.Ticks).Append('|')
+            [void]$builder.AppendLine($hash)
+        }
+
+    $fingerprintBytes = [System.Text.Encoding]::UTF8.GetBytes($builder.ToString())
+    $fingerprintHash = [System.Security.Cryptography.SHA256]::HashData($fingerprintBytes)
+    return ([System.BitConverter]::ToString($fingerprintHash)).Replace('-', '').ToLowerInvariant()
+}
+
+function Get-NormalizedVulnColumnCacheDirectoryPath {
+        [CmdletBinding()]
+        [OutputType([string])]
+        param(
+            [Parameter(Mandatory = $true)]
+            [string]$BasePath,
+
+            [Parameter(Mandatory = $true)]
+            [string]$Fingerprint,
+
+            [Parameter(Mandatory = $false)]
+            [switch]$Create
+        )
+
+    $cacheDirectory = Get-DashboardCacheDirectory -BasePath $BasePath -ChildPath 'vuln-columns' -Create:$Create
+    return Join-Path $cacheDirectory ("columns-{0}" -f $Fingerprint)
+}
+
+function Get-NormalizedVulnColumnCacheManifestPath {
+        [CmdletBinding()]
+        [OutputType([string])]
+        param(
+            [Parameter(Mandatory = $true)]
+            [string]$BasePath,
+
+            [Parameter(Mandatory = $true)]
+            [string]$Fingerprint,
+
+            [Parameter(Mandatory = $false)]
+            [switch]$Create
+        )
+
+    $cacheDirectory = Get-DashboardCacheDirectory -BasePath $BasePath -ChildPath 'vuln-columns' -Create:$Create
+    return Join-Path $cacheDirectory ("columns-{0}.json" -f $Fingerprint)
+}
+
+function Get-NormalizedVulnColumnCacheColumnPaths {
+        [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '', Justification = 'Internal helper intentionally returns the full set of normalized vulnerability column paths.')]
+        [CmdletBinding()]
+        [OutputType([hashtable])]
+        param(
+            [Parameter(Mandatory = $true)]
+            [string]$DirectoryPath
+        )
+
+        $paths = [ordered]@{}
+        foreach ($columnName in @('d', 'c', 's', 'v', 'f', 'l', 'ua', 'u', 'dp', 'rp', 'iv')) {
+            $paths[$columnName] = Join-Path $DirectoryPath ($columnName + '.json')
+        }
+
+    return $paths
+}
+
+function Clear-StaleNormalizedVulnColumnCache {
+        [CmdletBinding()]
+        param(
+            [Parameter(Mandatory = $true)]
+            [string]$BasePath,
+
+            [Parameter(Mandatory = $false)]
+            [string[]]$KeepPaths = @()
+        )
+
+        $cacheDirectory = Get-DashboardCacheDirectory -BasePath $BasePath -ChildPath 'vuln-columns'
+        if (-not (Test-Path -LiteralPath $cacheDirectory -PathType Container)) {
+            return
+        }
+
+        $normalizedKeepPaths = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+        foreach ($keepPath in @($KeepPaths)) {
+            if (-not [string]::IsNullOrWhiteSpace($keepPath)) {
+                [void]$normalizedKeepPaths.Add([System.IO.Path]::GetFullPath($keepPath))
+            }
+        }
+
+    foreach ($cacheItem in @(Get-ChildItem -Path $cacheDirectory -Force -ErrorAction SilentlyContinue)) {
+        if ($normalizedKeepPaths.Contains($cacheItem.FullName)) {
+            continue
+        }
+
+        Remove-Item -LiteralPath $cacheItem.FullName -Recurse -Force -ErrorAction SilentlyContinue
+    }
+}
+
+function Get-NormalizedVulnColumnCacheEntry {
+        [CmdletBinding()]
+        [OutputType([pscustomobject])]
+        param(
+            [Parameter(Mandatory = $true)]
+            [string]$BasePath,
+
+            [Parameter(Mandatory = $false)]
+            [switch]$SkipObservedWindowMerge
+        )
+
+        $fingerprint = Get-NormalizedVulnColumnCacheFingerprint -BasePath $BasePath -SkipObservedWindowMerge:$SkipObservedWindowMerge
+        if ([string]::IsNullOrWhiteSpace($fingerprint)) {
+            return $null
+        }
+
+        $columnDirectoryPath = Get-NormalizedVulnColumnCacheDirectoryPath -BasePath $BasePath -Fingerprint $fingerprint -Create
+        $manifestPath = Get-NormalizedVulnColumnCacheManifestPath -BasePath $BasePath -Fingerprint $fingerprint -Create
+        if ((-not (Test-Path -LiteralPath $columnDirectoryPath -PathType Container)) -or (-not (Test-Path -LiteralPath $manifestPath -PathType Leaf))) {
+            return $null
+        }
+
+        $columnPaths = Get-NormalizedVulnColumnCacheColumnPaths -DirectoryPath $columnDirectoryPath
+        foreach ($columnPath in $columnPaths.Values) {
+            if (-not (Test-Path -LiteralPath ([string]$columnPath) -PathType Leaf)) {
+                return $null
+            }
+        }
+
+        $manifest = Read-NormalizedPayloadManifest -Path $manifestPath
+        if ($null -eq $manifest) {
+            return $null
+        }
+
+        if ([string]$manifest.Fingerprint -ne $fingerprint) {
+            return $null
+        }
+
+    Clear-StaleNormalizedVulnColumnCache -BasePath $BasePath -KeepPaths @($columnDirectoryPath, $manifestPath)
+    return [PSCustomObject]@{
+        Fingerprint = $fingerprint
+        ColumnDirectoryPath = $columnDirectoryPath
+        ColumnPaths = $columnPaths
+        ManifestPath = $manifestPath
+        Manifest = $manifest
+    }
+}
+
+function Publish-NormalizedVulnColumnCache {
+        [CmdletBinding()]
+        [OutputType([pscustomobject])]
+        param(
+            [Parameter(Mandatory = $true)]
+            [string]$BasePath,
+
+            [Parameter(Mandatory = $true)]
+            [hashtable]$VulnColumnPaths,
+
+            [Parameter(Mandatory = $true)]
+            [int]$VulnCount,
+
+            [Parameter(Mandatory = $true)]
+            [object[]]$Dates,
+
+            [Parameter(Mandatory = $false)]
+            [object]$Quality,
+
+            [Parameter(Mandatory = $false)]
+            [switch]$SkipObservedWindowMerge,
+
+            [Parameter(Mandatory = $false)]
+            [int]$InventoryTupleCount = 0
+        )
+
+        $fingerprint = Get-NormalizedVulnColumnCacheFingerprint -BasePath $BasePath -SkipObservedWindowMerge:$SkipObservedWindowMerge
+        if ([string]::IsNullOrWhiteSpace($fingerprint)) {
+            return $null
+        }
+
+        $columnDirectoryPath = Get-NormalizedVulnColumnCacheDirectoryPath -BasePath $BasePath -Fingerprint $fingerprint -Create
+        $manifestPath = Get-NormalizedVulnColumnCacheManifestPath -BasePath $BasePath -Fingerprint $fingerprint -Create
+        $existingEntry = Get-NormalizedVulnColumnCacheEntry -BasePath $BasePath -SkipObservedWindowMerge:$SkipObservedWindowMerge
+        if ($existingEntry -and ([string]$existingEntry.Fingerprint -eq $fingerprint)) {
+            return $existingEntry
+        }
+
+        if (-not (Test-Path -LiteralPath $columnDirectoryPath -PathType Container)) {
+            [void](New-Item -Path $columnDirectoryPath -ItemType Directory -Force)
+        }
+
+        $cacheColumnPaths = Get-NormalizedVulnColumnCacheColumnPaths -DirectoryPath $columnDirectoryPath
+        foreach ($columnName in @($cacheColumnPaths.Keys)) {
+            $sourcePath = [string]$VulnColumnPaths[$columnName]
+            $destinationPath = [string]$cacheColumnPaths[$columnName]
+            if ([string]::IsNullOrWhiteSpace($sourcePath) -or -not (Test-Path -LiteralPath $sourcePath -PathType Leaf)) {
+                return $null
+            }
+
+            Copy-Item -LiteralPath $sourcePath -Destination $destinationPath -Force
+        }
+
+        $manifest = [ordered]@{
+            Version = 'dashboard-vuln-column-cache-v1'
+            Fingerprint = $fingerprint
+            GeneratedOnUtc = (Get-Date).ToUniversalTime().ToString('o')
+            VulnCount = $VulnCount
+            Dates = @($Dates)
+            Quality = $Quality
+            SkipObservedWindowMerge = ($SkipObservedWindowMerge -eq $true)
+            InventoryTupleCount = $InventoryTupleCount
+        }
+        Write-NormalizedPayloadManifest -Path $manifestPath -Manifest $manifest | Out-Null
+
+    Clear-StaleNormalizedVulnColumnCache -BasePath $BasePath -KeepPaths @($columnDirectoryPath, $manifestPath)
+    return [PSCustomObject]@{
+        Fingerprint = $fingerprint
+        ColumnDirectoryPath = $columnDirectoryPath
+        ColumnPaths = $cacheColumnPaths
+        ManifestPath = $manifestPath
+        Manifest = [PSCustomObject]$manifest
+    }
+}
+
 function Get-DashboardPayloadCacheFingerprint {
     [CmdletBinding()]
     [OutputType([string])]
@@ -3087,6 +3474,308 @@ function Get-NormalizationContext {
     }
 }
 
+function ConvertTo-NormalizedLookupRecord {
+    [CmdletBinding()]
+    [OutputType([pscustomobject])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [object]$Lookups,
+
+        [Parameter(Mandatory = $true)]
+        [int]$NoTagsIdx
+    )
+
+    return [PSCustomObject]@{
+        vendors = $Lookups.vendors
+        severities = $Lookups.severities
+        exploitLevels = $Lookups.exploitLevels
+        groups = $Lookups.groups
+        platforms = $Lookups.platforms
+        tags = $Lookups.tags
+        updates = $Lookups.updates
+        versions = $Lookups.versions
+        dates = $Lookups.dates
+        diskPaths = $Lookups.diskPaths
+        regPaths = $Lookups.regPaths
+        affSoftware = $Lookups.affSoftware
+        batchTitles = $Lookups.batchTitles
+        devices = $Lookups.devices
+        inventory = $Lookups.inventory
+        software = $Lookups.software
+        cves = $Lookups.cves
+        noTagsIdx = $NoTagsIdx
+    }
+}
+
+function Restore-ContentStoreNormalizedLookupsFromColumnCache {
+    [CmdletBinding()]
+    [OutputType([pscustomobject])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$DataPath,
+
+        [Parameter(Mandatory = $true)]
+        [hashtable]$Machines,
+
+        [Parameter(Mandatory = $false)]
+        [hashtable]$AdvancedHuntingData = @{},
+
+        [Parameter(Mandatory = $false)]
+        [hashtable]$AdvancedHuntingDeviceUsers = @{},
+
+        [Parameter(Mandatory = $false)]
+        [hashtable]$AdvancedHuntingInventoryData = @{},
+
+        [Parameter(Mandatory = $false)]
+        [hashtable]$NvdCveData = @{},
+
+        [Parameter(Mandatory = $false)]
+        [object[]]$CachedDates = @()
+    )
+
+    $dictionaryPath = Get-VulnContentDictionaryPath -BasePath $DataPath
+    if (-not (Test-Path -LiteralPath $dictionaryPath -PathType Leaf)) {
+        throw "Content dictionary '$dictionaryPath' was not found."
+    }
+
+    Compress-NormalizationMachineLookup -Machines $Machines | Out-Null
+
+    $context = Get-NormalizationContext
+    $context.Machines = $Machines
+    $context.AdvancedHuntingData = $AdvancedHuntingData
+    $context.AdvancedHuntingDeviceUsers = $AdvancedHuntingDeviceUsers
+    $context.AdvancedHuntingInventoryData = $AdvancedHuntingInventoryData
+    $context.NvdCveData = $NvdCveData
+
+    foreach ($cachedDate in @($CachedDates)) {
+        $dateText = [string]$cachedDate
+        if ([string]::IsNullOrWhiteSpace($dateText)) {
+            continue
+        }
+
+        if (-not $context.Indexes.dates.ContainsKey($dateText)) {
+            $context.Indexes.dates[$dateText] = $context.Lookups.dates.Count
+            $context.Lookups.dates.Add($dateText)
+        }
+    }
+
+    $dictionary = Read-VulnContentDictionary -Path $dictionaryPath
+    foreach ($deviceProfile in @($dictionary.deviceProfiles)) {
+        Add-NormalizedDevice `
+            -DeviceId ([string]$deviceProfile.id) `
+            -DeviceName ([string]$deviceProfile.n) `
+            -GroupName ([string]$deviceProfile.g) `
+            -OsPlatform ([string]$deviceProfile.o) `
+            -OsVersion ([string]$deviceProfile.ov) `
+            -MachineTags $(if ($deviceProfile.t) { @($deviceProfile.t) } else { @() }) `
+            -Context $context | Out-Null
+    }
+
+    foreach ($contentTemplate in @($dictionary.contentTemplates)) {
+        Resolve-NormalizedContentLookup `
+            -SoftwareVendor ([string]$contentTemplate.sv) `
+            -SoftwareName ([string]$contentTemplate.sn) `
+            -RecommendationReference ([string]$contentTemplate.rr) `
+            -CveId ([string]$contentTemplate.c) `
+            -CvssScore $contentTemplate.sc `
+            -SeverityLevel ([string]$contentTemplate.sev) `
+            -ExploitabilityLevel ([string]$contentTemplate.ex) `
+            -CveUrl ([string]$contentTemplate.bu) `
+            -CveBatchTitle ([string]$contentTemplate.bt) `
+            -RecommendedSecurityUpdate ([string]$contentTemplate.ru) `
+            -RecommendedSecurityUpdateId ([string]$contentTemplate.rid) `
+            -RecommendedSecurityUpdateUrl ([string]$contentTemplate.url) `
+            -SoftwareVersion ([string]$contentTemplate.ver) `
+            -DiskPaths @($contentTemplate.dp) `
+            -RegistryPaths @($contentTemplate.rp) `
+            -SecurityUpdateAvailable ($contentTemplate.ua -eq $true) `
+            -Context $context | Out-Null
+    }
+
+    $lookups = $context.Lookups
+    $tagIndex = $context.Indexes.tags
+    $noTagsLabel = '(No Tags)'
+    if ($context.HasNoTags -and -not $tagIndex.ContainsKey($noTagsLabel)) {
+        $tagIndex[$noTagsLabel] = $lookups.tags.Count
+        $lookups.tags.Add($noTagsLabel)
+    }
+    $noTagsIdx = if ($tagIndex.ContainsKey($noTagsLabel)) { $tagIndex[$noTagsLabel] } else { -1 }
+
+    Update-NormalizedAffectedSoftwareLookup -Lookups $lookups
+
+    return [PSCustomObject]@{
+        Lookups = (ConvertTo-NormalizedLookupRecord -Lookups $lookups -NoTagsIdx $noTagsIdx)
+        Quality = [PSCustomObject]@{
+            FirstLastSwappedCount = 0
+        }
+        Context = $context
+    }
+}
+
+function Restore-NormalizedVulnColumnPathsFromCache {
+    [CmdletBinding()]
+    [OutputType([pscustomobject])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [hashtable]$CachedColumnPaths,
+
+        [Parameter(Mandatory = $true)]
+        [pscustomobject]$RestoredLookupsResult,
+
+        [Parameter(Mandatory = $true)]
+        [string]$OutputDirectoryPath,
+
+        [Parameter(Mandatory = $false)]
+        [int]$CachedInventoryTupleCount = 0
+    )
+
+    $context = $RestoredLookupsResult.Context
+    $currentInventoryTupleCount = if ($null -ne $context -and $null -ne $context.AdvancedHuntingInventoryData) { $context.AdvancedHuntingInventoryData.Count } else { 0 }
+    if (($CachedInventoryTupleCount -eq 0) -and ($currentInventoryTupleCount -eq 0)) {
+        return [PSCustomObject]@{
+            ColumnPaths = $CachedColumnPaths
+            RefreshedInventoryColumn = $false
+            RowCount = 0
+        }
+    }
+
+    if ($null -eq $context) {
+        throw 'Restored lookup result does not contain the normalization context needed to refresh cached inventory columns.'
+    }
+
+    $resolvedOutputDirectoryPath = [System.IO.Path]::GetFullPath($OutputDirectoryPath)
+    if (Test-Path -LiteralPath $resolvedOutputDirectoryPath -PathType Container) {
+        Remove-Item -LiteralPath $resolvedOutputDirectoryPath -Recurse -Force -ErrorAction SilentlyContinue
+    }
+    [void](New-Item -Path $resolvedOutputDirectoryPath -ItemType Directory -Force)
+
+    $inventoryColumnPath = Join-Path $resolvedOutputDirectoryPath 'iv.json'
+    $inventoryColumnWriter = [PSCustomObject]@{
+        Path = $inventoryColumnPath
+        StreamWriter = [System.IO.StreamWriter]::new($inventoryColumnPath, $false, [System.Text.UTF8Encoding]::new($false))
+        Buffer = [System.Text.StringBuilder]::new(131072)
+        HasValue = $false
+    }
+    $inventoryColumnWriter.StreamWriter.Write('[')
+
+    $readerStates = [System.Collections.Generic.List[System.IDisposable]]::new()
+    $deviceReaderState = $null
+    $softwareReaderState = $null
+    $versionReaderState = $null
+
+    try {
+        foreach ($requiredColumnName in @('d', 's', 'v')) {
+            $columnPath = [string]$CachedColumnPaths[$requiredColumnName]
+            if ([string]::IsNullOrWhiteSpace($columnPath) -or -not (Test-Path -LiteralPath $columnPath -PathType Leaf)) {
+                throw "Cached normalized vulnerability column '$requiredColumnName' was not found."
+            }
+        }
+
+        $deviceReaderState = Open-CompactJsonArrayReader -Path ([string]$CachedColumnPaths['d'])
+        $softwareReaderState = Open-CompactJsonArrayReader -Path ([string]$CachedColumnPaths['s'])
+        $versionReaderState = Open-CompactJsonArrayReader -Path ([string]$CachedColumnPaths['v'])
+        [void]$readerStates.Add($deviceReaderState.JsonReader)
+        [void]$readerStates.Add($deviceReaderState.StreamReader)
+        [void]$readerStates.Add($softwareReaderState.JsonReader)
+        [void]$readerStates.Add($softwareReaderState.StreamReader)
+        [void]$readerStates.Add($versionReaderState.JsonReader)
+        [void]$readerStates.Add($versionReaderState.StreamReader)
+
+        $lookups = $context.Lookups
+        $rowCount = 0
+        while ($true) {
+            $deviceValueState = Read-NextCompactJsonArrayValue -ReaderState $deviceReaderState
+            $softwareValueState = Read-NextCompactJsonArrayValue -ReaderState $softwareReaderState
+            $versionValueState = Read-NextCompactJsonArrayValue -ReaderState $versionReaderState
+
+            if ((-not $deviceValueState.HasValue) -and (-not $softwareValueState.HasValue) -and (-not $versionValueState.HasValue)) {
+                break
+            }
+
+            if ((-not $deviceValueState.HasValue) -or (-not $softwareValueState.HasValue) -or (-not $versionValueState.HasValue)) {
+                throw 'Cached normalized vulnerability columns d/s/v have mismatched lengths.'
+            }
+
+            $deviceId = $null
+            $softwareVendor = ''
+            $softwareName = ''
+            $softwareVersion = ''
+
+            if ($null -ne $deviceValueState.Value) {
+                $deviceIndex = [int]$deviceValueState.Value
+                if ($deviceIndex -ge 0 -and $deviceIndex -lt $lookups.devices.Count) {
+                    $deviceEntry = $lookups.devices[$deviceIndex]
+                    $deviceId = if ($deviceEntry.PSObject.Properties['id']) { [string]$deviceEntry.id } else { $null }
+                }
+            }
+
+            if ($null -ne $softwareValueState.Value) {
+                $softwareIndex = [int]$softwareValueState.Value
+                if ($softwareIndex -ge 0 -and $softwareIndex -lt $lookups.software.Count) {
+                    $softwareEntry = $lookups.software[$softwareIndex]
+                    $softwareName = if ($softwareEntry.PSObject.Properties['n']) { [string]$softwareEntry.n } else { '' }
+                    if ($softwareEntry.PSObject.Properties['v'] -and $null -ne $softwareEntry.v) {
+                        $vendorIndex = [int]$softwareEntry.v
+                        if ($vendorIndex -ge 0 -and $vendorIndex -lt $lookups.vendors.Count) {
+                            $softwareVendor = [string]$lookups.vendors[$vendorIndex]
+                        }
+                    }
+                }
+            }
+
+            if ($null -ne $versionValueState.Value) {
+                $versionIndex = [int]$versionValueState.Value
+                if ($versionIndex -ge 0 -and $versionIndex -lt $lookups.versions.Count) {
+                    $softwareVersion = [string]$lookups.versions[$versionIndex]
+                }
+            }
+
+            $inventoryValue = Resolve-NormalizedInventoryLookup `
+                -DeviceId $deviceId `
+                -SoftwareVendor $softwareVendor `
+                -SoftwareName $softwareName `
+                -SoftwareVersion $softwareVersion `
+                -Context $context
+            Write-CompactColumnFileValue -WriterState $inventoryColumnWriter -Value $inventoryValue
+
+            $rowCount++
+            if (($rowCount % 100000) -eq 0) {
+                if ($inventoryColumnWriter.Buffer.Length -gt 0) {
+                    $inventoryColumnWriter.StreamWriter.Write($inventoryColumnWriter.Buffer.ToString())
+                    [void]$inventoryColumnWriter.Buffer.Clear()
+                }
+                $inventoryColumnWriter.StreamWriter.Flush()
+            }
+        }
+    }
+    finally {
+        foreach ($disposable in $readerStates) {
+            $disposable.Dispose()
+        }
+
+        if ($inventoryColumnWriter.StreamWriter) {
+            if ($inventoryColumnWriter.Buffer.Length -gt 0) {
+                $inventoryColumnWriter.StreamWriter.Write($inventoryColumnWriter.Buffer.ToString())
+                [void]$inventoryColumnWriter.Buffer.Clear()
+            }
+            $inventoryColumnWriter.StreamWriter.Write(']')
+            $inventoryColumnWriter.StreamWriter.Dispose()
+            $inventoryColumnWriter.StreamWriter = $null
+        }
+    }
+
+    $restoredColumnPaths = [ordered]@{}
+    foreach ($columnName in @('d', 'c', 's', 'v', 'f', 'l', 'ua', 'u', 'dp', 'rp', 'iv')) {
+        $restoredColumnPaths[$columnName] = if ($columnName -eq 'iv') { $inventoryColumnPath } else { [string]$CachedColumnPaths[$columnName] }
+    }
+
+    return [PSCustomObject]@{
+        ColumnPaths = $restoredColumnPaths
+        RefreshedInventoryColumn = $true
+        RowCount = $rowCount
+    }
+}
+
 function Write-CompactVulnRecordJson {
     param(
         [Parameter(Mandatory = $true)]
@@ -3268,6 +3957,74 @@ function Get-JsonElementPropertyValue {
     return Convert-JsonElementToScalarValue -Element $property
 }
 
+function Compress-NormalizationMachineLookup {
+    [CmdletBinding()]
+    [OutputType([hashtable])]
+    param(
+        [Parameter(Mandatory = $false)]
+        [AllowNull()]
+        [hashtable]$Machines
+    )
+
+    if ($null -eq $Machines -or $Machines.Count -eq 0) {
+        return @{}
+    }
+
+    foreach ($deviceId in @($Machines.Keys)) {
+        $machine = $Machines[$deviceId]
+        if ($null -eq $machine) {
+            $Machines.Remove($deviceId)
+            continue
+        }
+
+        if ($machine -is [System.Array] -and $machine.Length -ge 10) {
+            continue
+        }
+
+        $ip = $machine.PSObject.Properties['lastIpAddress']?.Value
+        $externalIp = $machine.PSObject.Properties['lastExternalIpAddress']?.Value
+        $healthStatus = $machine.PSObject.Properties['healthStatus']?.Value
+        $riskScore = $machine.PSObject.Properties['riskScore']?.Value
+        $exposureLevel = $machine.PSObject.Properties['exposureLevel']?.Value
+        $deviceValue = $machine.PSObject.Properties['deviceValue']?.Value
+        $managedBy = $machine.PSObject.Properties['managedBy']?.Value
+        $isAadJoined = $machine.PSObject.Properties['isAadJoined']?.Value
+        $lastSeen = $machine.PSObject.Properties['lastSeen']?.Value
+        $firstSeen = $machine.PSObject.Properties['firstSeen']?.Value
+
+        if (
+            $null -eq $ip -and
+            $null -eq $externalIp -and
+            $null -eq $healthStatus -and
+            $null -eq $riskScore -and
+            $null -eq $exposureLevel -and
+            $null -eq $deviceValue -and
+            $null -eq $managedBy -and
+            $null -eq $isAadJoined -and
+            $null -eq $lastSeen -and
+            $null -eq $firstSeen
+        ) {
+            $Machines.Remove($deviceId)
+            continue
+        }
+
+        $Machines[$deviceId] = [object[]]@(
+            $ip,
+            $externalIp,
+            $healthStatus,
+            $riskScore,
+            $exposureLevel,
+            $deviceValue,
+            $managedBy,
+            $isAadJoined,
+            $lastSeen,
+            $firstSeen
+        )
+    }
+
+    return $Machines
+}
+
 function Add-NormalizedDevice {
     param(
         $DeviceId,
@@ -3300,6 +4057,7 @@ function Add-NormalizedDevice {
 
     if (-not $deviceIndex.ContainsKey($deviceKey)) {
         $machine = if (-not [string]::IsNullOrWhiteSpace($DeviceId)) { $Context.Machines[$DeviceId] } else { $null }
+        $machineTuple = if ($machine -is [System.Array] -and $machine.Length -ge 10) { $machine } else { $null }
         $machineUsers = [string[]]@()
         if ($null -ne $Context.AdvancedHuntingDeviceUsers -and -not [string]::IsNullOrWhiteSpace($DeviceId)) {
             $rawMachineUsers = $Context.AdvancedHuntingDeviceUsers[[string]$DeviceId]
@@ -3312,18 +4070,16 @@ function Add-NormalizedDevice {
             }
         }
 
-        $resolvedGroupName = if ($machine) { $machine.PSObject.Properties['rbacGroupName']?.Value } else { $GroupName }
+        $resolvedGroupName = $GroupName
         if ([string]::IsNullOrWhiteSpace([string]$resolvedGroupName)) {
             $resolvedGroupName = if ([string]::IsNullOrWhiteSpace([string]$GroupName)) { '(none)' } else { $GroupName }
         }
         $groupIdx = Get-OrCreateIndex -value $resolvedGroupName -list $lookups.groups -indexMap $groupIndex
 
-        $osPlat = if ($machine) { $machine.PSObject.Properties['osPlatform']?.Value } else { $OsPlatform }
+        $osPlat = $OsPlatform
         $platIdx = Get-OrCreateIndex -value $osPlat -list $lookups.platforms -indexMap $platformIndex
 
-        $effectiveTags = if ($machine -and $machine.PSObject.Properties['machineTags']?.Value) { $machine.machineTags }
-                        elseif ($MachineTags) { $MachineTags }
-                        else { @() }
+        $effectiveTags = if ($MachineTags) { $MachineTags } else { @() }
         $tagIndices = [System.Collections.Generic.List[int]]::new()
         foreach ($tag in $effectiveTags) {
             $tagIdx = Get-OrCreateIndex -value $tag -list $lookups.tags -indexMap $tagIndex
@@ -3335,18 +4091,18 @@ function Add-NormalizedDevice {
 
         $machineInfo = $null
         if ($machine -or $machineUsers.Count -gt 0) {
-            $machineLastSeen = if ($machine) { $machine.PSObject.Properties['lastSeen']?.Value } else { $null }
-            $machineFirstSeen = if ($machine) { $machine.PSObject.Properties['firstSeen']?.Value } else { $null }
+            $machineLastSeen = if ($machineTuple) { $machineTuple[8] } elseif ($machine) { $machine.PSObject.Properties['lastSeen']?.Value } else { $null }
+            $machineFirstSeen = if ($machineTuple) { $machineTuple[9] } elseif ($machine) { $machine.PSObject.Properties['firstSeen']?.Value } else { $null }
             $machineInfo = [PSCustomObject]@{
-                ip = if ($machine) { $machine.PSObject.Properties['lastIpAddress']?.Value } else { $null }
-                eip = if ($machine) { $machine.PSObject.Properties['lastExternalIpAddress']?.Value } else { $null }
+                ip = if ($machineTuple) { $machineTuple[0] } elseif ($machine) { $machine.PSObject.Properties['lastIpAddress']?.Value } else { $null }
+                eip = if ($machineTuple) { $machineTuple[1] } elseif ($machine) { $machine.PSObject.Properties['lastExternalIpAddress']?.Value } else { $null }
                 u = if ($machineUsers.Count -gt 0) { @($machineUsers) } else { $null }
-                hs = if ($machine) { $machine.PSObject.Properties['healthStatus']?.Value } else { $null }
-                rs = if ($machine) { $machine.PSObject.Properties['riskScore']?.Value } else { $null }
-                el = if ($machine) { $machine.PSObject.Properties['exposureLevel']?.Value } else { $null }
-                dv = if ($machine) { $machine.PSObject.Properties['deviceValue']?.Value } else { $null }
-                mb = if ($machine) { $machine.PSObject.Properties['managedBy']?.Value } else { $null }
-                aad = if ($machine) { $machine.PSObject.Properties['isAadJoined']?.Value } else { $null }
+                hs = if ($machineTuple) { $machineTuple[2] } elseif ($machine) { $machine.PSObject.Properties['healthStatus']?.Value } else { $null }
+                rs = if ($machineTuple) { $machineTuple[3] } elseif ($machine) { $machine.PSObject.Properties['riskScore']?.Value } else { $null }
+                el = if ($machineTuple) { $machineTuple[4] } elseif ($machine) { $machine.PSObject.Properties['exposureLevel']?.Value } else { $null }
+                dv = if ($machineTuple) { $machineTuple[5] } elseif ($machine) { $machine.PSObject.Properties['deviceValue']?.Value } else { $null }
+                mb = if ($machineTuple) { $machineTuple[6] } elseif ($machine) { $machine.PSObject.Properties['managedBy']?.Value } else { $null }
+                aad = if ($machineTuple) { $machineTuple[7] } elseif ($machine) { $machine.PSObject.Properties['isAadJoined']?.Value } else { $null }
                 ls = Get-NormalizationCachedYmdDate -Context $Context -DateValue $machineLastSeen
                 fs = Get-NormalizationCachedYmdDate -Context $Context -DateValue $machineFirstSeen
             }
@@ -3354,10 +4110,10 @@ function Add-NormalizedDevice {
 
         $lookups.devices.Add([PSCustomObject]@{
             id = $DeviceId
-            n = if ($machine) { $machine.PSObject.Properties['computerDnsName']?.Value } elseif ($DeviceName) { $DeviceName } else { '(no machine data)' }
+            n = if ($DeviceName) { $DeviceName } elseif ($machine -and -not $machineTuple) { $machine.PSObject.Properties['computerDnsName']?.Value } else { '(no machine data)' }
             g = $groupIdx
             o = $platIdx
-            ov = if ($machine) { $machine.PSObject.Properties['osVersion']?.Value } else { $OsVersion }
+            ov = if ($OsVersion) { $OsVersion } elseif ($machine -and -not $machineTuple) { $machine.PSObject.Properties['osVersion']?.Value } else { $null }
             t = $tagIndices
             m = $machineInfo
         })
@@ -4214,6 +4970,8 @@ function Invoke-ContentStoreNormalization {
     $contentTemplates = @($dictionary.contentTemplates)
     $deviceProfileCount = $deviceProfiles.Count
     $contentTemplateCount = $contentTemplates.Count
+    $deviceProfileIds = [string[]]::new($deviceProfileCount)
+    $contentInventoryKeys = [object[]]::new($contentTemplateCount)
     $deviceLookupIndices = New-Object 'System.Int32[]' $deviceProfileCount
     $deviceOnboardedFlags = New-Object 'System.Boolean[]' $deviceProfileCount
     $contentLookupCache = New-Object 'System.Object[]' $contentTemplateCount
@@ -4224,6 +4982,7 @@ function Invoke-ContentStoreNormalization {
 
     for ($deviceProfileIndexValue = 0; $deviceProfileIndexValue -lt $deviceProfileCount; $deviceProfileIndexValue++) {
         $deviceProfile = $deviceProfiles[$deviceProfileIndexValue]
+        $deviceProfileIds[$deviceProfileIndexValue] = [string]$deviceProfile.id
         $machineTags = if ($deviceProfile.t) { @($deviceProfile.t) } else { @() }
         $deviceLookupIndices[$deviceProfileIndexValue] = Add-NormalizedDevice `
             -DeviceId ([string]$deviceProfile.id) `
@@ -4234,10 +4993,23 @@ function Invoke-ContentStoreNormalization {
             -MachineTags $machineTags `
             -Context $Context
         $deviceOnboardedFlags[$deviceProfileIndexValue] = ($deviceProfile.ob -eq $true)
+        $deviceProfiles[$deviceProfileIndexValue] = $null
+    }
+
+    $deviceProfiles = $deviceProfileIds
+
+    $dictionaryDeviceProfilesProperty = if ($null -ne $dictionary) { $dictionary.PSObject.Properties['deviceProfiles'] } else { $null }
+    if ($null -ne $dictionaryDeviceProfilesProperty) {
+        $dictionaryDeviceProfilesProperty.Value = @()
     }
 
     for ($contentTemplateIndexValue = 0; $contentTemplateIndexValue -lt $contentTemplateCount; $contentTemplateIndexValue++) {
         $contentTemplate = $contentTemplates[$contentTemplateIndexValue]
+        $contentInventoryKeys[$contentTemplateIndexValue] = [object[]]@(
+            [string]$contentTemplate.sv,
+            [string]$contentTemplate.sn,
+            [string]$contentTemplate.ver
+        )
 
         $contentLookupCache[$contentTemplateIndexValue] = Resolve-NormalizedContentLookup `
             -SoftwareVendor ([string]$contentTemplate.sv) `
@@ -4257,6 +5029,15 @@ function Invoke-ContentStoreNormalization {
             -RegistryPaths @($contentTemplate.rp) `
             -SecurityUpdateAvailable ($contentTemplate.ua -eq $true) `
             -Context $Context
+
+        $contentTemplates[$contentTemplateIndexValue] = $null
+    }
+
+    $contentTemplates = $contentInventoryKeys
+
+    $dictionaryContentTemplatesProperty = if ($null -ne $dictionary) { $dictionary.PSObject.Properties['contentTemplates'] } else { $null }
+    if ($null -ne $dictionaryContentTemplatesProperty) {
+        $dictionaryContentTemplatesProperty.Value = @()
     }
 
     try {
@@ -4380,7 +5161,7 @@ function Invoke-ContentStoreNormalization {
 
                             $contentLookup = $contentLookupCache[$contentTemplateIndexValue]
                             $contentTemplate = $contentTemplates[$contentTemplateIndexValue]
-                            $deviceProfile = $deviceProfiles[$deviceProfileIndexValue]
+                            $deviceProfileId = $deviceProfiles[$deviceProfileIndexValue]
                             $compactRecord[0] = $deviceLookupIndices[$deviceProfileIndexValue]
                             $compactRecord[1] = $contentLookup.cve
                             $compactRecord[2] = $contentLookup.sw
@@ -4392,10 +5173,10 @@ function Invoke-ContentStoreNormalization {
                             $compactRecord[8] = $contentLookup.dp
                             $compactRecord[9] = $contentLookup.rp
                             $compactRecord[10] = Resolve-NormalizedInventoryLookup `
-                                -DeviceId ([string]$deviceProfile.id) `
-                                -SoftwareVendor ([string]$contentTemplate.sv) `
-                                -SoftwareName ([string]$contentTemplate.sn) `
-                                -SoftwareVersion ([string]$contentTemplate.ver) `
+                                -DeviceId ([string]$deviceProfileId) `
+                                -SoftwareVendor ([string]$contentTemplate[0]) `
+                                -SoftwareName ([string]$contentTemplate[1]) `
+                                -SoftwareVersion ([string]$contentTemplate[2]) `
                                 -Context $Context
 
                             if ($columnStates) {
@@ -4526,7 +5307,7 @@ function Invoke-ContentStoreNormalization {
 
                                     $contentLookup = $contentLookupCache[$ctv]
                                     $contentTemplate = $contentTemplates[$ctv]
-                                    $deviceProfile = $deviceProfiles[$dpv]
+                                    $deviceProfileId = $deviceProfiles[$dpv]
                                     $compactRecord[0] = $deviceLookupIndices[$dpv]
                                     $compactRecord[1] = $contentLookup.cve
                                     $compactRecord[2] = $contentLookup.sw
@@ -4538,10 +5319,10 @@ function Invoke-ContentStoreNormalization {
                                     $compactRecord[8] = $contentLookup.dp
                                     $compactRecord[9] = $contentLookup.rp
                                     $compactRecord[10] = Resolve-NormalizedInventoryLookup `
-                                        -DeviceId ([string]$deviceProfile.id) `
-                                        -SoftwareVendor ([string]$contentTemplate.sv) `
-                                        -SoftwareName ([string]$contentTemplate.sn) `
-                                        -SoftwareVersion ([string]$contentTemplate.ver) `
+                                        -DeviceId ([string]$deviceProfileId) `
+                                        -SoftwareVendor ([string]$contentTemplate[0]) `
+                                        -SoftwareName ([string]$contentTemplate[1]) `
+                                        -SoftwareVersion ([string]$contentTemplate[2]) `
                                         -Context $Context
 
                                     if ($columnStates) {
@@ -4617,6 +5398,45 @@ function Invoke-ContentStoreNormalization {
         }
 
         Sync-NormalizedVulnWriter -WriterState $writerState
+
+        # Payload finalization only needs the compact lookup collections. Release
+        # the much larger content-store scaffolding first so hosted Automation
+        # does not carry that transient state into lookup serialization.
+        foreach ($transientArray in @($deviceProfiles, $contentTemplates, $deviceLookupIndices, $deviceOnboardedFlags, $contentLookupCache)) {
+            if ($null -ne $transientArray) {
+                [System.Array]::Clear($transientArray, 0, $transientArray.Length)
+            }
+        }
+
+        if ($null -ne $refPaths) {
+            $refPaths.Clear()
+        }
+
+        $Context.Machines = @{}
+        $Context.AdvancedHuntingData = @{}
+        $Context.AdvancedHuntingDeviceUsers = @{}
+        $Context.AdvancedHuntingInventoryData = @{}
+        $Context.NvdCveData = @{}
+
+        $dateValueCacheProperty = $Context.PSObject.Properties['DateValueCache']
+        if ($null -ne $dateValueCacheProperty -and $null -ne $dateValueCacheProperty.Value) {
+            $dateValueCacheProperty.Value.Clear()
+        }
+
+        $dictionary = $null
+        $deviceProfiles = $null
+        $contentTemplates = $null
+        $deviceLookupIndices = $null
+        $deviceOnboardedFlags = $null
+        $contentLookupCache = $null
+        $refPaths = $null
+
+        if (-not [string]::IsNullOrWhiteSpace($PayloadOutputPath)) {
+            Invoke-FullGarbageCollection
+            if (Get-Command -Name Write-MemoryUsage -ErrorAction SilentlyContinue) {
+                $null = Write-MemoryUsage -Label 'Pre-PayloadClose'
+            }
+        }
     }
     finally {
         if ($writerState) {
@@ -5489,6 +6309,7 @@ function ConvertTo-NormalizedData {
 
     Write-Information '  Normalizing data structure...' -InformationAction Continue
     Write-Information ("  Normalization inputs: {0} machine(s), {1} Advanced Hunting CVE(s), {2} device user row(s), {3} inventory tuple(s), {4} NVD CVE(s)" -f $Machines.Count, $AdvancedHuntingData.Count, $AdvancedHuntingDeviceUsers.Count, $AdvancedHuntingInventoryData.Count, $NvdCveData.Count) -InformationAction Continue
+    Compress-NormalizationMachineLookup -Machines $Machines | Out-Null
     $context = Get-NormalizationContext
     $context.Machines = $Machines
     $context.AdvancedHuntingData = $AdvancedHuntingData
@@ -5628,26 +6449,7 @@ function ConvertTo-NormalizedData {
     Update-NormalizedAffectedSoftwareLookup -Lookups $lookups
 
     return @{
-        Lookups = [PSCustomObject]@{
-            vendors = $lookups.vendors
-            severities = $lookups.severities
-            exploitLevels = $lookups.exploitLevels
-            groups = $lookups.groups
-            platforms = $lookups.platforms
-            tags = $lookups.tags
-            updates = $lookups.updates
-            versions = $lookups.versions
-            dates = $lookups.dates
-            diskPaths = $lookups.diskPaths
-            regPaths = $lookups.regPaths
-            affSoftware = $lookups.affSoftware
-            batchTitles = $lookups.batchTitles
-            devices = $lookups.devices
-            inventory = $lookups.inventory
-            software = $lookups.software
-            cves = $lookups.cves
-            noTagsIdx = $noTagsIdx
-        }
+        Lookups = (ConvertTo-NormalizedLookupRecord -Lookups $lookups -NoTagsIdx $noTagsIdx)
         Quality = [PSCustomObject]@{
             FirstLastSwappedCount = $firstLastSwappedCount
         }

--- a/src/powershell/Validation/Audit/DashboardAudit.ps1
+++ b/src/powershell/Validation/Audit/DashboardAudit.ps1
@@ -1819,6 +1819,87 @@ function Get-LegacyMigrationRegressionAudit {
     }
 }
 
+function New-DashboardAuditPhaseTimings {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '', Justification = 'Internal helper only creates an in-memory phase timing record for audit output.')]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '', Justification = 'Internal helper returns a structured collection of phase timing values by design.')]
+    [CmdletBinding()]
+    [OutputType([pscustomobject])]
+    param(
+        [Parameter(Mandatory = $false)]
+        [hashtable]$Values = @{}
+    )
+
+    $phaseTimings = [ordered]@{
+        MachineLoadElapsedSeconds = $null
+        AdvancedHuntingLoadElapsedSeconds = $null
+        SourceMaterializationElapsedSeconds = $null
+        PayloadLoadElapsedSeconds = $null
+        VendorIndexElapsedSeconds = $null
+        SourceSignatureElapsedSeconds = $null
+        PayloadSignatureElapsedSeconds = $null
+        RowComparisonElapsedSeconds = $null
+        EnrichmentAuditElapsedSeconds = $null
+        ReportComparisonsElapsedSeconds = $null
+        DuplicateIdentityElapsedSeconds = $null
+        OpenStateElapsedSeconds = $null
+        ComparisonElapsedSeconds = $null
+        BaselineAuditElapsedSeconds = $null
+        BaselineCoverageElapsedSeconds = $null
+        LegacyFixtureRegressionElapsedSeconds = $null
+        TotalElapsedSeconds = $null
+    }
+
+    foreach ($key in $Values.Keys) {
+        if ($phaseTimings.Contains($key)) {
+            $phaseTimings[$key] = $Values[$key]
+        }
+    }
+
+    return [PSCustomObject]$phaseTimings
+}
+
+function Write-DashboardAuditPhaseTimingSummary {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        $PhaseTimings
+    )
+
+    $phaseLabels = [ordered]@{
+        MachineLoadElapsedSeconds = 'machine load'
+        AdvancedHuntingLoadElapsedSeconds = 'Advanced Hunting load'
+        SourceMaterializationElapsedSeconds = 'source materialization'
+        PayloadLoadElapsedSeconds = 'payload load'
+        VendorIndexElapsedSeconds = 'vendor index'
+        SourceSignatureElapsedSeconds = 'source signatures'
+        PayloadSignatureElapsedSeconds = 'payload signatures'
+        RowComparisonElapsedSeconds = 'row comparison'
+        EnrichmentAuditElapsedSeconds = 'enrichment audit'
+        ReportComparisonsElapsedSeconds = 'report comparisons'
+        DuplicateIdentityElapsedSeconds = 'duplicate identity audit'
+        OpenStateElapsedSeconds = 'open-state audit'
+        ComparisonElapsedSeconds = 'comparison'
+        BaselineAuditElapsedSeconds = 'baseline audit'
+        BaselineCoverageElapsedSeconds = 'baseline coverage'
+        LegacyFixtureRegressionElapsedSeconds = 'legacy fixture regression'
+        TotalElapsedSeconds = 'total'
+    }
+
+    $segments = [System.Collections.Generic.List[string]]::new()
+    foreach ($propertyName in $phaseLabels.Keys) {
+        $property = $PhaseTimings.PSObject.Properties[$propertyName]
+        if ($null -eq $property -or $null -eq $property.Value) {
+            continue
+        }
+
+        $segments.Add(("{0} {1:N2}s" -f $phaseLabels[$propertyName], [double]$property.Value)) | Out-Null
+    }
+
+    if ($segments.Count -gt 0) {
+        Write-Information ("  Audit phase timing summary: {0}" -f ($segments -join '; ')) -InformationAction Continue
+    }
+}
+
 function Get-DashboardAuditResult {
     [CmdletBinding()]
     param(
@@ -1843,7 +1924,7 @@ function Get-DashboardAuditResult {
 
     $skipObservedWindowMerge = (Test-IsSyntheticDataset -BasePath $ResolvedExportsPath)
     $payloadCacheEntry = Get-NormalizedPayloadCacheEntry -BasePath $ResolvedExportsPath -SkipObservedWindowMerge:$skipObservedWindowMerge
-    $largeAuditThreshold = 250000
+    $largeAuditThreshold = 100000
     if (
         -not $payloadCacheEntry -and
         [string]::IsNullOrWhiteSpace($ResolvedBaselineAuditPath) -and
@@ -1904,18 +1985,42 @@ function Get-DashboardAuditResult {
         return (Get-StreamingDashboardAuditResult -ResolvedHtmlPath $ResolvedHtmlPath -ResolvedExportsPath $ResolvedExportsPath -PayloadCacheEntry $payloadCacheEntry)
     }
 
+    $auditStopwatch = [System.Diagnostics.Stopwatch]::StartNew()
+    $machineLoadStopwatch = [System.Diagnostics.Stopwatch]::StartNew()
     $machines = Read-MachineData -Path $ResolvedExportsPath
+    $machineLoadStopwatch.Stop()
+    $machineLoadElapsedSeconds = [math]::Round($machineLoadStopwatch.Elapsed.TotalSeconds, 2)
+
+    $advancedHuntingLoadStopwatch = [System.Diagnostics.Stopwatch]::StartNew()
     $advancedHunting = Read-AdvancedHuntingData -Path $ResolvedExportsPath
     $advancedHuntingInventory = Read-AdvancedHuntingInventoryData -Path $ResolvedExportsPath
     $nvdCveData = Read-NvdCveData -Path $ResolvedExportsPath
+    $advancedHuntingLoadStopwatch.Stop()
+    $advancedHuntingLoadElapsedSeconds = [math]::Round($advancedHuntingLoadStopwatch.Elapsed.TotalSeconds, 2)
+
+    $sourceMaterializationStopwatch = [System.Diagnostics.Stopwatch]::StartNew()
     $sourceResult = Read-SourceRow -ExportsPath $ResolvedExportsPath -Machines $machines -AdvancedHunting $advancedHunting -SkipObservedWindowMerge:$skipObservedWindowMerge -AdvancedHuntingInventory $advancedHuntingInventory -NvdCveData $nvdCveData
+    $sourceMaterializationStopwatch.Stop()
+    $sourceMaterializationElapsedSeconds = [math]::Round($sourceMaterializationStopwatch.Elapsed.TotalSeconds, 2)
+
+    $payloadLoadStopwatch = [System.Diagnostics.Stopwatch]::StartNew()
     $payload = Read-DashboardPayload -Path $ResolvedHtmlPath
     $dashboardRows = Read-DashboardRow -Payload $payload
+    $payloadLoadStopwatch.Stop()
+    $payloadLoadElapsedSeconds = [math]::Round($payloadLoadStopwatch.Elapsed.TotalSeconds, 2)
     $baselineDashboardHtmlPath = Resolve-BaselineDashboardHtmlPath -RequestedPath $ResolvedBaselineDashboardHtmlPath
 
+    $rowComparisonStopwatch = [System.Diagnostics.Stopwatch]::StartNew()
     $rowComparison = Compare-RowSet -ExpectedRows $sourceResult.Rows -ActualRows $dashboardRows
-    $enrichmentAudit = Get-EnrichmentAudit -SourceRows $sourceResult.Rows -DashboardRows $dashboardRows
+    $rowComparisonStopwatch.Stop()
+    $rowComparisonElapsedSeconds = [math]::Round($rowComparisonStopwatch.Elapsed.TotalSeconds, 2)
 
+    $enrichmentAuditStopwatch = [System.Diagnostics.Stopwatch]::StartNew()
+    $enrichmentAudit = Get-EnrichmentAudit -SourceRows $sourceResult.Rows -DashboardRows $dashboardRows
+    $enrichmentAuditStopwatch.Stop()
+    $enrichmentAuditElapsedSeconds = [math]::Round($enrichmentAuditStopwatch.Elapsed.TotalSeconds, 2)
+
+    $reportComparisonsStopwatch = [System.Diagnostics.Stopwatch]::StartNew()
     $reportComparisons = @(
         Compare-ReportOutput -Name 'Stats' -Expected (Get-StatsReport -Rows $sourceResult.Rows) -Actual (Get-StatsReport -Rows $dashboardRows)
         Compare-ReportOutput -Name 'ActiveChart' -Expected @(Get-ActiveChartReport -Rows $sourceResult.Rows) -Actual @(Get-ActiveChartReport -Rows $dashboardRows)
@@ -1926,16 +2031,31 @@ function Get-DashboardAuditResult {
         Compare-ReportOutput -Name 'DevicesByRemediation' -Expected @(Get-DevicesByRemediationReport -Rows $sourceResult.Rows) -Actual @(Get-DevicesByRemediationReport -Rows $dashboardRows)
         Compare-ReportOutput -Name 'RemediationsByDevice' -Expected @(Get-RemediationsByDeviceReport -Rows $sourceResult.Rows) -Actual @(Get-RemediationsByDeviceReport -Rows $dashboardRows)
     )
+    $reportComparisonsStopwatch.Stop()
+    $reportComparisonsElapsedSeconds = [math]::Round($reportComparisonsStopwatch.Elapsed.TotalSeconds, 2)
 
+    $duplicateAuditStopwatch = [System.Diagnostics.Stopwatch]::StartNew()
     $duplicateAudit = Get-DuplicateIdentityAudit -SourceRows $sourceResult.Rows
+    $duplicateAuditStopwatch.Stop()
+    $duplicateIdentityElapsedSeconds = [math]::Round($duplicateAuditStopwatch.Elapsed.TotalSeconds, 2)
+
+    $openStateAuditStopwatch = [System.Diagnostics.Stopwatch]::StartNew()
     $openStateAudit = Get-OpenStateAudit -Rows $sourceResult.Rows
+    $openStateAuditStopwatch.Stop()
+    $openStateElapsedSeconds = [math]::Round($openStateAuditStopwatch.Elapsed.TotalSeconds, 2)
+
     $legacyMigrationAudit = Get-LegacyMigrationRegressionAudit
     $qualityMeta = if ($payload.PSObject.Properties['quality'] -and $payload.quality) { $payload.quality } else { $null }
+
+    $baselineAuditElapsedSeconds = $null
+    $baselineCoverageElapsedSeconds = $null
+    $legacyFixtureRegressionElapsedSeconds = $null
 
     $result = [PSCustomObject]@{
         GeneratedOn = (Get-Date).ToString('o')
         HtmlPath = $ResolvedHtmlPath
         ExportsPath = $ResolvedExportsPath
+        AuditMode = 'full-dashboard-audit'
         Source = [PSCustomObject]@{
             RowCount = $sourceResult.Rows.Count
             MissingMachineCount = $sourceResult.MissingMachineCount
@@ -1956,16 +2076,44 @@ function Get-DashboardAuditResult {
     }
 
     if (-not [string]::IsNullOrWhiteSpace($ResolvedBaselineAuditPath)) {
+        $baselineAuditStopwatch = [System.Diagnostics.Stopwatch]::StartNew()
         $result | Add-Member -NotePropertyName RegressionComparison -NotePropertyValue (Compare-BaselineAudit -CurrentAudit $result -BaselinePath $ResolvedBaselineAuditPath)
+        $baselineAuditStopwatch.Stop()
+        $baselineAuditElapsedSeconds = [math]::Round($baselineAuditStopwatch.Elapsed.TotalSeconds, 2)
     }
 
     if (-not [string]::IsNullOrWhiteSpace($baselineDashboardHtmlPath)) {
+        $baselineCoverageStopwatch = [System.Diagnostics.Stopwatch]::StartNew()
         $result | Add-Member -NotePropertyName BaselineDashboardCoverage -NotePropertyValue (Compare-BaselineDashboardCoverage -CurrentDashboardRows $dashboardRows -BaselineHtmlPath $baselineDashboardHtmlPath)
+        $baselineCoverageStopwatch.Stop()
+        $baselineCoverageElapsedSeconds = [math]::Round($baselineCoverageStopwatch.Elapsed.TotalSeconds, 2)
     }
 
     if ($RunLegacyFixtureRegression) {
+        $legacyFixtureRegressionStopwatch = [System.Diagnostics.Stopwatch]::StartNew()
         $result | Add-Member -NotePropertyName LegacyFixtureRegression -NotePropertyValue (Get-LegacyFixtureRegressionAudit -FixturePath $ResolvedLegacyFixturePath)
+        $legacyFixtureRegressionStopwatch.Stop()
+        $legacyFixtureRegressionElapsedSeconds = [math]::Round($legacyFixtureRegressionStopwatch.Elapsed.TotalSeconds, 2)
     }
+
+    $auditStopwatch.Stop()
+    $phaseTimings = New-DashboardAuditPhaseTimings -Values @{
+        MachineLoadElapsedSeconds = $machineLoadElapsedSeconds
+        AdvancedHuntingLoadElapsedSeconds = $advancedHuntingLoadElapsedSeconds
+        SourceMaterializationElapsedSeconds = $sourceMaterializationElapsedSeconds
+        PayloadLoadElapsedSeconds = $payloadLoadElapsedSeconds
+        RowComparisonElapsedSeconds = $rowComparisonElapsedSeconds
+        EnrichmentAuditElapsedSeconds = $enrichmentAuditElapsedSeconds
+        ReportComparisonsElapsedSeconds = $reportComparisonsElapsedSeconds
+        DuplicateIdentityElapsedSeconds = $duplicateIdentityElapsedSeconds
+        OpenStateElapsedSeconds = $openStateElapsedSeconds
+        BaselineAuditElapsedSeconds = $baselineAuditElapsedSeconds
+        BaselineCoverageElapsedSeconds = $baselineCoverageElapsedSeconds
+        LegacyFixtureRegressionElapsedSeconds = $legacyFixtureRegressionElapsedSeconds
+        TotalElapsedSeconds = [math]::Round($auditStopwatch.Elapsed.TotalSeconds, 2)
+    }
+    $result | Add-Member -NotePropertyName PhaseTimings -NotePropertyValue $phaseTimings
+    Write-DashboardAuditPhaseTimingSummary -PhaseTimings $phaseTimings
 
     return $result
 }

--- a/src/powershell/Validation/Audit/LargeDatasetAudit.ps1
+++ b/src/powershell/Validation/Audit/LargeDatasetAudit.ps1
@@ -173,6 +173,300 @@ function Get-PartitionedSignatureFilePath {
     return (Join-Path $DirectoryPath ("p{0:D3}.txt" -f $Index))
 }
 
+function Get-PartitionedSignatureSetMetadataPath {
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$DirectoryPath
+    )
+
+    return (Join-Path $DirectoryPath 'signature-set.json')
+}
+
+function Get-PayloadSignatureCacheDirectory {
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory = $true)]
+        $PayloadCacheEntry,
+
+        [Parameter(Mandatory = $false)]
+        [switch]$Create
+    )
+
+    $payloadDirectory = Split-Path -Path ([System.IO.Path]::GetFullPath([string]$PayloadCacheEntry.PayloadPath)) -Parent
+    $cacheDirectory = Join-Path $payloadDirectory ("payload-signatures-{0}" -f [string]$PayloadCacheEntry.Fingerprint)
+    if ($Create) {
+        [void](New-Item -Path $cacheDirectory -ItemType Directory -Force)
+    }
+
+    return $cacheDirectory
+}
+
+function Get-SourceSignatureCacheDirectory {
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory = $true)]
+        $PayloadCacheEntry,
+
+        [Parameter(Mandatory = $true)]
+        [string]$SourceFingerprint,
+
+        [Parameter(Mandatory = $false)]
+        [switch]$Create
+    )
+
+    $payloadDirectory = Split-Path -Path ([System.IO.Path]::GetFullPath([string]$PayloadCacheEntry.PayloadPath)) -Parent
+    $cacheDirectory = Join-Path $payloadDirectory ("source-signatures-{0}" -f $SourceFingerprint)
+    if ($Create) {
+        [void](New-Item -Path $cacheDirectory -ItemType Directory -Force)
+    }
+
+    return $cacheDirectory
+}
+
+function Clear-StalePayloadSignatureCaches {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '')]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '', Justification = 'Internal helper clears multiple cached payload signature directories by design.')]
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        $PayloadCacheEntry
+    )
+
+    $payloadDirectory = Split-Path -Path ([System.IO.Path]::GetFullPath([string]$PayloadCacheEntry.PayloadPath)) -Parent
+    if (-not (Test-Path -LiteralPath $payloadDirectory -PathType Container)) {
+        return
+    }
+
+    $expectedDirectory = Get-PayloadSignatureCacheDirectory -PayloadCacheEntry $PayloadCacheEntry
+    foreach ($cacheDirectory in @(Get-ChildItem -Path $payloadDirectory -Directory -Filter 'payload-signatures-*' -ErrorAction SilentlyContinue)) {
+        if ([System.StringComparer]::OrdinalIgnoreCase.Equals($cacheDirectory.FullName, $expectedDirectory)) {
+            continue
+        }
+
+        Remove-Item -LiteralPath $cacheDirectory.FullName -Recurse -Force -ErrorAction SilentlyContinue
+    }
+}
+
+function Clear-StaleSourceSignatureCaches {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '')]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '', Justification = 'Internal helper clears multiple cached source signature directories by design.')]
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        $PayloadCacheEntry,
+
+        [Parameter(Mandatory = $true)]
+        [string]$ExpectedSourceFingerprint
+    )
+
+    $payloadDirectory = Split-Path -Path ([System.IO.Path]::GetFullPath([string]$PayloadCacheEntry.PayloadPath)) -Parent
+    if (-not (Test-Path -LiteralPath $payloadDirectory -PathType Container)) {
+        return
+    }
+
+    $expectedDirectory = Get-SourceSignatureCacheDirectory -PayloadCacheEntry $PayloadCacheEntry -SourceFingerprint $ExpectedSourceFingerprint
+    foreach ($cacheDirectory in @(Get-ChildItem -Path $payloadDirectory -Directory -Filter 'source-signatures-*' -ErrorAction SilentlyContinue)) {
+        if ([System.StringComparer]::OrdinalIgnoreCase.Equals($cacheDirectory.FullName, $expectedDirectory)) {
+            continue
+        }
+
+        Remove-Item -LiteralPath $cacheDirectory.FullName -Recurse -Force -ErrorAction SilentlyContinue
+    }
+}
+
+function Get-CachedPayloadSignatureSet {
+    [CmdletBinding()]
+    [OutputType([pscustomobject])]
+    param(
+        [Parameter(Mandatory = $true)]
+        $PayloadCacheEntry,
+
+        [Parameter(Mandatory = $true)]
+        [string]$ExpectedPayloadSha256,
+
+        [Parameter(Mandatory = $true)]
+        [int]$ExpectedPayloadRowCount
+    )
+
+    $cacheDirectory = Get-PayloadSignatureCacheDirectory -PayloadCacheEntry $PayloadCacheEntry
+    $metadataPath = Get-PartitionedSignatureSetMetadataPath -DirectoryPath $cacheDirectory
+    if ((-not (Test-Path -LiteralPath $cacheDirectory -PathType Container)) -or (-not (Test-Path -LiteralPath $metadataPath -PathType Leaf))) {
+        return $null
+    }
+
+    $metadata = Read-NormalizedPayloadManifest -Path $metadataPath
+    if ($null -eq $metadata) {
+        return $null
+    }
+
+    if ([string]$metadata.Version -ne 'payload-signature-cache-v1') {
+        return $null
+    }
+
+    if ([string]$metadata.ValidationLogicVersion -ne (Get-DashboardSemanticValidationLogicVersion)) {
+        return $null
+    }
+
+    if ([string]$metadata.Fingerprint -ne [string]$PayloadCacheEntry.Fingerprint) {
+        return $null
+    }
+
+    if ([string]$metadata.PayloadSha256 -ne $ExpectedPayloadSha256) {
+        return $null
+    }
+
+    if ([int]$metadata.PayloadRowCount -ne $ExpectedPayloadRowCount) {
+        return $null
+    }
+
+    $partitionCount = [int]$metadata.PartitionCount
+    $rowCount = [int]$metadata.RowCount
+    if (($partitionCount -lt 1) -or ($rowCount -lt 0)) {
+        return $null
+    }
+
+    return [PSCustomObject]@{
+        DirectoryPath = $cacheDirectory
+        Count = $rowCount
+        PartitionCount = $partitionCount
+        Persistent = $true
+    }
+}
+
+function Get-CachedSourceSignatureSet {
+    [CmdletBinding()]
+    [OutputType([pscustomobject])]
+    param(
+        [Parameter(Mandatory = $true)]
+        $PayloadCacheEntry,
+
+        [Parameter(Mandatory = $true)]
+        [string]$ExpectedSourceFingerprint
+    )
+
+    $cacheDirectory = Get-SourceSignatureCacheDirectory -PayloadCacheEntry $PayloadCacheEntry -SourceFingerprint $ExpectedSourceFingerprint
+    $metadataPath = Get-PartitionedSignatureSetMetadataPath -DirectoryPath $cacheDirectory
+    if ((-not (Test-Path -LiteralPath $cacheDirectory -PathType Container)) -or (-not (Test-Path -LiteralPath $metadataPath -PathType Leaf))) {
+        return $null
+    }
+
+    $metadata = Read-NormalizedPayloadManifest -Path $metadataPath
+    if ($null -eq $metadata) {
+        return $null
+    }
+
+    if ([string]$metadata.Version -ne 'source-signature-cache-v1') {
+        return $null
+    }
+
+    if ([string]$metadata.ValidationLogicVersion -ne (Get-DashboardSemanticValidationLogicVersion)) {
+        return $null
+    }
+
+    if ([string]$metadata.SourceFingerprint -ne $ExpectedSourceFingerprint) {
+        return $null
+    }
+
+    $partitionCount = [int]$metadata.PartitionCount
+    $rowCount = [int]$metadata.RowCount
+    if (($partitionCount -lt 1) -or ($rowCount -lt 0)) {
+        return $null
+    }
+
+    return [PSCustomObject]@{
+        DirectoryPath = $cacheDirectory
+        Count = $rowCount
+        PartitionCount = $partitionCount
+        Persistent = $true
+        SourceMissingMachineCount = [int]$metadata.SourceMissingMachineCount
+        SourceFirstLastSwappedCount = [int]$metadata.SourceFirstLastSwappedCount
+        SourceUniqueVendors = @($metadata.SourceUniqueVendors | ForEach-Object { [string]$_ })
+    }
+}
+
+function Write-CachedPayloadSignatureSetMetadata {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '', Justification = 'Internal helper only writes cache metadata for a signature set generated from the current payload cache entry.')]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '', Justification = 'Internal helper writes metadata that describes a cached payload signature set.')]
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory = $true)]
+        $PayloadCacheEntry,
+
+        [Parameter(Mandatory = $true)]
+        [string]$PayloadSha256,
+
+        [Parameter(Mandatory = $true)]
+        [int]$PayloadRowCount,
+
+        [Parameter(Mandatory = $true)]
+        $SignatureSet
+    )
+
+    $cacheDirectory = Get-PayloadSignatureCacheDirectory -PayloadCacheEntry $PayloadCacheEntry -Create
+    $metadataPath = Get-PartitionedSignatureSetMetadataPath -DirectoryPath $cacheDirectory
+    $metadata = [ordered]@{
+        Version = 'payload-signature-cache-v1'
+        ValidationLogicVersion = Get-DashboardSemanticValidationLogicVersion
+        Fingerprint = [string]$PayloadCacheEntry.Fingerprint
+        PayloadPath = [string]$PayloadCacheEntry.PayloadPath
+        PayloadSha256 = $PayloadSha256
+        PayloadRowCount = $PayloadRowCount
+        PartitionCount = [int]$SignatureSet.PartitionCount
+        RowCount = [int]$SignatureSet.Count
+        GeneratedOnUtc = (Get-Date).ToUniversalTime().ToString('o')
+    }
+
+    return (Write-NormalizedPayloadManifest -Path $metadataPath -Manifest $metadata)
+}
+
+function Write-CachedSourceSignatureSetMetadata {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '', Justification = 'Internal helper only writes cache metadata for a signature set generated from the current source exports.')]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '', Justification = 'Internal helper writes metadata that describes a cached source signature set.')]
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory = $true)]
+        $PayloadCacheEntry,
+
+        [Parameter(Mandatory = $true)]
+        [string]$SourceFingerprint,
+
+        [Parameter(Mandatory = $true)]
+        $SignatureSet,
+
+        [Parameter(Mandatory = $true)]
+        [int]$SourceMissingMachineCount,
+
+        [Parameter(Mandatory = $true)]
+        [int]$SourceFirstLastSwappedCount,
+
+        [Parameter(Mandatory = $true)]
+        [AllowEmptyCollection()]
+        [string[]]$SourceUniqueVendors
+    )
+
+    $cacheDirectory = Get-SourceSignatureCacheDirectory -PayloadCacheEntry $PayloadCacheEntry -SourceFingerprint $SourceFingerprint -Create
+    $metadataPath = Get-PartitionedSignatureSetMetadataPath -DirectoryPath $cacheDirectory
+    $metadata = [ordered]@{
+        Version = 'source-signature-cache-v1'
+        ValidationLogicVersion = Get-DashboardSemanticValidationLogicVersion
+        SourceFingerprint = $SourceFingerprint
+        PartitionCount = [int]$SignatureSet.PartitionCount
+        RowCount = [int]$SignatureSet.Count
+        SourceMissingMachineCount = $SourceMissingMachineCount
+        SourceFirstLastSwappedCount = $SourceFirstLastSwappedCount
+        SourceUniqueVendors = @($SourceUniqueVendors)
+        GeneratedOnUtc = (Get-Date).ToUniversalTime().ToString('o')
+    }
+
+    return (Write-NormalizedPayloadManifest -Path $metadataPath -Manifest $metadata)
+}
+
 function Remove-PartitionedSignatureSet {
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '')]
     [CmdletBinding()]
@@ -183,6 +477,10 @@ function Remove-PartitionedSignatureSet {
     )
 
     if ($null -eq $SignatureSet) {
+        return
+    }
+
+    if ($SignatureSet.PSObject.Properties['Persistent'] -and ($SignatureSet.Persistent -eq $true)) {
         return
     }
 
@@ -208,11 +506,27 @@ function Write-PartitionedSignatureSet {
 
         [Parameter(Mandatory = $false)]
         [ValidateRange(10000, 1000000)]
-        [int]$ProgressInterval = 250000
+        [int]$ProgressInterval = 250000,
+
+        [Parameter(Mandatory = $false)]
+        [AllowEmptyString()]
+        [string]$OutputDirectoryPath,
+
+        [Parameter(Mandatory = $false)]
+        [switch]$Persistent
     )
 
-    $directoryPath = Join-Path ([System.IO.Path]::GetTempPath()) ('dashboard-audit-signatures-' + [guid]::NewGuid().ToString('N'))
+    $directoryPath = if (-not [string]::IsNullOrWhiteSpace($OutputDirectoryPath)) {
+        [System.IO.Path]::GetFullPath($OutputDirectoryPath)
+    }
+    else {
+        Join-Path ([System.IO.Path]::GetTempPath()) ('dashboard-audit-signatures-' + [guid]::NewGuid().ToString('N'))
+    }
+
     [void](New-Item -Path $directoryPath -ItemType Directory -Force)
+    foreach ($existingFile in @(Get-ChildItem -Path $directoryPath -File -ErrorAction SilentlyContinue)) {
+        Remove-Item -LiteralPath $existingFile.FullName -Force -ErrorAction SilentlyContinue
+    }
 
     $writers = [System.IO.StreamWriter[]]::new($PartitionCount)
     $count = 0
@@ -248,6 +562,7 @@ function Write-PartitionedSignatureSet {
         DirectoryPath = $directoryPath
         Count = $count
         PartitionCount = $PartitionCount
+        Persistent = ($Persistent -eq $true)
     }
 }
 
@@ -1418,11 +1733,32 @@ function New-AttestedStreamingDashboardAuditResult {
         [int]$CachedPayloadRowCount
     )
 
+    $phaseTimings = [PSCustomObject]@{
+        MachineLoadElapsedSeconds = 0
+        AdvancedHuntingLoadElapsedSeconds = 0
+        SourceMaterializationElapsedSeconds = $null
+        PayloadLoadElapsedSeconds = $null
+        VendorIndexElapsedSeconds = 0
+        SourceSignatureElapsedSeconds = 0
+        PayloadSignatureElapsedSeconds = 0
+        RowComparisonElapsedSeconds = $null
+        EnrichmentAuditElapsedSeconds = $null
+        ReportComparisonsElapsedSeconds = $null
+        DuplicateIdentityElapsedSeconds = $null
+        OpenStateElapsedSeconds = $null
+        ComparisonElapsedSeconds = 0
+        BaselineAuditElapsedSeconds = $null
+        BaselineCoverageElapsedSeconds = $null
+        LegacyFixtureRegressionElapsedSeconds = $null
+        TotalElapsedSeconds = 0
+    }
+
     return [PSCustomObject]@{
         GeneratedOn = (Get-Date).ToString('o')
         HtmlPath = $ResolvedHtmlPath
         ExportsPath = $ResolvedExportsPath
         AuditMode = 'streaming-large-dataset-attested'
+        PhaseTimings = $phaseTimings
         Source = [PSCustomObject]@{
             RowCount = [int]$Attestation.SourceRowCount
             MissingMachineCount = [int]$Attestation.SourceMissingMachineCount
@@ -1495,19 +1831,13 @@ function New-AttestedStreamingDashboardAuditResult {
             IncludesMachineInfo = $true
             ComparisonStorage = 'attested-manifest'
             ComparisonPayloadSource = 'cached-payload'
+            SourceSignatureCacheUsed = $false
+            PayloadSignatureCacheUsed = $false
             PartitionCount = if ($Attestation.PSObject.Properties['PartitionCount']) { [int]$Attestation.PartitionCount } else { $null }
             SourceSignatureElapsedSeconds = 0
             PayloadSignatureElapsedSeconds = 0
             ComparisonElapsedSeconds = 0
-            PhaseTimings = [PSCustomObject]@{
-                MachineLoadElapsedSeconds = 0
-                AdvancedHuntingLoadElapsedSeconds = 0
-                VendorIndexElapsedSeconds = 0
-                SourceSignatureElapsedSeconds = 0
-                PayloadSignatureElapsedSeconds = 0
-                ComparisonElapsedSeconds = 0
-                TotalElapsedSeconds = 0
-            }
+            PhaseTimings = $phaseTimings
             PayloadByteParityMatch = $true
             AttestationUsed = $true
             ValidationLogicVersion = [string]$Attestation.ValidationLogicVersion
@@ -1571,6 +1901,8 @@ function Get-StreamingDashboardAuditResult {
     $sourceUniqueVendors = @()
     $sourceFirstLastSwappedCount = 0
     $sourceMissingMachineCount = 0
+    $sourceSignatureCacheUsed = $false
+    $payloadSignatureCacheUsed = $false
     $auditStopwatch = [System.Diagnostics.Stopwatch]::StartNew()
 
     try {
@@ -1580,28 +1912,11 @@ function Get-StreamingDashboardAuditResult {
             Write-Information ("  Requested partition compare runspace throttle: {0}" -f $Script:DashboardValidationPartitionCompareParallelism) -InformationAction Continue
         }
 
-        $machineLoadStopwatch = [System.Diagnostics.Stopwatch]::StartNew()
-        $machines = Read-MachineData -Path $ResolvedExportsPath
-        $machineLoadStopwatch.Stop()
-        $machineLoadElapsedSeconds = [math]::Round($machineLoadStopwatch.Elapsed.TotalSeconds, 2)
-
-        $advancedHuntingLoadStopwatch = [System.Diagnostics.Stopwatch]::StartNew()
-        $advancedHunting = Read-AdvancedHuntingData -Path $ResolvedExportsPath
-    $advancedHuntingInventory = Read-AdvancedHuntingInventoryData -Path $ResolvedExportsPath
-    $nvdCveData = Read-NvdCveData -Path $ResolvedExportsPath
-        $advancedHuntingLoadStopwatch.Stop()
-        $advancedHuntingLoadElapsedSeconds = [math]::Round($advancedHuntingLoadStopwatch.Elapsed.TotalSeconds, 2)
-
-        $vendorIndexStopwatch = [System.Diagnostics.Stopwatch]::StartNew()
-        $vendorSet = Get-SourceVendorSetForAudit -ExportsPath $ResolvedExportsPath -SkipObservedWindowMerge:$skipObservedWindowMerge
-        $vendorIndexStopwatch.Stop()
-        $vendorIndexElapsedSeconds = [math]::Round($vendorIndexStopwatch.Elapsed.TotalSeconds, 2)
-        $sourceUniqueVendors = @($vendorSet | Sort-Object)
-
         if ($payloadParityMatch) {
             $comparisonPayloadSource = 'cached-payload'
             $comparisonPayloadPath = $PayloadCacheEntry.PayloadPath
             $comparisonPayloadLabel = 'dashboard-cache'
+            Clear-StalePayloadSignatureCaches -PayloadCacheEntry $PayloadCacheEntry
             Write-Information '  Dashboard payload matches the normalized payload cache; reusing cached payload for semantic comparison.' -InformationAction Continue
         }
         else {
@@ -1610,27 +1925,97 @@ function Get-StreamingDashboardAuditResult {
             Write-Information '  Dashboard payload differs from the normalized payload cache; comparing dashboard payload directly against source exports.' -InformationAction Continue
         }
 
+        $currentSourceFingerprint = Get-DashboardPayloadCacheFingerprint -BasePath $ResolvedExportsPath -SkipObservedWindowMerge:$skipObservedWindowMerge
+        if (-not [string]::IsNullOrWhiteSpace($currentSourceFingerprint)) {
+            Clear-StaleSourceSignatureCaches -PayloadCacheEntry $PayloadCacheEntry -ExpectedSourceFingerprint $currentSourceFingerprint
+        }
+
         try {
             $sourceStopwatch = [System.Diagnostics.Stopwatch]::StartNew()
-            $sourceSignatureSet = Write-PartitionedSignatureSet -Label 'source' -ProgressInterval $Script:DashboardValidationProgressInterval -SignatureSource {
-                Read-SourceCanonicalSignatureStream `
-                    -ExportsPath $ResolvedExportsPath `
-                    -Machines $machines `
-                    -AdvancedHunting $advancedHunting `
-                    -AdvancedHuntingInventory $advancedHuntingInventory `
-                    -NvdCveData $nvdCveData `
-                    -VendorSet $vendorSet `
-                    -SkipObservedWindowMerge:$skipObservedWindowMerge `
-                    -FirstLastSwappedCount ([ref]$sourceFirstLastSwappedCount) `
-                    -MissingMachineCount ([ref]$sourceMissingMachineCount)
+            if (-not [string]::IsNullOrWhiteSpace($currentSourceFingerprint)) {
+                $sourceSignatureSet = Get-CachedSourceSignatureSet -PayloadCacheEntry $PayloadCacheEntry -ExpectedSourceFingerprint $currentSourceFingerprint
+            }
+
+            if ($null -ne $sourceSignatureSet) {
+                $sourceSignatureCacheUsed = $true
+                $sourceMissingMachineCount = [int]$sourceSignatureSet.SourceMissingMachineCount
+                $sourceFirstLastSwappedCount = [int]$sourceSignatureSet.SourceFirstLastSwappedCount
+                $sourceUniqueVendors = @($sourceSignatureSet.SourceUniqueVendors)
+                Write-Information '  Reusing cached source signature set for semantic comparison.' -InformationAction Continue
+            }
+            else {
+                $machineLoadStopwatch = [System.Diagnostics.Stopwatch]::StartNew()
+                $machines = Read-MachineData -Path $ResolvedExportsPath
+                $machineLoadStopwatch.Stop()
+                $machineLoadElapsedSeconds = [math]::Round($machineLoadStopwatch.Elapsed.TotalSeconds, 2)
+
+                $advancedHuntingLoadStopwatch = [System.Diagnostics.Stopwatch]::StartNew()
+                $advancedHunting = Read-AdvancedHuntingData -Path $ResolvedExportsPath
+                $advancedHuntingInventory = Read-AdvancedHuntingInventoryData -Path $ResolvedExportsPath
+                $nvdCveData = Read-NvdCveData -Path $ResolvedExportsPath
+                $advancedHuntingLoadStopwatch.Stop()
+                $advancedHuntingLoadElapsedSeconds = [math]::Round($advancedHuntingLoadStopwatch.Elapsed.TotalSeconds, 2)
+
+                $vendorIndexStopwatch = [System.Diagnostics.Stopwatch]::StartNew()
+                $vendorSet = Get-SourceVendorSetForAudit -ExportsPath $ResolvedExportsPath -SkipObservedWindowMerge:$skipObservedWindowMerge
+                $vendorIndexStopwatch.Stop()
+                $vendorIndexElapsedSeconds = [math]::Round($vendorIndexStopwatch.Elapsed.TotalSeconds, 2)
+                $sourceUniqueVendors = @($vendorSet | Sort-Object)
+
+                if (-not [string]::IsNullOrWhiteSpace($currentSourceFingerprint)) {
+                    $sourceSignatureSet = Write-PartitionedSignatureSet -Label 'source' -ProgressInterval $Script:DashboardValidationProgressInterval -OutputDirectoryPath (Get-SourceSignatureCacheDirectory -PayloadCacheEntry $PayloadCacheEntry -SourceFingerprint $currentSourceFingerprint -Create) -Persistent -SignatureSource {
+                        Read-SourceCanonicalSignatureStream `
+                            -ExportsPath $ResolvedExportsPath `
+                            -Machines $machines `
+                            -AdvancedHunting $advancedHunting `
+                            -AdvancedHuntingInventory $advancedHuntingInventory `
+                            -NvdCveData $nvdCveData `
+                            -VendorSet $vendorSet `
+                            -SkipObservedWindowMerge:$skipObservedWindowMerge `
+                            -FirstLastSwappedCount ([ref]$sourceFirstLastSwappedCount) `
+                            -MissingMachineCount ([ref]$sourceMissingMachineCount)
+                    }
+                    Write-CachedSourceSignatureSetMetadata -PayloadCacheEntry $PayloadCacheEntry -SourceFingerprint $currentSourceFingerprint -SignatureSet $sourceSignatureSet -SourceMissingMachineCount $sourceMissingMachineCount -SourceFirstLastSwappedCount $sourceFirstLastSwappedCount -SourceUniqueVendors $sourceUniqueVendors | Out-Null
+                    Write-Information '  Cached source signature set for future semantic comparisons.' -InformationAction Continue
+                }
+                else {
+                    $sourceSignatureSet = Write-PartitionedSignatureSet -Label 'source' -ProgressInterval $Script:DashboardValidationProgressInterval -SignatureSource {
+                        Read-SourceCanonicalSignatureStream `
+                            -ExportsPath $ResolvedExportsPath `
+                            -Machines $machines `
+                            -AdvancedHunting $advancedHunting `
+                            -AdvancedHuntingInventory $advancedHuntingInventory `
+                            -NvdCveData $nvdCveData `
+                            -VendorSet $vendorSet `
+                            -SkipObservedWindowMerge:$skipObservedWindowMerge `
+                            -FirstLastSwappedCount ([ref]$sourceFirstLastSwappedCount) `
+                            -MissingMachineCount ([ref]$sourceMissingMachineCount)
+                    }
+                }
             }
             $sourceStopwatch.Stop()
             $sourceElapsedSeconds = [math]::Round($sourceStopwatch.Elapsed.TotalSeconds, 2)
             Write-Information ("  Source signature pass completed in {0:N2}s" -f $sourceElapsedSeconds) -InformationAction Continue
 
             $payloadStopwatch = [System.Diagnostics.Stopwatch]::StartNew()
-            $payloadSignatureSet = Write-PartitionedSignatureSet -Label $comparisonPayloadLabel -ProgressInterval $Script:DashboardValidationProgressInterval -SignatureSource {
-                Read-PayloadCanonicalSignatureStream -PayloadPath $comparisonPayloadPath
+            if ($payloadParityMatch) {
+                $payloadSignatureSet = Get-CachedPayloadSignatureSet -PayloadCacheEntry $PayloadCacheEntry -ExpectedPayloadSha256 $cachedPayloadSha256 -ExpectedPayloadRowCount $cachedPayloadRowCount
+                if ($null -ne $payloadSignatureSet) {
+                    $payloadSignatureCacheUsed = $true
+                    Write-Information '  Reusing cached payload signature set for semantic comparison.' -InformationAction Continue
+                }
+                else {
+                    $payloadSignatureSet = Write-PartitionedSignatureSet -Label $comparisonPayloadLabel -ProgressInterval $Script:DashboardValidationProgressInterval -OutputDirectoryPath (Get-PayloadSignatureCacheDirectory -PayloadCacheEntry $PayloadCacheEntry -Create) -Persistent -SignatureSource {
+                        Read-PayloadCanonicalSignatureStream -PayloadPath $comparisonPayloadPath
+                    }
+                    Write-CachedPayloadSignatureSetMetadata -PayloadCacheEntry $PayloadCacheEntry -PayloadSha256 $cachedPayloadSha256 -PayloadRowCount $cachedPayloadRowCount -SignatureSet $payloadSignatureSet | Out-Null
+                    Write-Information '  Cached payload signature set for future semantic comparisons.' -InformationAction Continue
+                }
+            }
+            else {
+                $payloadSignatureSet = Write-PartitionedSignatureSet -Label $comparisonPayloadLabel -ProgressInterval $Script:DashboardValidationProgressInterval -SignatureSource {
+                    Read-PayloadCanonicalSignatureStream -PayloadPath $comparisonPayloadPath
+                }
             }
             $payloadStopwatch.Stop()
             $payloadElapsedSeconds = [math]::Round($payloadStopwatch.Elapsed.TotalSeconds, 2)
@@ -1664,6 +2049,25 @@ function Get-StreamingDashboardAuditResult {
     $auditStopwatch.Stop()
     $totalElapsedSeconds = [math]::Round($auditStopwatch.Elapsed.TotalSeconds, 2)
     $comparisonPartitionCount = if ($sourceSignatureSet) { [int]$sourceSignatureSet.PartitionCount } elseif ($payloadSignatureSet) { [int]$payloadSignatureSet.PartitionCount } else { $null }
+    $phaseTimings = [PSCustomObject]@{
+        MachineLoadElapsedSeconds = $machineLoadElapsedSeconds
+        AdvancedHuntingLoadElapsedSeconds = $advancedHuntingLoadElapsedSeconds
+        SourceMaterializationElapsedSeconds = $null
+        PayloadLoadElapsedSeconds = $null
+        VendorIndexElapsedSeconds = $vendorIndexElapsedSeconds
+        SourceSignatureElapsedSeconds = $sourceElapsedSeconds
+        PayloadSignatureElapsedSeconds = $payloadElapsedSeconds
+        RowComparisonElapsedSeconds = $null
+        EnrichmentAuditElapsedSeconds = $null
+        ReportComparisonsElapsedSeconds = $null
+        DuplicateIdentityElapsedSeconds = $null
+        OpenStateElapsedSeconds = $null
+        ComparisonElapsedSeconds = $comparisonElapsedSeconds
+        BaselineAuditElapsedSeconds = $null
+        BaselineCoverageElapsedSeconds = $null
+        LegacyFixtureRegressionElapsedSeconds = $null
+        TotalElapsedSeconds = $totalElapsedSeconds
+    }
 
     if ($payloadParityMatch -and $rowComparison.Match) {
         $semanticAttestation = [ordered]@{
@@ -1698,6 +2102,7 @@ function Get-StreamingDashboardAuditResult {
         HtmlPath = $ResolvedHtmlPath
         ExportsPath = $ResolvedExportsPath
         AuditMode = 'streaming-large-dataset'
+        PhaseTimings = $phaseTimings
         Source = [PSCustomObject]@{
             RowCount = [int]$rowComparison.ExpectedRows
             MissingMachineCount = $sourceMissingMachineCount
@@ -1760,19 +2165,13 @@ function Get-StreamingDashboardAuditResult {
             IncludesMachineInfo = $true
             ComparisonStorage = $comparisonStorage
             ComparisonPayloadSource = $comparisonPayloadSource
+            SourceSignatureCacheUsed = $sourceSignatureCacheUsed
+            PayloadSignatureCacheUsed = $payloadSignatureCacheUsed
             PartitionCount = $comparisonPartitionCount
             SourceSignatureElapsedSeconds = $sourceElapsedSeconds
             PayloadSignatureElapsedSeconds = $payloadElapsedSeconds
             ComparisonElapsedSeconds = $comparisonElapsedSeconds
-            PhaseTimings = [PSCustomObject]@{
-                MachineLoadElapsedSeconds = $machineLoadElapsedSeconds
-                AdvancedHuntingLoadElapsedSeconds = $advancedHuntingLoadElapsedSeconds
-                VendorIndexElapsedSeconds = $vendorIndexElapsedSeconds
-                SourceSignatureElapsedSeconds = $sourceElapsedSeconds
-                PayloadSignatureElapsedSeconds = $payloadElapsedSeconds
-                ComparisonElapsedSeconds = $comparisonElapsedSeconds
-                TotalElapsedSeconds = $totalElapsedSeconds
-            }
+            PhaseTimings = $phaseTimings
             PayloadByteParityMatch = $payloadParityMatch
         }
     }

--- a/tests/Generate-SyntheticLargeExports.ps1
+++ b/tests/Generate-SyntheticLargeExports.ps1
@@ -37,8 +37,8 @@ param(
     [int]$SafetyRowLimit = 2500000,
 
     [Parameter(Mandatory = $false)]
-    [ValidateRange(1, 256)]
-    [int]$MinimumAvailableMemoryGB = 8,
+    [ValidateRange(0.5, 256.0)]
+    [double]$MinimumAvailableMemoryGB = 8,
 
     [Parameter(Mandatory = $false)]
     [ValidateRange(1, 2048)]
@@ -158,7 +158,7 @@ function Assert-SyntheticGenerationPreflight {
         [int]$SafetyRowLimit,
 
         [Parameter(Mandatory = $true)]
-        [int]$MinimumAvailableMemoryGB,
+        [double]$MinimumAvailableMemoryGB,
 
         [Parameter(Mandatory = $true)]
         [int]$MinimumFreeDiskGB,
@@ -1234,7 +1234,7 @@ try {
                 Sync-GzipWriter -WriterState $writerState
             }
 
-            Write-Output ("Progress: {0}/{1} devices, {2} current rows, {3} history rows, elapsed {4}" -f $plan.DeviceOrdinal, $TargetDeviceCount, $writtenCurrentRows, $writtenHistoryRows, $generationStopwatch.Elapsed.ToString('hh\:mm\:ss'))
+            Write-Output ("[{0}] Progress: {1}/{2} devices, {3} current rows, {4} history rows, elapsed {5}" -f (Get-Date).ToString('yyyy-MM-dd HH:mm:ss'), $plan.DeviceOrdinal, $TargetDeviceCount, $writtenCurrentRows, $writtenHistoryRows, $generationStopwatch.Elapsed.ToString('hh\:mm\:ss'))
             Write-GenerationCheckpoint -OutputPath $OutputPath -Stage 'writing-vulnerability-rows' -CompletedDevices $plan.DeviceOrdinal -TotalDevices $TargetDeviceCount -WrittenCurrentRows $writtenCurrentRows -WrittenHistoryRows $writtenHistoryRows -Stopwatch $generationStopwatch -Extra @{
                 targetCurrentRows = $targetCurrentRows
                 targetHistoryRows = $targetHistoryRows

--- a/tests/Import-BenchmarkDatasetCatalog.ps1
+++ b/tests/Import-BenchmarkDatasetCatalog.ps1
@@ -1,0 +1,154 @@
+﻿Set-StrictMode -Version Latest
+
+function Get-BenchmarkDatasetCatalogPath {
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory = $false)]
+        [string]$RepoRoot = (Split-Path -Path $PSScriptRoot -Parent)
+    )
+
+    return (Join-Path $RepoRoot 'tests\benchmark-datasets.json')
+}
+
+function Import-BenchmarkDatasetCatalog {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '', Justification = 'Internal helper returns the full benchmark dataset catalog by design.')]
+    [CmdletBinding()]
+    [OutputType([object[]])]
+    param(
+        [Parameter(Mandatory = $false)]
+        [string]$RepoRoot = (Split-Path -Path $PSScriptRoot -Parent)
+    )
+
+    $catalogPath = Get-BenchmarkDatasetCatalogPath -RepoRoot $RepoRoot
+    if (-not (Test-Path -LiteralPath $catalogPath -PathType Leaf)) {
+        throw "Benchmark dataset catalog not found: $catalogPath"
+    }
+
+    return @((Get-Content -LiteralPath $catalogPath -Raw | ConvertFrom-Json -Depth 20))
+}
+
+function Get-BenchmarkDatasetDefinition {
+    [CmdletBinding()]
+    [OutputType([pscustomobject])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$DatasetId,
+
+        [Parameter(Mandatory = $false)]
+        [string]$RepoRoot = (Split-Path -Path $PSScriptRoot -Parent)
+    )
+
+    return @(
+        Import-BenchmarkDatasetCatalog -RepoRoot $RepoRoot | Where-Object { [string]$_.id -eq $DatasetId }
+    ) | Select-Object -First 1
+}
+
+function Resolve-BenchmarkDatasetSourcePath {
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory = $true)]
+        $Definition,
+
+        [Parameter(Mandatory = $false)]
+        [string]$RepoRoot = (Split-Path -Path $PSScriptRoot -Parent)
+    )
+
+    $sourceRelativePath = [string]$Definition.sourceRelativePath
+    if ([string]::IsNullOrWhiteSpace($sourceRelativePath)) {
+        return (Join-Path $RepoRoot 'exports')
+    }
+
+    return [System.IO.Path]::GetFullPath((Join-Path $RepoRoot $sourceRelativePath))
+}
+
+function Resolve-BenchmarkDatasetOutputPath {
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory = $true)]
+        $Definition,
+
+        [Parameter(Mandatory = $false)]
+        [string]$RepoRoot = (Split-Path -Path $PSScriptRoot -Parent)
+    )
+
+    $outputRelativePath = [string]$Definition.outputRelativePath
+    if ([string]::IsNullOrWhiteSpace($outputRelativePath)) {
+        throw 'Benchmark dataset definition does not declare outputRelativePath.'
+    }
+
+    return [System.IO.Path]::GetFullPath((Join-Path $RepoRoot $outputRelativePath))
+}
+
+function Get-BenchmarkDatasetMetadataPath {
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$DatasetPath
+    )
+
+    return (Join-Path ([System.IO.Path]::GetFullPath($DatasetPath)) 'benchmark-dataset.json')
+}
+
+function Get-BenchmarkDatasetMetadata {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '', Justification = 'Metadata is a fixed benchmark sidecar concept in this repository and matches benchmark-dataset.json.')]
+    [CmdletBinding()]
+    [OutputType([pscustomobject])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$DatasetPath
+    )
+
+    $metadataPath = Get-BenchmarkDatasetMetadataPath -DatasetPath $DatasetPath
+    if (-not (Test-Path -LiteralPath $metadataPath -PathType Leaf)) {
+        return $null
+    }
+
+    return (Get-Content -LiteralPath $metadataPath -Raw | ConvertFrom-Json -Depth 20)
+}
+
+function Test-BenchmarkDatasetDefinitionMatch {
+    [CmdletBinding()]
+    [OutputType([bool])]
+    param(
+        [Parameter(Mandatory = $true)]
+        $Definition,
+
+        [Parameter(Mandatory = $true)]
+        $Manifest
+    )
+
+    if ($null -eq $Manifest) {
+        return $false
+    }
+
+    return (
+        ([string]$Manifest.preset -eq [string]$Definition.preset) -and
+        ([int]$Manifest.seed -eq [int]$Definition.seed) -and
+        ([int]$Manifest.targetDeviceCount -eq [int]$Definition.targetDeviceCount) -and
+        ([int]$Manifest.targetTotalVulnRows -eq [int]$Definition.targetTotalVulnRows)
+    )
+}
+
+function Find-BenchmarkDatasetDefinitionForManifest {
+    [CmdletBinding()]
+    [OutputType([pscustomobject])]
+    param(
+        [Parameter(Mandatory = $true)]
+        $Manifest,
+
+        [Parameter(Mandatory = $false)]
+        [string]$RepoRoot = (Split-Path -Path $PSScriptRoot -Parent)
+    )
+
+    foreach ($definition in @(Import-BenchmarkDatasetCatalog -RepoRoot $RepoRoot)) {
+        if (Test-BenchmarkDatasetDefinitionMatch -Definition $definition -Manifest $Manifest) {
+            return $definition
+        }
+    }
+
+    return $null
+}

--- a/tests/Invoke-BenchmarkSeries.ps1
+++ b/tests/Invoke-BenchmarkSeries.ps1
@@ -1,0 +1,176 @@
+﻿#Requires -Version 7.0
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $false)]
+    [string]$BenchmarkDatasetId = 'benchmark-medium-v1',
+
+    [Parameter(Mandatory = $false)]
+    [ValidateRange(1, 20)]
+    [int]$Iterations = 3,
+
+    [Parameter(Mandatory = $false)]
+    [string]$CurrentBaselineName = 'current-working-tree',
+
+    [Parameter(Mandatory = $false)]
+    [string]$ResultsRoot = (Join-Path (Split-Path -Path $PSScriptRoot -Parent) '.local\benchmark-series'),
+
+    [Parameter(Mandatory = $false)]
+    [ValidateRange(0.5, 256.0)]
+    [double]$MinimumAvailableMemoryGB = 3,
+
+    [Parameter(Mandatory = $false)]
+    [switch]$LocalOnly,
+
+    [Parameter(Mandatory = $false)]
+    [switch]$IncludePersistentLocalWorkflow,
+
+    [Parameter(Mandatory = $false)]
+    [switch]$ForceDatasetRefresh
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+. (Join-Path $PSScriptRoot 'Import-BenchmarkDatasetCatalog.ps1')
+
+function Get-NumericSeriesSummary {
+    [CmdletBinding()]
+    [OutputType([pscustomobject])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [AllowEmptyCollection()]
+        [double[]]$Values
+    )
+
+    $filteredValues = @($Values | Where-Object { $null -ne $_ })
+    if ($filteredValues.Count -eq 0) {
+        return $null
+    }
+
+    $orderedValues = @($filteredValues | Sort-Object)
+    $middleIndex = [math]::Floor($orderedValues.Count / 2)
+    $median = if (($orderedValues.Count % 2) -eq 1) {
+        $orderedValues[$middleIndex]
+    }
+    else {
+        [math]::Round((($orderedValues[$middleIndex - 1] + $orderedValues[$middleIndex]) / 2.0), 2)
+    }
+
+    return [PSCustomObject]@{
+        count = $orderedValues.Count
+        min = [math]::Round(($orderedValues | Measure-Object -Minimum).Minimum, 2)
+        max = [math]::Round(($orderedValues | Measure-Object -Maximum).Maximum, 2)
+        average = [math]::Round(($orderedValues | Measure-Object -Average).Average, 2)
+        median = $median
+    }
+}
+
+function Get-MarkdownStatisticLine {
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Label,
+
+        [Parameter(Mandatory = $false)]
+        [AllowNull()]
+        $Summary
+    )
+
+    if ($null -eq $Summary) {
+        return ('- {0}: n/a' -f $Label)
+    }
+
+    return ('- {0}: min `{1:N2}s`, median `{2:N2}s`, avg `{3:N2}s`, max `{4:N2}s`' -f $Label, [double]$Summary.min, [double]$Summary.median, [double]$Summary.average, [double]$Summary.max)
+}
+
+$repoRoot = Split-Path -Path $PSScriptRoot -Parent
+$definition = Get-BenchmarkDatasetDefinition -DatasetId $BenchmarkDatasetId -RepoRoot $repoRoot
+if ($null -eq $definition) {
+    throw "Benchmark dataset definition '$BenchmarkDatasetId' was not found."
+}
+
+$datasetPath = Resolve-BenchmarkDatasetOutputPath -Definition $definition -RepoRoot $repoRoot
+$resolvedResultsRoot = [System.IO.Path]::GetFullPath((Join-Path $ResultsRoot ($BenchmarkDatasetId + '-' + (Get-Date -Format 'yyyyMMdd-HHmmss'))))
+if (-not (Test-Path -LiteralPath $resolvedResultsRoot -PathType Container)) {
+    $null = New-Item -Path $resolvedResultsRoot -ItemType Directory -Force
+}
+
+& (Join-Path $PSScriptRoot 'New-BenchmarkDataset.ps1') -DatasetId $BenchmarkDatasetId -MinimumAvailableMemoryGB $MinimumAvailableMemoryGB -Force:$ForceDatasetRefresh
+
+$historyTags = @($definition.historyTags | ForEach-Object { [string]$_ }) + @('series-capture')
+$measureScriptPath = Join-Path $PSScriptRoot 'Measure-BranchVsMainBenchmark.ps1'
+$historyScriptPath = Join-Path $PSScriptRoot 'Record-BenchmarkHistory.ps1'
+
+$runResults = [System.Collections.Generic.List[object]]::new()
+$resultPaths = [System.Collections.Generic.List[string]]::new()
+
+for ($iteration = 1; $iteration -le $Iterations; $iteration++) {
+    $resultPath = Join-Path $resolvedResultsRoot ('run-{0:00}.json' -f $iteration)
+    Write-Host ('Starting benchmark iteration {0}/{1}: {2}' -f $iteration, $Iterations, $resultPath) -ForegroundColor Cyan
+
+    $measureArguments = @{
+        CurrentOnly = $true
+        BenchmarkDatasetId = $BenchmarkDatasetId
+        ResultsOutputPath = $resultPath
+        CurrentBaselineName = $CurrentBaselineName
+        MinimumAvailableMemoryGB = $MinimumAvailableMemoryGB
+    }
+    if ($LocalOnly) {
+        $measureArguments.LocalOnly = $true
+    }
+    if ($IncludePersistentLocalWorkflow) {
+        $measureArguments.IncludePersistentLocalWorkflow = $true
+    }
+
+    & $measureScriptPath @measureArguments
+    & $historyScriptPath -BenchmarkResultPath $resultPath -Tags ($historyTags + @('series', ('iteration-{0:00}' -f $iteration)))
+
+    $runResults.Add((Get-Content -LiteralPath $resultPath -Raw | ConvertFrom-Json -Depth 50)) | Out-Null
+    $resultPaths.Add($resultPath) | Out-Null
+}
+
+$summary = [PSCustomObject]@{
+    generated_utc = [datetime]::UtcNow.ToString('o')
+    benchmark_dataset_id = [string]$definition.id
+    benchmark_dataset_path = $datasetPath
+    iteration_count = $Iterations
+    local_only = ($LocalOnly -eq $true)
+    persistent_local_workflow = ($IncludePersistentLocalWorkflow -eq $true)
+    result_paths = @($resultPaths)
+    local_elapsed_seconds = Get-NumericSeriesSummary -Values @($runResults | ForEach-Object { [double]$_.current.local.elapsed_seconds })
+    runbook_elapsed_seconds = if ($LocalOnly) { $null } else { Get-NumericSeriesSummary -Values @($runResults | ForEach-Object { [double]$_.current.runbook.elapsed_seconds }) }
+    function_active_elapsed_seconds = if ($LocalOnly) { $null } else { Get-NumericSeriesSummary -Values @($runResults | ForEach-Object { if ($null -ne $_.current.function_app.active_elapsed_seconds) { [double]$_.current.function_app.active_elapsed_seconds } }) }
+    function_end_to_end_elapsed_seconds = if ($LocalOnly) { $null } else { Get-NumericSeriesSummary -Values @($runResults | ForEach-Object { [double]$_.current.function_app.end_to_end_elapsed_seconds }) }
+    function_pickup_delay_seconds = if ($LocalOnly) { $null } else { Get-NumericSeriesSummary -Values @($runResults | ForEach-Object { if ($null -ne $_.current.function_app.pickup_delay_seconds) { [double]$_.current.function_app.pickup_delay_seconds } }) }
+    persistent_reuse_elapsed_seconds = if ($IncludePersistentLocalWorkflow) { Get-NumericSeriesSummary -Values @($runResults | ForEach-Object { [double]$_.current.local_persistent_cache.reuse_after_payload_eviction.elapsed_seconds }) } else { $null }
+}
+
+$summaryPath = Join-Path $resolvedResultsRoot 'series-summary.json'
+$summary | ConvertTo-Json -Depth 20 | Set-Content -LiteralPath $summaryPath -Encoding utf8
+
+$summaryLines = [System.Collections.Generic.List[string]]::new()
+$summaryLines.Add('# Benchmark Series Summary') | Out-Null
+$summaryLines.Add('') | Out-Null
+$summaryLines.Add(('- Dataset: `{0}`' -f [string]$definition.id)) | Out-Null
+$summaryLines.Add(('- Dataset path: `{0}`' -f $datasetPath)) | Out-Null
+$summaryLines.Add(('- Iterations: `{0}`' -f $Iterations)) | Out-Null
+$summaryLines.Add(('- Results root: `{0}`' -f $resolvedResultsRoot)) | Out-Null
+$summaryLines.Add('') | Out-Null
+$summaryLines.Add((Get-MarkdownStatisticLine -Label 'Local elapsed' -Summary $summary.local_elapsed_seconds)) | Out-Null
+if (-not $LocalOnly) {
+    $summaryLines.Add((Get-MarkdownStatisticLine -Label 'Runbook elapsed' -Summary $summary.runbook_elapsed_seconds)) | Out-Null
+    $summaryLines.Add((Get-MarkdownStatisticLine -Label 'Function active elapsed' -Summary $summary.function_active_elapsed_seconds)) | Out-Null
+    $summaryLines.Add((Get-MarkdownStatisticLine -Label 'Function end-to-end elapsed' -Summary $summary.function_end_to_end_elapsed_seconds)) | Out-Null
+    $summaryLines.Add((Get-MarkdownStatisticLine -Label 'Function pickup delay' -Summary $summary.function_pickup_delay_seconds)) | Out-Null
+}
+if ($IncludePersistentLocalWorkflow) {
+    $summaryLines.Add((Get-MarkdownStatisticLine -Label 'Persistent local reuse elapsed' -Summary $summary.persistent_reuse_elapsed_seconds)) | Out-Null
+}
+
+$summaryMarkdownPath = Join-Path $resolvedResultsRoot 'series-summary.md'
+[System.IO.File]::WriteAllLines($summaryMarkdownPath, $summaryLines, [System.Text.UTF8Encoding]::new($false))
+
+Write-Host ('Benchmark series summary: {0}' -f $summaryPath) -ForegroundColor Green
+Write-Host ('Benchmark series markdown: {0}' -f $summaryMarkdownPath) -ForegroundColor Green

--- a/tests/Invoke-HotPhaseReview.ps1
+++ b/tests/Invoke-HotPhaseReview.ps1
@@ -1,0 +1,633 @@
+﻿#Requires -Version 7.0
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $false)]
+    [string]$DirectoryPath = (Join-Path (Split-Path -Path $PSScriptRoot -Parent) 'exports'),
+
+    [Parameter(Mandatory = $false)]
+    [string]$OutputRoot = (Join-Path (Split-Path -Path $PSScriptRoot -Parent) ('.local\hot-phase-review\' + (Get-Date -Format 'yyyyMMdd-HHmmss'))),
+
+    [Parameter(Mandatory = $false)]
+    [switch]$SplitAssets,
+
+    [Parameter(Mandatory = $false)]
+    [switch]$ForceFullValidation,
+
+    [Parameter(Mandatory = $false)]
+    [ValidateRange(15, 3600)]
+    [int]$ValidationHeartbeatSeconds = 60,
+
+    [Parameter(Mandatory = $false)]
+    [ValidateRange(1, 64)]
+    [int]$ValidationPartitionCompareParallelism = 1,
+
+    [Parameter(Mandatory = $false)]
+    [ValidateRange(1, 60)]
+    [int]$PollIntervalSeconds = 5
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+if (-not $IsWindows) {
+    throw 'tests/Invoke-HotPhaseReview.ps1 currently supports Windows only because it relies on Win32 CIM classes for process and memory sampling.'
+}
+
+function Get-TextWithoutAnsiEscape {
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [AllowEmptyString()]
+        [string]$Text
+    )
+
+    return ([regex]::Replace($Text, "`e\[[0-9;]*m", ''))
+}
+
+function Get-AvailableMemoryGB {
+    [CmdletBinding()]
+    [OutputType([double])]
+    param()
+
+    $os = Get-CimInstance Win32_OperatingSystem
+    return [math]::Round(($os.FreePhysicalMemory / 1MB), 2)
+}
+
+function Get-HeartbeatTimestampText {
+    [CmdletBinding()]
+    [OutputType([string])]
+    param()
+
+    return (Get-Date).ToString('yyyy-MM-dd HH:mm:ss')
+}
+
+function Get-HeartbeatFileStatus {
+    [CmdletBinding()]
+    [OutputType([pscustomobject])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Path
+    )
+
+    if (-not (Test-Path -LiteralPath $Path -PathType Leaf)) {
+        return [PSCustomObject]@{
+            bytes = 0L
+            ageSeconds = $null
+        }
+    }
+
+    $item = Get-Item -LiteralPath $Path
+    return [PSCustomObject]@{
+        bytes = [int64]$item.Length
+        ageSeconds = [math]::Round(((Get-Date).ToUniversalTime() - $item.LastWriteTimeUtc).TotalSeconds, 1)
+    }
+}
+
+function Write-ReviewHeartbeat {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [System.Diagnostics.Stopwatch]$Stopwatch,
+
+        [Parameter(Mandatory = $true)]
+        [AllowEmptyCollection()]
+        [System.Collections.Generic.List[object]]$Samples,
+
+        [Parameter(Mandatory = $true)]
+        [string]$StdoutPath,
+
+        [Parameter(Mandatory = $true)]
+        [int64]$PeakRssBytes,
+
+        [Parameter(Mandatory = $true)]
+        [int64]$PeakPrivateBytes
+    )
+
+    $lastSample = if ($Samples.Count -gt 0) { $Samples[$Samples.Count - 1] } else { $null }
+    $stdoutStatus = Get-HeartbeatFileStatus -Path $StdoutPath
+    $availableMemory = if ($null -ne $lastSample) { [double]$lastSample.available_memory_gb } else { Get-AvailableMemoryGB }
+    $stdoutAgeText = if ($null -ne $stdoutStatus.ageSeconds) { ('{0:N1}s' -f $stdoutStatus.ageSeconds) } else { 'n/a' }
+
+    $message = "[{0}] Review heartbeat: elapsed={1} peak-rss={2}GB peak-private={3}GB samples={4} available={5}GB stdout-bytes={6} stdout-age={7}" -f @(
+        (Get-HeartbeatTimestampText)
+        $Stopwatch.Elapsed.ToString('hh\:mm\:ss')
+        [math]::Round(($PeakRssBytes / 1GB), 3)
+        [math]::Round(($PeakPrivateBytes / 1GB), 3)
+        $Samples.Count
+        $availableMemory
+        $stdoutStatus.bytes
+        $stdoutAgeText
+    )
+    Write-Output $message
+}
+
+function Get-ProcessTree {
+    [CmdletBinding()]
+    [OutputType([System.Diagnostics.Process[]])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [int]$RootProcessId
+    )
+
+    $processById = @{}
+    foreach ($process in @(Get-Process -ErrorAction SilentlyContinue)) {
+        $processById[$process.Id] = $process
+    }
+
+    $childrenByParent = @{}
+    foreach ($process in @(Get-CimInstance Win32_Process -ErrorAction SilentlyContinue)) {
+        $parentId = [int]$process.ParentProcessId
+        if (-not $childrenByParent.ContainsKey($parentId)) {
+            $childrenByParent[$parentId] = [System.Collections.Generic.List[int]]::new()
+        }
+
+        $childrenByParent[$parentId].Add([int]$process.ProcessId)
+    }
+
+    $queue = [System.Collections.Generic.Queue[int]]::new()
+    $seen = [System.Collections.Generic.HashSet[int]]::new()
+    $queue.Enqueue($RootProcessId)
+
+    while ($queue.Count -gt 0) {
+        $currentId = $queue.Dequeue()
+        if (-not $seen.Add($currentId)) {
+            continue
+        }
+
+        if ($childrenByParent.ContainsKey($currentId)) {
+            foreach ($childId in $childrenByParent[$currentId]) {
+                $queue.Enqueue($childId)
+            }
+        }
+    }
+
+    $processes = [System.Collections.Generic.List[System.Diagnostics.Process]]::new()
+    foreach ($processId in $seen) {
+        if ($processById.ContainsKey($processId)) {
+            $processes.Add($processById[$processId]) | Out-Null
+        }
+    }
+
+    return @($processes | Sort-Object -Property Id)
+}
+
+function Write-LogTail {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Path,
+
+        [Parameter(Mandatory = $true)]
+        [string]$Label,
+
+        [Parameter(Mandatory = $false)]
+        [int]$TailLineCount = 120
+    )
+
+    if (-not (Test-Path -LiteralPath $Path -PathType Leaf)) {
+        return
+    }
+
+    $tailLines = @(Get-Content -Path $Path -Tail $TailLineCount)
+    if ($tailLines.Count -eq 0) {
+        return
+    }
+
+    Write-Output ''
+    Write-Output ("--- {0} (last {1} line(s)) ---" -f $Label, $tailLines.Count)
+    foreach ($line in $tailLines) {
+        Write-Output $line
+    }
+}
+
+function Get-ValidationAuditSummary {
+    [CmdletBinding()]
+    [OutputType([pscustomobject])]
+    param(
+        [Parameter(Mandatory = $false)]
+        [AllowNull()]
+        $Audit
+    )
+
+    if ($null -eq $Audit) {
+        return $null
+    }
+
+    $semanticParity = if ($Audit.PSObject.Properties['SemanticParity']) {
+        $Audit.SemanticParity
+    }
+    else {
+        $null
+    }
+
+    return [PSCustomObject]@{
+        auditMode = if ($Audit.PSObject.Properties['AuditMode']) { [string]$Audit.AuditMode } else { $null }
+        rowMatch = if ($Audit.PSObject.Properties['RowComparison']) { [bool]$Audit.RowComparison.Match } else { $null }
+        payloadByteParityMatch = if ($null -ne $semanticParity -and $semanticParity.PSObject.Properties['PayloadByteParityMatch']) { [bool]$semanticParity.PayloadByteParityMatch } else { $null }
+        comparisonStorage = if ($null -ne $semanticParity -and $semanticParity.PSObject.Properties['ComparisonStorage']) { [string]$semanticParity.ComparisonStorage } else { $null }
+        comparisonPayloadSource = if ($null -ne $semanticParity -and $semanticParity.PSObject.Properties['ComparisonPayloadSource']) { [string]$semanticParity.ComparisonPayloadSource } else { $null }
+        attestationUsed = if ($null -ne $semanticParity -and $semanticParity.PSObject.Properties['AttestationUsed']) { [bool]$semanticParity.AttestationUsed } else { $false }
+        phaseTimings = if ($Audit.PSObject.Properties['PhaseTimings']) { $Audit.PhaseTimings } elseif ($null -ne $semanticParity -and $semanticParity.PSObject.Properties['PhaseTimings']) { $semanticParity.PhaseTimings } else { $null }
+    }
+}
+
+function Get-LocalPhaseSummaryFromLog {
+    [CmdletBinding()]
+    [OutputType([object[]])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Path
+    )
+
+    if (-not (Test-Path -LiteralPath $Path -PathType Leaf)) {
+        return @()
+    }
+
+    $phaseByName = [ordered]@{}
+    foreach ($rawLine in Get-Content -Path $Path) {
+        $line = Get-TextWithoutAnsiEscape -Text ([string]$rawLine)
+        if ($line -match '^\s*--- Local Phase: (?<name>.+?) ---\s*$') {
+            $phaseName = [string]$matches.name
+            if (-not $phaseByName.Contains($phaseName)) {
+                $phaseByName[$phaseName] = [ordered]@{
+                    name = $phaseName
+                    status = 'started'
+                    elapsedSeconds = $null
+                    startWorkingSetMB = $null
+                    endWorkingSetMB = $null
+                    startGcHeapMB = $null
+                    endGcHeapMB = $null
+                }
+            }
+
+            continue
+        }
+
+        if ($line -match '^\s*\[(?<name>.+?)/(?<checkpoint>start|end)\] Memory .*?Working set: (?<working>[0-9.]+)MB\s*\|\s*GC heap: (?<heap>[0-9.]+)MB\s*$') {
+            $phaseName = [string]$matches.name
+            if (-not $phaseByName.Contains($phaseName)) {
+                $phaseByName[$phaseName] = [ordered]@{ name = $phaseName }
+            }
+
+            $phaseEntry = $phaseByName[$phaseName]
+            $checkpoint = [string]$matches.checkpoint
+            $workingSetMB = [double]$matches.working
+            $gcHeapMB = [double]$matches.heap
+            if ($checkpoint -eq 'start') {
+                $phaseEntry.startWorkingSetMB = $workingSetMB
+                $phaseEntry.startGcHeapMB = $gcHeapMB
+            }
+            else {
+                $phaseEntry.endWorkingSetMB = $workingSetMB
+                $phaseEntry.endGcHeapMB = $gcHeapMB
+            }
+
+            continue
+        }
+
+        if ($line -match '^\s*\[(?<name>.+?)\] Elapsed: (?<seconds>[0-9.,]+)s(?:\s*\((?<status>[^)]+)\))?\s*$') {
+            $phaseName = [string]$matches.name
+            if (-not $phaseByName.Contains($phaseName)) {
+                $phaseByName[$phaseName] = [ordered]@{ name = $phaseName }
+            }
+
+            $phaseEntry = $phaseByName[$phaseName]
+            $phaseEntry.elapsedSeconds = [double](($matches.seconds -replace ',', ''))
+            $phaseEntry.status = if ($matches.status) { [string]$matches.status } else { 'completed' }
+        }
+    }
+
+    return @(
+        foreach ($phaseEntry in $phaseByName.Values) {
+            [PSCustomObject]@{
+                name = [string]$phaseEntry.name
+                status = if ($phaseEntry.Contains('status')) { [string]$phaseEntry.status } else { 'unknown' }
+                elapsedSeconds = if ($phaseEntry.Contains('elapsedSeconds')) { $phaseEntry.elapsedSeconds } else { $null }
+                startWorkingSetMB = if ($phaseEntry.Contains('startWorkingSetMB')) { $phaseEntry.startWorkingSetMB } else { $null }
+                endWorkingSetMB = if ($phaseEntry.Contains('endWorkingSetMB')) { $phaseEntry.endWorkingSetMB } else { $null }
+                startGcHeapMB = if ($phaseEntry.Contains('startGcHeapMB')) { $phaseEntry.startGcHeapMB } else { $null }
+                endGcHeapMB = if ($phaseEntry.Contains('endGcHeapMB')) { $phaseEntry.endGcHeapMB } else { $null }
+            }
+        }
+    )
+}
+
+function Get-ValidationPhaseSummaryFromAudit {
+    [CmdletBinding()]
+    [OutputType([object[]])]
+    param(
+        [Parameter(Mandatory = $false)]
+        [AllowNull()]
+        $Audit
+    )
+
+    if ($null -eq $Audit) {
+        return @()
+    }
+
+    $phaseTimings = if ($Audit.PSObject.Properties['PhaseTimings']) {
+        $Audit.PhaseTimings
+    }
+    elseif ($Audit.PSObject.Properties['SemanticParity'] -and $Audit.SemanticParity.PSObject.Properties['PhaseTimings']) {
+        $Audit.SemanticParity.PhaseTimings
+    }
+    else {
+        $null
+    }
+
+    if ($null -eq $phaseTimings) {
+        return @()
+    }
+
+    $phaseMap = [ordered]@{
+        MachineLoadElapsedSeconds = 'Machine load'
+        AdvancedHuntingLoadElapsedSeconds = 'Advanced Hunting load'
+        SourceMaterializationElapsedSeconds = 'Source materialization'
+        PayloadLoadElapsedSeconds = 'Payload load'
+        VendorIndexElapsedSeconds = 'Vendor index'
+        SourceSignatureElapsedSeconds = 'Source signatures'
+        PayloadSignatureElapsedSeconds = 'Payload signatures'
+        RowComparisonElapsedSeconds = 'Row comparison'
+        EnrichmentAuditElapsedSeconds = 'Enrichment audit'
+        ReportComparisonsElapsedSeconds = 'Report comparisons'
+        DuplicateIdentityElapsedSeconds = 'Duplicate identity audit'
+        OpenStateElapsedSeconds = 'Open state audit'
+        ComparisonElapsedSeconds = 'Comparison'
+        BaselineAuditElapsedSeconds = 'Baseline audit'
+        BaselineCoverageElapsedSeconds = 'Baseline coverage'
+        LegacyFixtureRegressionElapsedSeconds = 'Legacy fixture regression'
+    }
+
+    return @(
+        foreach ($propertyName in $phaseMap.Keys) {
+            if (-not $phaseTimings.PSObject.Properties[$propertyName]) {
+                continue
+            }
+
+            $value = $phaseTimings.$propertyName
+            if ($null -eq $value -or [double]$value -le 0) {
+                continue
+            }
+
+            [PSCustomObject]@{
+                name = [string]$phaseMap[$propertyName]
+                property = [string]$propertyName
+                elapsedSeconds = [double]$value
+            }
+        }
+    )
+}
+
+function Get-HotPhaseSummary {
+    [CmdletBinding()]
+    [OutputType([object[]])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [AllowEmptyCollection()]
+        [object[]]$GeneratorPhases,
+
+        [Parameter(Mandatory = $true)]
+        [AllowEmptyCollection()]
+        [object[]]$ValidationPhases
+    )
+
+    $combined = [System.Collections.Generic.List[object]]::new()
+    foreach ($phase in @($GeneratorPhases | Where-Object { $null -ne $_.elapsedSeconds })) {
+        $combined.Add([PSCustomObject]@{
+            scope = 'generator'
+            name = [string]$phase.name
+            elapsedSeconds = [double]$phase.elapsedSeconds
+        }) | Out-Null
+    }
+
+    foreach ($phase in @($ValidationPhases | Where-Object { $null -ne $_.elapsedSeconds })) {
+        $combined.Add([PSCustomObject]@{
+            scope = 'validation'
+            name = [string]$phase.name
+            elapsedSeconds = [double]$phase.elapsedSeconds
+        }) | Out-Null
+    }
+
+    return @($combined | Sort-Object -Property elapsedSeconds -Descending)
+}
+
+function Add-MeasurementSample {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [AllowEmptyCollection()]
+        [System.Collections.Generic.List[object]]$Samples,
+
+        [Parameter(Mandatory = $true)]
+        [System.Diagnostics.Process]$Process,
+
+        [Parameter(Mandatory = $true)]
+        [System.Diagnostics.Stopwatch]$Stopwatch,
+
+        [Parameter(Mandatory = $true)]
+        [ref]$PeakRssBytes,
+
+        [Parameter(Mandatory = $true)]
+        [ref]$PeakRssAt,
+
+        [Parameter(Mandatory = $true)]
+        [ref]$PeakPrivateBytes,
+
+        [Parameter(Mandatory = $true)]
+        [ref]$PeakPrivateAt
+    )
+
+    $tree = @(Get-ProcessTree -RootProcessId $Process.Id)
+    if ($tree.Count -eq 0) {
+        try {
+            $null = $Process.WorkingSet64
+            $tree = @($Process)
+        }
+        catch {
+            return
+        }
+    }
+
+    $rssBytes = [int64](($tree | Measure-Object -Property WorkingSet64 -Sum).Sum)
+    $privateBytes = [int64](($tree | Measure-Object -Property PrivateMemorySize64 -Sum).Sum)
+    $elapsedSeconds = [math]::Round($Stopwatch.Elapsed.TotalSeconds, 2)
+    if ($rssBytes -gt $PeakRssBytes.Value) {
+        $PeakRssBytes.Value = $rssBytes
+        $PeakRssAt.Value = $elapsedSeconds
+    }
+    if ($privateBytes -gt $PeakPrivateBytes.Value) {
+        $PeakPrivateBytes.Value = $privateBytes
+        $PeakPrivateAt.Value = $elapsedSeconds
+    }
+
+    $Samples.Add([PSCustomObject]@{
+        elapsed_seconds = $elapsedSeconds
+        process_count = $tree.Count
+        tree_rss_bytes = $rssBytes
+        tree_private_bytes = $privateBytes
+        available_memory_gb = Get-AvailableMemoryGB
+    }) | Out-Null
+}
+
+$repoRoot = Split-Path -Path $PSScriptRoot -Parent
+$dashboardScript = Join-Path $repoRoot 'Generate-VulnerabilityDashboard.ps1'
+$resolvedDirectoryPath = [System.IO.Path]::GetFullPath($DirectoryPath)
+$resolvedOutputRoot = [System.IO.Path]::GetFullPath($OutputRoot)
+
+if (-not (Test-Path -LiteralPath $resolvedDirectoryPath -PathType Container)) {
+    throw "Directory '$resolvedDirectoryPath' was not found."
+}
+
+if (-not (Test-Path -LiteralPath $resolvedOutputRoot -PathType Container)) {
+    $null = New-Item -Path $resolvedOutputRoot -ItemType Directory -Force
+}
+
+$dashboardPath = Join-Path $resolvedOutputRoot 'VulnerabilityDashboard.html'
+$auditPath = Join-Path $resolvedOutputRoot 'dashboard-audit.json'
+$stdoutPath = Join-Path $resolvedOutputRoot 'hot-phase-review.stdout.log'
+$stderrPath = Join-Path $resolvedOutputRoot 'hot-phase-review.stderr.log'
+$reportPath = Join-Path $resolvedOutputRoot 'hot-phase-review.json'
+
+foreach ($path in @($dashboardPath, $auditPath, $stdoutPath, $stderrPath, $reportPath)) {
+    if (Test-Path -LiteralPath $path) {
+        Remove-Item -LiteralPath $path -Recurse -Force -ErrorAction SilentlyContinue
+    }
+}
+
+$argumentList = @(
+    '-NoProfile'
+    '-File', $dashboardScript
+    '-DirectoryPath', $resolvedDirectoryPath
+    '-OutputPath', $dashboardPath
+    '-ExportMachineData:$false'
+    '-Validate'
+    '-ValidationOutputPath', $auditPath
+    '-ValidationHeartbeatSeconds', $ValidationHeartbeatSeconds
+    '-ValidationPartitionCompareParallelism', $ValidationPartitionCompareParallelism
+)
+if ($SplitAssets) {
+    $argumentList += '-SplitAssets'
+}
+if ($ForceFullValidation) {
+    $argumentList += '-ForceFullValidation'
+}
+
+Write-Output 'Running hot phase review...'
+Write-Output ("  Dataset: {0}" -f $resolvedDirectoryPath)
+Write-Output ("  Output root: {0}" -f $resolvedOutputRoot)
+
+$process = Start-Process -FilePath 'pwsh' -ArgumentList $argumentList -WorkingDirectory $repoRoot -RedirectStandardOutput $stdoutPath -RedirectStandardError $stderrPath -PassThru
+$stopwatch = [System.Diagnostics.Stopwatch]::StartNew()
+$samples = [System.Collections.Generic.List[object]]::new()
+$peakRssBytes = [int64]0
+$peakRssAt = [double]0
+$peakPrivateBytes = [int64]0
+$peakPrivateAt = [double]0
+
+Add-MeasurementSample -Samples $samples -Process $process -Stopwatch $stopwatch -PeakRssBytes ([ref]$peakRssBytes) -PeakRssAt ([ref]$peakRssAt) -PeakPrivateBytes ([ref]$peakPrivateBytes) -PeakPrivateAt ([ref]$peakPrivateAt)
+Write-ReviewHeartbeat -Stopwatch $stopwatch -Samples $samples -StdoutPath $stdoutPath -PeakRssBytes $peakRssBytes -PeakPrivateBytes $peakPrivateBytes
+
+while (-not $process.HasExited) {
+    Start-Sleep -Seconds $PollIntervalSeconds
+    $process.Refresh()
+    Add-MeasurementSample -Samples $samples -Process $process -Stopwatch $stopwatch -PeakRssBytes ([ref]$peakRssBytes) -PeakRssAt ([ref]$peakRssAt) -PeakPrivateBytes ([ref]$peakPrivateBytes) -PeakPrivateAt ([ref]$peakPrivateAt)
+    if (-not $process.HasExited) {
+        Write-ReviewHeartbeat -Stopwatch $stopwatch -Samples $samples -StdoutPath $stdoutPath -PeakRssBytes $peakRssBytes -PeakPrivateBytes $peakPrivateBytes
+    }
+}
+
+$process.WaitForExit()
+$process.Refresh()
+Add-MeasurementSample -Samples $samples -Process $process -Stopwatch $stopwatch -PeakRssBytes ([ref]$peakRssBytes) -PeakRssAt ([ref]$peakRssAt) -PeakPrivateBytes ([ref]$peakPrivateBytes) -PeakPrivateAt ([ref]$peakPrivateAt)
+$stopwatch.Stop()
+
+$generatorPhases = Get-LocalPhaseSummaryFromLog -Path $stdoutPath
+$audit = if (Test-Path -LiteralPath $auditPath -PathType Leaf) {
+    Get-Content -Path $auditPath -Raw | ConvertFrom-Json -Depth 100
+}
+else {
+    $null
+}
+$auditSummary = Get-ValidationAuditSummary -Audit $audit
+$validationPhases = Get-ValidationPhaseSummaryFromAudit -Audit $audit
+$hotPhases = Get-HotPhaseSummary -GeneratorPhases @($generatorPhases) -ValidationPhases @($validationPhases)
+
+$observations = [System.Collections.Generic.List[string]]::new()
+$topGeneratorPhase = @($generatorPhases | Where-Object { $null -ne $_.elapsedSeconds } | Sort-Object -Property elapsedSeconds -Descending | Select-Object -First 1)
+if ($topGeneratorPhase.Count -gt 0) {
+    $observations.Add(("Generator hot phase: {0} ({1:N2}s)." -f $topGeneratorPhase[0].name, $topGeneratorPhase[0].elapsedSeconds)) | Out-Null
+}
+
+$topValidationPhase = @($validationPhases | Sort-Object -Property elapsedSeconds -Descending | Select-Object -First 1)
+if ($topValidationPhase.Count -gt 0) {
+    $observations.Add(("Validation hot phase: {0} ({1:N2}s)." -f $topValidationPhase[0].name, $topValidationPhase[0].elapsedSeconds)) | Out-Null
+}
+elseif ($null -ne $audit) {
+    $observations.Add('Validation audit completed without semantic phase timings for this dataset shape.') | Out-Null
+}
+
+if ($null -ne $auditSummary -and $auditSummary.attestationUsed) {
+    $observations.Add('Validation reused a semantic attestation, so the captured validation timings represent the attested fast path.') | Out-Null
+}
+elseif ($null -ne $auditSummary -and [string]$auditSummary.comparisonStorage -eq 'partitioned-hash-files') {
+    $observations.Add('Validation used the partitioned signature comparison path, so signature and comparison phases are the primary optimization targets in the audit.') | Out-Null
+}
+
+$report = [PSCustomObject]@{
+    generatedOnUtc = [datetime]::UtcNow.ToString('o')
+    datasetPath = $resolvedDirectoryPath
+    outputRoot = $resolvedOutputRoot
+    command = @('pwsh') + $argumentList
+    status = if ($process.ExitCode -eq 0) { 'success' } else { 'failure' }
+    processMetrics = [PSCustomObject]@{
+        elapsedSeconds = [math]::Round($stopwatch.Elapsed.TotalSeconds, 2)
+        peakTreeRssBytes = $peakRssBytes
+        peakTreeRssGb = [math]::Round(($peakRssBytes / 1GB), 3)
+        peakTreeRssAtSeconds = $peakRssAt
+        peakTreePrivateBytes = $peakPrivateBytes
+        peakTreePrivateGb = [math]::Round(($peakPrivateBytes / 1GB), 3)
+        peakTreePrivateAtSeconds = $peakPrivateAt
+        sampleCount = $samples.Count
+        dashboardExists = (Test-Path -LiteralPath $dashboardPath -PathType Leaf)
+        dashboardBytes = if (Test-Path -LiteralPath $dashboardPath -PathType Leaf) { (Get-Item -LiteralPath $dashboardPath).Length } else { 0 }
+    }
+    artifacts = [PSCustomObject]@{
+        dashboardPath = $dashboardPath
+        auditPath = if (Test-Path -LiteralPath $auditPath -PathType Leaf) { $auditPath } else { $null }
+        stdoutPath = $stdoutPath
+        stderrPath = $stderrPath
+        reportPath = $reportPath
+    }
+    review = [PSCustomObject]@{
+        validationHeartbeatSeconds = $ValidationHeartbeatSeconds
+        validationPartitionCompareParallelism = $ValidationPartitionCompareParallelism
+        splitAssets = ($SplitAssets -eq $true)
+        forceFullValidation = ($ForceFullValidation -eq $true)
+    }
+    generatorPhases = @($generatorPhases)
+    validationAuditSummary = $auditSummary
+    validationPhases = @($validationPhases)
+    hotPhases = @($hotPhases)
+    observations = @($observations)
+    samples = @($samples)
+}
+
+$report | ConvertTo-Json -Depth 20 | Set-Content -Path $reportPath -Encoding utf8
+
+Write-Output ''
+Write-Output 'Hot phase review completed.'
+Write-Output ("  Elapsed seconds: {0}" -f $report.processMetrics.elapsedSeconds)
+Write-Output ("  Peak RSS GB: {0}" -f $report.processMetrics.peakTreeRssGb)
+Write-Output ("  Peak Private GB: {0}" -f $report.processMetrics.peakTreePrivateGb)
+foreach ($hotPhase in @($hotPhases | Select-Object -First 5)) {
+    Write-Output ("  Hot phase [{0}] {1}: {2:N2}s" -f $hotPhase.scope, $hotPhase.name, $hotPhase.elapsedSeconds)
+}
+Write-Output ("  Report: {0}" -f $reportPath)
+
+if ($process.ExitCode -ne 0) {
+    Write-LogTail -Path $stdoutPath -Label 'Child stdout'
+    Write-LogTail -Path $stderrPath -Label 'Child stderr'
+    throw "Hot phase review child process exited with code $($process.ExitCode)."
+}

--- a/tests/Invoke-LargeDatasetValidation.ps1
+++ b/tests/Invoke-LargeDatasetValidation.ps1
@@ -60,6 +60,9 @@ param(
     [string]$DashboardOutputPath,
 
     [Parameter(Mandatory = $false)]
+    [string]$ValidationOutputPath,
+
+    [Parameter(Mandatory = $false)]
     [ValidateRange(15, 3600)]
     [int]$ValidationHeartbeatSeconds = 60,
 
@@ -72,6 +75,10 @@ Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
 . (Join-Path (Split-Path -Path $PSScriptRoot -Parent) 'build\Import-SharedHelpers.ps1')
+
+if (-not $Validate -and -not [string]::IsNullOrWhiteSpace($ValidationOutputPath)) {
+    throw 'ValidationOutputPath requires -Validate.'
+}
 
 function Get-StreamingCount {
     [CmdletBinding()]
@@ -89,6 +96,37 @@ function Get-StreamingCount {
     }
 
     return $count
+}
+
+function Get-ValidationAuditSummary {
+    [CmdletBinding()]
+    [OutputType([pscustomobject])]
+    param(
+        [Parameter(Mandatory = $false)]
+        [AllowNull()]
+        $Audit
+    )
+
+    if ($null -eq $Audit) {
+        return $null
+    }
+
+    $semanticParity = if ($Audit.PSObject.Properties['SemanticParity']) {
+        $Audit.SemanticParity
+    }
+    else {
+        $null
+    }
+
+    return [PSCustomObject]@{
+        auditMode = if ($Audit.PSObject.Properties['AuditMode']) { [string]$Audit.AuditMode } else { $null }
+        rowMatch = if ($Audit.PSObject.Properties['RowComparison']) { [bool]$Audit.RowComparison.Match } else { $null }
+        payloadByteParityMatch = if ($null -ne $semanticParity -and $semanticParity.PSObject.Properties['PayloadByteParityMatch']) { [bool]$semanticParity.PayloadByteParityMatch } else { $null }
+        attestationUsed = if ($null -ne $semanticParity -and $semanticParity.PSObject.Properties['AttestationUsed']) { [bool]$semanticParity.AttestationUsed } else { $false }
+        comparisonStorage = if ($null -ne $semanticParity -and $semanticParity.PSObject.Properties['ComparisonStorage']) { [string]$semanticParity.ComparisonStorage } else { $null }
+        comparisonPayloadSource = if ($null -ne $semanticParity -and $semanticParity.PSObject.Properties['ComparisonPayloadSource']) { [string]$semanticParity.ComparisonPayloadSource } else { $null }
+        phaseTimings = if ($Audit.PSObject.Properties['PhaseTimings']) { $Audit.PhaseTimings } elseif ($null -ne $semanticParity -and $semanticParity.PSObject.Properties['PhaseTimings']) { $semanticParity.PhaseTimings } else { $null }
+    }
 }
 
 function Write-StressValidationReport {
@@ -109,6 +147,10 @@ function Write-StressValidationReport {
         [Parameter(Mandatory = $true)]
         [string]$DashboardOutputPath,
 
+        [Parameter(Mandatory = $false)]
+        [AllowEmptyString()]
+        [string]$ResolvedValidationAuditPath,
+
         [Parameter(Mandatory = $true)]
         [double]$ElapsedSeconds,
 
@@ -126,6 +168,9 @@ function Write-StressValidationReport {
         $Manifest,
 
         [Parameter(Mandatory = $true)]
+        [bool]$SkipObservedWindowMerge,
+
+        [Parameter(Mandatory = $true)]
         [ValidateSet('success', 'failure')]
         [string]$Status,
 
@@ -135,7 +180,11 @@ function Write-StressValidationReport {
 
         [Parameter(Mandatory = $false)]
         [AllowNull()]
-        $FailureRecord
+        $FailureRecord,
+
+        [Parameter(Mandatory = $false)]
+        [AllowNull()]
+        $Audit
     )
 
     $resolvedDashboardOutputPath = [System.IO.Path]::GetFullPath($DashboardOutputPath)
@@ -162,7 +211,9 @@ function Write-StressValidationReport {
             validate = $Validate.IsPresent
             heartbeatSeconds = $ValidationHeartbeatSeconds
             partitionCompareParallelism = $ValidationPartitionCompareParallelism
-            skipObservedWindowMerge = $skipObservedWindowMerge
+            skipObservedWindowMerge = $SkipObservedWindowMerge
+            auditPath = if ([string]::IsNullOrWhiteSpace($ResolvedValidationAuditPath)) { $null } else { [System.IO.Path]::GetFullPath($ResolvedValidationAuditPath) }
+            auditSummary = Get-ValidationAuditSummary -Audit $Audit
         }
         error = if ($null -ne $FailureRecord) {
             [PSCustomObject]@{
@@ -232,6 +283,16 @@ else {
     Join-Path ([System.IO.Path]::GetTempPath()) ('stress-dashboard-' + [guid]::NewGuid().ToString('N') + '.html')
 }
 
+$resolvedValidationOutputPath = if (-not [string]::IsNullOrWhiteSpace($ValidationOutputPath)) {
+    [System.IO.Path]::GetFullPath($ValidationOutputPath)
+}
+elseif ($Validate) {
+    Join-Path $resolvedSyntheticPath 'dashboard-audit.json'
+}
+else {
+    $null
+}
+
 if ($null -ne $manifest) {
     $machineCount = [int]$manifest.actualDeviceCount
     $currentRowCount = [int]$manifest.actualCurrentRows
@@ -262,6 +323,9 @@ if ($skipObservedWindowMerge) {
 }
 if ($Validate) {
     $generateArgs.Validate = $true
+    if (-not [string]::IsNullOrWhiteSpace($resolvedValidationOutputPath)) {
+        $generateArgs.ValidationOutputPath = $resolvedValidationOutputPath
+    }
 }
 
 $reportPath = Join-Path $resolvedSyntheticPath 'stress-validation-report.json'
@@ -272,6 +336,9 @@ if (Test-Path -LiteralPath $reportPath -PathType Leaf) {
 if (Test-Path -LiteralPath $dashboardOutput -PathType Leaf) {
     Remove-Item -LiteralPath $dashboardOutput -Force
 }
+if (-not [string]::IsNullOrWhiteSpace($resolvedValidationOutputPath) -and (Test-Path -LiteralPath $resolvedValidationOutputPath -PathType Leaf)) {
+    Remove-Item -LiteralPath $resolvedValidationOutputPath -Force
+}
 
 Write-Output ''
 Write-Output 'Running dashboard generation against the synthetic exports...'
@@ -280,6 +347,7 @@ $stopwatch = [System.Diagnostics.Stopwatch]::StartNew()
 $status = 'success'
 $dashboardExitCode = $null
 $failureRecord = $null
+$audit = $null
 try {
     $global:LASTEXITCODE = 0
     & $dashboardScript @generateArgs
@@ -291,6 +359,14 @@ try {
 
     if (-not (Test-Path -LiteralPath $dashboardOutput -PathType Leaf)) {
         throw "Dashboard output '$dashboardOutput' was not created."
+    }
+
+    if (-not [string]::IsNullOrWhiteSpace($resolvedValidationOutputPath)) {
+        if (-not (Test-Path -LiteralPath $resolvedValidationOutputPath -PathType Leaf)) {
+            throw "Validation audit '$resolvedValidationOutputPath' was not created."
+        }
+
+        $audit = Get-Content -Path $resolvedValidationOutputPath -Raw | ConvertFrom-Json -Depth 100
     }
 }
 catch {
@@ -306,14 +382,17 @@ finally {
         -Preset $Preset `
         -SyntheticPath $resolvedSyntheticPath `
         -DashboardOutputPath $dashboardOutput `
+        -ResolvedValidationAuditPath $resolvedValidationOutputPath `
         -ElapsedSeconds $stopwatch.Elapsed.TotalSeconds `
         -MachineCount $machineCount `
         -CurrentRowCount $currentRowCount `
         -HistoryRowCount $historyRowCount `
         -Manifest $manifest `
+        -SkipObservedWindowMerge $skipObservedWindowMerge `
         -Status $status `
         -DashboardExitCode $dashboardExitCode `
-        -FailureRecord $failureRecord
+        -FailureRecord $failureRecord `
+        -Audit $audit
 }
 
 $dashboardItem = Get-Item -LiteralPath $dashboardOutput
@@ -322,6 +401,9 @@ Write-Output ''
 Write-Output 'Stress validation completed.'
 Write-Output ("  Synthetic path: {0}" -f $resolvedSyntheticPath)
 Write-Output ("  Dashboard output: {0}" -f ([System.IO.Path]::GetFullPath($dashboardOutput)))
+if (-not [string]::IsNullOrWhiteSpace($resolvedValidationOutputPath)) {
+    Write-Output ("  Validation audit: {0}" -f $resolvedValidationOutputPath)
+}
 Write-Output ("  Elapsed: {0} seconds" -f ([math]::Round($stopwatch.Elapsed.TotalSeconds, 2)))
 Write-Output ("  Devices: {0}" -f $machineCount)
 Write-Output ("  Vulnerability rows: {0} current + {1} history = {2} total" -f $currentRowCount, $historyRowCount, ($currentRowCount + $historyRowCount))

--- a/tests/Invoke-ValidationModeComparison.ps1
+++ b/tests/Invoke-ValidationModeComparison.ps1
@@ -1,0 +1,781 @@
+﻿#Requires -Version 7.0
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $false)]
+    [string]$DirectoryPath = (Join-Path (Split-Path -Path $PSScriptRoot -Parent) 'exports'),
+
+    [Parameter(Mandatory = $false)]
+    [string]$OutputRoot = (Join-Path (Split-Path -Path $PSScriptRoot -Parent) ('.local\validation-mode-comparison\' + (Get-Date -Format 'yyyyMMdd-HHmmss'))),
+
+    [Parameter(Mandatory = $false)]
+    [ValidateRange(15, 3600)]
+    [int]$ValidationHeartbeatSeconds = 60,
+
+    [Parameter(Mandatory = $false)]
+    [ValidateRange(1, 64)]
+    [int]$ValidationPartitionCompareParallelism = 1,
+
+    [Parameter(Mandatory = $false)]
+    [ValidateRange(1, 60)]
+    [int]$PollIntervalSeconds = 5
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+if (-not $IsWindows) {
+    throw 'tests/Invoke-ValidationModeComparison.ps1 currently supports Windows only because it relies on Win32 CIM classes for process and memory sampling.'
+}
+
+function Get-TextWithoutAnsiEscape {
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [AllowEmptyString()]
+        [string]$Text
+    )
+
+    return ([regex]::Replace($Text, "`e\[[0-9;]*m", ''))
+}
+
+function Get-AvailableMemoryGB {
+    [CmdletBinding()]
+    [OutputType([double])]
+    param()
+
+    $os = Get-CimInstance Win32_OperatingSystem
+    return [math]::Round(($os.FreePhysicalMemory / 1MB), 2)
+}
+
+function Get-HeartbeatTimestampText {
+    [CmdletBinding()]
+    [OutputType([string])]
+    param()
+
+    return (Get-Date).ToString('yyyy-MM-dd HH:mm:ss')
+}
+
+function Get-HeartbeatFileStatus {
+    [CmdletBinding()]
+    [OutputType([pscustomobject])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Path
+    )
+
+    if (-not (Test-Path -LiteralPath $Path -PathType Leaf)) {
+        return [PSCustomObject]@{
+            bytes = 0L
+            ageSeconds = $null
+        }
+    }
+
+    $item = Get-Item -LiteralPath $Path
+    return [PSCustomObject]@{
+        bytes = [int64]$item.Length
+        ageSeconds = [math]::Round(((Get-Date).ToUniversalTime() - $item.LastWriteTimeUtc).TotalSeconds, 1)
+    }
+}
+
+function Write-ModeComparisonHeartbeat {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Name,
+
+        [Parameter(Mandatory = $true)]
+        [System.Diagnostics.Stopwatch]$Stopwatch,
+
+        [Parameter(Mandatory = $true)]
+        [AllowEmptyCollection()]
+        [System.Collections.Generic.List[object]]$Samples,
+
+        [Parameter(Mandatory = $true)]
+        [string]$StdoutPath,
+
+        [Parameter(Mandatory = $true)]
+        [int64]$PeakRssBytes,
+
+        [Parameter(Mandatory = $true)]
+        [int64]$PeakPrivateBytes
+    )
+
+    $lastSample = if ($Samples.Count -gt 0) { $Samples[$Samples.Count - 1] } else { $null }
+    $stdoutStatus = Get-HeartbeatFileStatus -Path $StdoutPath
+    $availableMemory = if ($null -ne $lastSample) { [double]$lastSample.available_memory_gb } else { Get-AvailableMemoryGB }
+    $stdoutAgeText = if ($null -ne $stdoutStatus.ageSeconds) { ('{0:N1}s' -f $stdoutStatus.ageSeconds) } else { 'n/a' }
+
+    $message = "[{0}] Validation comparison heartbeat ({1}): elapsed={2} peak-rss={3}GB peak-private={4}GB samples={5} available={6}GB stdout-bytes={7} stdout-age={8}" -f @(
+        (Get-HeartbeatTimestampText)
+        $Name
+        $Stopwatch.Elapsed.ToString('hh\:mm\:ss')
+        [math]::Round(($PeakRssBytes / 1GB), 3)
+        [math]::Round(($PeakPrivateBytes / 1GB), 3)
+        $Samples.Count
+        $availableMemory
+        $stdoutStatus.bytes
+        $stdoutAgeText
+    )
+    Write-Host $message
+}
+
+function Get-ProcessTree {
+    [CmdletBinding()]
+    [OutputType([System.Diagnostics.Process[]])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [int]$RootProcessId
+    )
+
+    $processById = @{}
+    foreach ($process in @(Get-Process -ErrorAction SilentlyContinue)) {
+        $processById[$process.Id] = $process
+    }
+
+    $childrenByParent = @{}
+    foreach ($process in @(Get-CimInstance Win32_Process -ErrorAction SilentlyContinue)) {
+        $parentId = [int]$process.ParentProcessId
+        if (-not $childrenByParent.ContainsKey($parentId)) {
+            $childrenByParent[$parentId] = [System.Collections.Generic.List[int]]::new()
+        }
+
+        $childrenByParent[$parentId].Add([int]$process.ProcessId)
+    }
+
+    $queue = [System.Collections.Generic.Queue[int]]::new()
+    $seen = [System.Collections.Generic.HashSet[int]]::new()
+    $queue.Enqueue($RootProcessId)
+
+    while ($queue.Count -gt 0) {
+        $currentId = $queue.Dequeue()
+        if (-not $seen.Add($currentId)) {
+            continue
+        }
+
+        if ($childrenByParent.ContainsKey($currentId)) {
+            foreach ($childId in $childrenByParent[$currentId]) {
+                $queue.Enqueue($childId)
+            }
+        }
+    }
+
+    $processes = [System.Collections.Generic.List[System.Diagnostics.Process]]::new()
+    foreach ($processId in $seen) {
+        if ($processById.ContainsKey($processId)) {
+            $processes.Add($processById[$processId]) | Out-Null
+        }
+    }
+
+    return @($processes | Sort-Object -Property Id)
+}
+
+function Add-MeasurementSample {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [AllowEmptyCollection()]
+        [System.Collections.Generic.List[object]]$Samples,
+
+        [Parameter(Mandatory = $true)]
+        [System.Diagnostics.Process]$Process,
+
+        [Parameter(Mandatory = $true)]
+        [System.Diagnostics.Stopwatch]$Stopwatch,
+
+        [Parameter(Mandatory = $true)]
+        [ref]$PeakRssBytes,
+
+        [Parameter(Mandatory = $true)]
+        [ref]$PeakRssAt,
+
+        [Parameter(Mandatory = $true)]
+        [ref]$PeakPrivateBytes,
+
+        [Parameter(Mandatory = $true)]
+        [ref]$PeakPrivateAt
+    )
+
+    $tree = @(Get-ProcessTree -RootProcessId $Process.Id)
+    if ($tree.Count -eq 0) {
+        try {
+            $null = $Process.WorkingSet64
+            $tree = @($Process)
+        }
+        catch {
+            return
+        }
+    }
+
+    $rssBytes = [int64](($tree | Measure-Object -Property WorkingSet64 -Sum).Sum)
+    $privateBytes = [int64](($tree | Measure-Object -Property PrivateMemorySize64 -Sum).Sum)
+    $elapsedSeconds = [math]::Round($Stopwatch.Elapsed.TotalSeconds, 2)
+    if ($rssBytes -gt $PeakRssBytes.Value) {
+        $PeakRssBytes.Value = $rssBytes
+        $PeakRssAt.Value = $elapsedSeconds
+    }
+    if ($privateBytes -gt $PeakPrivateBytes.Value) {
+        $PeakPrivateBytes.Value = $privateBytes
+        $PeakPrivateAt.Value = $elapsedSeconds
+    }
+
+    $Samples.Add([PSCustomObject]@{
+        elapsed_seconds = $elapsedSeconds
+        process_count = $tree.Count
+        tree_rss_bytes = $rssBytes
+        tree_private_bytes = $privateBytes
+        available_memory_gb = Get-AvailableMemoryGB
+    }) | Out-Null
+}
+
+function Write-LogTail {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Path,
+
+        [Parameter(Mandatory = $true)]
+        [string]$Label,
+
+        [Parameter(Mandatory = $false)]
+        [int]$TailLineCount = 120
+    )
+
+    if (-not (Test-Path -LiteralPath $Path -PathType Leaf)) {
+        return
+    }
+
+    $tailLines = @(Get-Content -Path $Path -Tail $TailLineCount)
+    if ($tailLines.Count -eq 0) {
+        return
+    }
+
+    Write-Host ''
+    Write-Host ("--- {0} (last {1} line(s)) ---" -f $Label, $tailLines.Count)
+    foreach ($line in $tailLines) {
+        Write-Host $line
+    }
+}
+
+function Get-ValidationAuditSummary {
+    [CmdletBinding()]
+    [OutputType([pscustomobject])]
+    param(
+        [Parameter(Mandatory = $false)]
+        [AllowNull()]
+        $Audit
+    )
+
+    if ($null -eq $Audit) {
+        return $null
+    }
+
+    $semanticParity = if ($Audit.PSObject.Properties['SemanticParity']) {
+        $Audit.SemanticParity
+    }
+    else {
+        $null
+    }
+
+    return [PSCustomObject]@{
+        auditMode = if ($Audit.PSObject.Properties['AuditMode']) { [string]$Audit.AuditMode } else { $null }
+        rowMatch = if ($Audit.PSObject.Properties['RowComparison']) { [bool]$Audit.RowComparison.Match } else { $null }
+        payloadByteParityMatch = if ($null -ne $semanticParity -and $semanticParity.PSObject.Properties['PayloadByteParityMatch']) { [bool]$semanticParity.PayloadByteParityMatch } else { $null }
+        comparisonStorage = if ($null -ne $semanticParity -and $semanticParity.PSObject.Properties['ComparisonStorage']) { [string]$semanticParity.ComparisonStorage } else { $null }
+        comparisonPayloadSource = if ($null -ne $semanticParity -and $semanticParity.PSObject.Properties['ComparisonPayloadSource']) { [string]$semanticParity.ComparisonPayloadSource } else { $null }
+        attestationUsed = if ($null -ne $semanticParity -and $semanticParity.PSObject.Properties['AttestationUsed']) { [bool]$semanticParity.AttestationUsed } else { $false }
+        phaseTimings = if ($Audit.PSObject.Properties['PhaseTimings']) { $Audit.PhaseTimings } elseif ($null -ne $semanticParity -and $semanticParity.PSObject.Properties['PhaseTimings']) { $semanticParity.PhaseTimings } else { $null }
+    }
+}
+
+function Get-LocalPhaseSummaryFromLog {
+    [CmdletBinding()]
+    [OutputType([object[]])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Path
+    )
+
+    if (-not (Test-Path -LiteralPath $Path -PathType Leaf)) {
+        return @()
+    }
+
+    $phaseByName = [ordered]@{}
+    foreach ($rawLine in Get-Content -Path $Path) {
+        $line = Get-TextWithoutAnsiEscape -Text ([string]$rawLine)
+        if ($line -match '^\s*--- Local Phase: (?<name>.+?) ---\s*$') {
+            $phaseName = [string]$matches.name
+            if (-not $phaseByName.Contains($phaseName)) {
+                $phaseByName[$phaseName] = [ordered]@{
+                    name = $phaseName
+                    status = 'started'
+                    elapsedSeconds = $null
+                    startWorkingSetMB = $null
+                    endWorkingSetMB = $null
+                    startGcHeapMB = $null
+                    endGcHeapMB = $null
+                }
+            }
+
+            continue
+        }
+
+        if ($line -match '^\s*\[(?<name>.+?)/(?<checkpoint>start|end)\] Memory .*?Working set: (?<working>[0-9.]+)MB\s*\|\s*GC heap: (?<heap>[0-9.]+)MB\s*$') {
+            $phaseName = [string]$matches.name
+            if (-not $phaseByName.Contains($phaseName)) {
+                $phaseByName[$phaseName] = [ordered]@{ name = $phaseName }
+            }
+
+            $phaseEntry = $phaseByName[$phaseName]
+            $checkpoint = [string]$matches.checkpoint
+            $workingSetMB = [double]$matches.working
+            $gcHeapMB = [double]$matches.heap
+            if ($checkpoint -eq 'start') {
+                $phaseEntry.startWorkingSetMB = $workingSetMB
+                $phaseEntry.startGcHeapMB = $gcHeapMB
+            }
+            else {
+                $phaseEntry.endWorkingSetMB = $workingSetMB
+                $phaseEntry.endGcHeapMB = $gcHeapMB
+            }
+
+            continue
+        }
+
+        if ($line -match '^\s*\[(?<name>.+?)\] Elapsed: (?<seconds>[0-9.,]+)s(?:\s*\((?<status>[^)]+)\))?\s*$') {
+            $phaseName = [string]$matches.name
+            if (-not $phaseByName.Contains($phaseName)) {
+                $phaseByName[$phaseName] = [ordered]@{ name = $phaseName }
+            }
+
+            $phaseEntry = $phaseByName[$phaseName]
+            $phaseEntry.elapsedSeconds = [double](($matches.seconds -replace ',', ''))
+            $phaseEntry.status = if ($matches.status) { [string]$matches.status } else { 'completed' }
+        }
+    }
+
+    return @(
+        foreach ($phaseEntry in $phaseByName.Values) {
+            [PSCustomObject]@{
+                name = [string]$phaseEntry.name
+                status = if ($phaseEntry.Contains('status')) { [string]$phaseEntry.status } else { 'unknown' }
+                elapsedSeconds = if ($phaseEntry.Contains('elapsedSeconds')) { $phaseEntry.elapsedSeconds } else { $null }
+                startWorkingSetMB = if ($phaseEntry.Contains('startWorkingSetMB')) { $phaseEntry.startWorkingSetMB } else { $null }
+                endWorkingSetMB = if ($phaseEntry.Contains('endWorkingSetMB')) { $phaseEntry.endWorkingSetMB } else { $null }
+                startGcHeapMB = if ($phaseEntry.Contains('startGcHeapMB')) { $phaseEntry.startGcHeapMB } else { $null }
+                endGcHeapMB = if ($phaseEntry.Contains('endGcHeapMB')) { $phaseEntry.endGcHeapMB } else { $null }
+            }
+        }
+    )
+}
+
+function Get-ValidationPhaseSummaryFromAudit {
+    [CmdletBinding()]
+    [OutputType([object[]])]
+    param(
+        [Parameter(Mandatory = $false)]
+        [AllowNull()]
+        $Audit
+    )
+
+    if ($null -eq $Audit) {
+        return @()
+    }
+
+    $phaseTimings = if ($Audit.PSObject.Properties['PhaseTimings']) {
+        $Audit.PhaseTimings
+    }
+    elseif ($Audit.PSObject.Properties['SemanticParity'] -and $Audit.SemanticParity.PSObject.Properties['PhaseTimings']) {
+        $Audit.SemanticParity.PhaseTimings
+    }
+    else {
+        $null
+    }
+
+    if ($null -eq $phaseTimings) {
+        return @()
+    }
+
+    $phaseMap = [ordered]@{
+        MachineLoadElapsedSeconds = 'Machine load'
+        AdvancedHuntingLoadElapsedSeconds = 'Advanced Hunting load'
+        SourceMaterializationElapsedSeconds = 'Source materialization'
+        PayloadLoadElapsedSeconds = 'Payload load'
+        VendorIndexElapsedSeconds = 'Vendor index'
+        SourceSignatureElapsedSeconds = 'Source signatures'
+        PayloadSignatureElapsedSeconds = 'Payload signatures'
+        RowComparisonElapsedSeconds = 'Row comparison'
+        EnrichmentAuditElapsedSeconds = 'Enrichment audit'
+        ReportComparisonsElapsedSeconds = 'Report comparisons'
+        DuplicateIdentityElapsedSeconds = 'Duplicate identity audit'
+        OpenStateElapsedSeconds = 'Open state audit'
+        ComparisonElapsedSeconds = 'Comparison'
+        BaselineAuditElapsedSeconds = 'Baseline audit'
+        BaselineCoverageElapsedSeconds = 'Baseline coverage'
+        LegacyFixtureRegressionElapsedSeconds = 'Legacy fixture regression'
+    }
+
+    return @(
+        foreach ($propertyName in $phaseMap.Keys) {
+            if (-not $phaseTimings.PSObject.Properties[$propertyName]) {
+                continue
+            }
+
+            $value = $phaseTimings.$propertyName
+            if ($null -eq $value -or [double]$value -le 0) {
+                continue
+            }
+
+            [PSCustomObject]@{
+                name = [string]$phaseMap[$propertyName]
+                property = [string]$propertyName
+                elapsedSeconds = [double]$value
+            }
+        }
+    )
+}
+
+function Get-HotPhaseSummary {
+    [CmdletBinding()]
+    [OutputType([object[]])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [AllowEmptyCollection()]
+        [object[]]$GeneratorPhases,
+
+        [Parameter(Mandatory = $true)]
+        [AllowEmptyCollection()]
+        [object[]]$ValidationPhases
+    )
+
+    $combined = [System.Collections.Generic.List[object]]::new()
+    foreach ($phase in @($GeneratorPhases | Where-Object { $null -ne $_.elapsedSeconds })) {
+        $combined.Add([PSCustomObject]@{
+            scope = 'generator'
+            name = [string]$phase.name
+            elapsedSeconds = [double]$phase.elapsedSeconds
+        }) | Out-Null
+    }
+
+    foreach ($phase in @($ValidationPhases | Where-Object { $null -ne $_.elapsedSeconds })) {
+        $combined.Add([PSCustomObject]@{
+            scope = 'validation'
+            name = [string]$phase.name
+            elapsedSeconds = [double]$phase.elapsedSeconds
+        }) | Out-Null
+    }
+
+    return @($combined | Sort-Object -Property elapsedSeconds -Descending)
+}
+
+function Invoke-ValidationModeRun {
+    [CmdletBinding()]
+    [OutputType([pscustomobject])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Name,
+
+        [Parameter(Mandatory = $true)]
+        [string]$RepoRoot,
+
+        [Parameter(Mandatory = $true)]
+        [string[]]$ArgumentList,
+
+        [Parameter(Mandatory = $true)]
+        [string]$ModeOutputRoot,
+
+        [Parameter(Mandatory = $false)]
+        [AllowEmptyString()]
+        [string]$DashboardPath,
+
+        [Parameter(Mandatory = $false)]
+        [AllowEmptyString()]
+        [string]$AuditPath,
+
+        [Parameter(Mandatory = $false)]
+        [switch]$ResetDashboardPath,
+
+        [Parameter(Mandatory = $false)]
+        [switch]$ResetAuditPath,
+
+        [Parameter(Mandatory = $true)]
+        [int]$PollIntervalSeconds
+    )
+
+    if (-not (Test-Path -LiteralPath $ModeOutputRoot -PathType Container)) {
+        $null = New-Item -Path $ModeOutputRoot -ItemType Directory -Force
+    }
+
+    $stdoutPath = Join-Path $ModeOutputRoot ($Name + '.stdout.log')
+    $stderrPath = Join-Path $ModeOutputRoot ($Name + '.stderr.log')
+
+    $pathsToRemove = [System.Collections.Generic.List[string]]::new()
+    $pathsToRemove.Add($stdoutPath) | Out-Null
+    $pathsToRemove.Add($stderrPath) | Out-Null
+    if ($ResetDashboardPath -and -not [string]::IsNullOrWhiteSpace($DashboardPath)) {
+        $pathsToRemove.Add($DashboardPath) | Out-Null
+    }
+    if ($ResetAuditPath -and -not [string]::IsNullOrWhiteSpace($AuditPath)) {
+        $pathsToRemove.Add($AuditPath) | Out-Null
+    }
+
+    foreach ($path in $pathsToRemove) {
+        if ([string]::IsNullOrWhiteSpace($path)) {
+            continue
+        }
+
+        if (Test-Path -LiteralPath $path) {
+            Remove-Item -LiteralPath $path -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+
+    Write-Host ''
+    Write-Host ("Running validation mode: {0}" -f $Name)
+    $process = Start-Process -FilePath 'pwsh' -ArgumentList $ArgumentList -WorkingDirectory $RepoRoot -RedirectStandardOutput $stdoutPath -RedirectStandardError $stderrPath -PassThru
+    $stopwatch = [System.Diagnostics.Stopwatch]::StartNew()
+    $samples = [System.Collections.Generic.List[object]]::new()
+    $peakRssBytes = [int64]0
+    $peakRssAt = [double]0
+    $peakPrivateBytes = [int64]0
+    $peakPrivateAt = [double]0
+
+    Add-MeasurementSample -Samples $samples -Process $process -Stopwatch $stopwatch -PeakRssBytes ([ref]$peakRssBytes) -PeakRssAt ([ref]$peakRssAt) -PeakPrivateBytes ([ref]$peakPrivateBytes) -PeakPrivateAt ([ref]$peakPrivateAt)
+    Write-ModeComparisonHeartbeat -Name $Name -Stopwatch $stopwatch -Samples $samples -StdoutPath $stdoutPath -PeakRssBytes $peakRssBytes -PeakPrivateBytes $peakPrivateBytes
+
+    while (-not $process.HasExited) {
+        Start-Sleep -Seconds $PollIntervalSeconds
+        $process.Refresh()
+        Add-MeasurementSample -Samples $samples -Process $process -Stopwatch $stopwatch -PeakRssBytes ([ref]$peakRssBytes) -PeakRssAt ([ref]$peakRssAt) -PeakPrivateBytes ([ref]$peakPrivateBytes) -PeakPrivateAt ([ref]$peakPrivateAt)
+        if (-not $process.HasExited) {
+            Write-ModeComparisonHeartbeat -Name $Name -Stopwatch $stopwatch -Samples $samples -StdoutPath $stdoutPath -PeakRssBytes $peakRssBytes -PeakPrivateBytes $peakPrivateBytes
+        }
+    }
+
+    $process.WaitForExit()
+    $process.Refresh()
+    Add-MeasurementSample -Samples $samples -Process $process -Stopwatch $stopwatch -PeakRssBytes ([ref]$peakRssBytes) -PeakRssAt ([ref]$peakRssAt) -PeakPrivateBytes ([ref]$peakPrivateBytes) -PeakPrivateAt ([ref]$peakPrivateAt)
+    $stopwatch.Stop()
+
+    $generatorPhases = Get-LocalPhaseSummaryFromLog -Path $stdoutPath
+    $audit = if (-not [string]::IsNullOrWhiteSpace($AuditPath) -and (Test-Path -LiteralPath $AuditPath -PathType Leaf)) {
+        Get-Content -Path $AuditPath -Raw | ConvertFrom-Json -Depth 100
+    }
+    else {
+        $null
+    }
+    $auditSummary = Get-ValidationAuditSummary -Audit $audit
+    $validationPhases = Get-ValidationPhaseSummaryFromAudit -Audit $audit
+    $hotPhases = Get-HotPhaseSummary -GeneratorPhases @($generatorPhases) -ValidationPhases @($validationPhases)
+
+    $observations = [System.Collections.Generic.List[string]]::new()
+    $topPhase = @($hotPhases | Select-Object -First 1)
+    if ($topPhase.Count -gt 0) {
+        $observations.Add(("Dominant phase [{0}] {1}: {2:N2}s." -f $topPhase[0].scope, $topPhase[0].name, $topPhase[0].elapsedSeconds)) | Out-Null
+    }
+    if ($null -ne $auditSummary -and $auditSummary.attestationUsed) {
+        $observations.Add('Validation reused a semantic attestation.') | Out-Null
+    }
+
+    $result = [PSCustomObject]@{
+        name = $Name
+        command = @('pwsh') + $ArgumentList
+        status = if ($process.ExitCode -eq 0) { 'success' } else { 'failure' }
+        exitCode = $process.ExitCode
+        processMetrics = [PSCustomObject]@{
+            elapsedSeconds = [math]::Round($stopwatch.Elapsed.TotalSeconds, 2)
+            peakTreeRssBytes = $peakRssBytes
+            peakTreeRssGb = [math]::Round(($peakRssBytes / 1GB), 3)
+            peakTreeRssAtSeconds = $peakRssAt
+            peakTreePrivateBytes = $peakPrivateBytes
+            peakTreePrivateGb = [math]::Round(($peakPrivateBytes / 1GB), 3)
+            peakTreePrivateAtSeconds = $peakPrivateAt
+            sampleCount = $samples.Count
+        }
+        artifacts = [PSCustomObject]@{
+            modeOutputRoot = $ModeOutputRoot
+            dashboardPath = if (-not [string]::IsNullOrWhiteSpace($DashboardPath) -and (Test-Path -LiteralPath $DashboardPath -PathType Leaf)) { $DashboardPath } else { $null }
+            auditPath = if (-not [string]::IsNullOrWhiteSpace($AuditPath) -and (Test-Path -LiteralPath $AuditPath -PathType Leaf)) { $AuditPath } else { $null }
+            stdoutPath = $stdoutPath
+            stderrPath = $stderrPath
+        }
+        validationAuditSummary = $auditSummary
+        generatorPhases = @($generatorPhases)
+        validationPhases = @($validationPhases)
+        hotPhases = @($hotPhases)
+        observations = @($observations)
+        samples = @($samples)
+    }
+
+    if ($process.ExitCode -ne 0) {
+        Write-LogTail -Path $stdoutPath -Label ($Name + ' stdout')
+        Write-LogTail -Path $stderrPath -Label ($Name + ' stderr')
+        throw "Validation mode '$Name' exited with code $($process.ExitCode)."
+    }
+
+    return $result
+}
+
+$repoRoot = Split-Path -Path $PSScriptRoot -Parent
+$dashboardScript = Join-Path $repoRoot 'Generate-VulnerabilityDashboard.ps1'
+$resolvedDirectoryPath = [System.IO.Path]::GetFullPath($DirectoryPath)
+$resolvedOutputRoot = [System.IO.Path]::GetFullPath($OutputRoot)
+
+if (-not (Test-Path -LiteralPath $resolvedDirectoryPath -PathType Container)) {
+    throw "Directory '$resolvedDirectoryPath' was not found."
+}
+
+if (-not (Test-Path -LiteralPath $resolvedOutputRoot -PathType Container)) {
+    $null = New-Item -Path $resolvedOutputRoot -ItemType Directory -Force
+}
+
+$warmupRoot = Join-Path $resolvedOutputRoot 'normalize-only-warmup'
+$warmupPayloadPath = Join-Path $warmupRoot 'normalized-payload.json.gz'
+$warmupManifestPath = Join-Path $warmupRoot 'normalized-payload.manifest.json'
+$warmupOutputPath = Join-Path $warmupRoot 'Warmup.html'
+
+$packageRoot = Join-Path $resolvedOutputRoot 'package-only'
+$packageOutputPath = Join-Path $packageRoot 'VulnerabilityDashboard.html'
+
+$validateForceRoot = Join-Path $resolvedOutputRoot 'validate-only-forcefull'
+$validateForceAuditPath = Join-Path $validateForceRoot 'dashboard-audit.json'
+
+$validateAttestedRoot = Join-Path $resolvedOutputRoot 'validate-only-attested'
+$validateAttestedAuditPath = Join-Path $validateAttestedRoot 'dashboard-audit.json'
+
+$fullForceRoot = Join-Path $resolvedOutputRoot 'full-generate-forcefull'
+$fullForceOutputPath = Join-Path $fullForceRoot 'VulnerabilityDashboard.html'
+$fullForceAuditPath = Join-Path $fullForceRoot 'dashboard-audit.json'
+
+$fullDefaultRoot = Join-Path $resolvedOutputRoot 'full-generate-default'
+$fullDefaultOutputPath = Join-Path $fullDefaultRoot 'VulnerabilityDashboard.html'
+$fullDefaultAuditPath = Join-Path $fullDefaultRoot 'dashboard-audit.json'
+
+$reportPath = Join-Path $resolvedOutputRoot 'validation-mode-comparison.json'
+if (Test-Path -LiteralPath $reportPath -PathType Leaf) {
+    Remove-Item -LiteralPath $reportPath -Force
+}
+
+Write-Output 'Running validation mode comparison...'
+Write-Output ("  Dataset: {0}" -f $resolvedDirectoryPath)
+Write-Output ("  Output root: {0}" -f $resolvedOutputRoot)
+
+$runs = [System.Collections.Generic.List[object]]::new()
+
+$warmupArgs = @(
+    '-NoProfile'
+    '-File', $dashboardScript
+    '-DirectoryPath', $resolvedDirectoryPath
+    '-OutputPath', $warmupOutputPath
+    '-ExportMachineData:$false'
+    '-NormalizeOnly'
+    '-NormalizedPayloadOutputPath', $warmupPayloadPath
+    '-NormalizedPayloadManifestOutputPath', $warmupManifestPath
+)
+$runs.Add((Invoke-ValidationModeRun -Name 'normalize-only-warmup' -RepoRoot $repoRoot -ArgumentList $warmupArgs -ModeOutputRoot $warmupRoot -DashboardPath '' -AuditPath '' -PollIntervalSeconds $PollIntervalSeconds)) | Out-Null
+
+$packageArgs = @(
+    '-NoProfile'
+    '-File', $dashboardScript
+    '-DirectoryPath', $resolvedDirectoryPath
+    '-OutputPath', $packageOutputPath
+    '-ExportMachineData:$false'
+    '-PackageOnly'
+    '-NormalizedPayloadInputPath', $warmupPayloadPath
+    '-NormalizedPayloadManifestInputPath', $warmupManifestPath
+)
+$runs.Add((Invoke-ValidationModeRun -Name 'package-only' -RepoRoot $repoRoot -ArgumentList $packageArgs -ModeOutputRoot $packageRoot -DashboardPath $packageOutputPath -AuditPath '' -ResetDashboardPath -PollIntervalSeconds $PollIntervalSeconds)) | Out-Null
+
+$validateForceArgs = @(
+    '-NoProfile'
+    '-File', $dashboardScript
+    '-DirectoryPath', $resolvedDirectoryPath
+    '-OutputPath', $packageOutputPath
+    '-ValidateOnly'
+    '-ValidationOutputPath', $validateForceAuditPath
+    '-ValidationHeartbeatSeconds', $ValidationHeartbeatSeconds
+    '-ValidationPartitionCompareParallelism', $ValidationPartitionCompareParallelism
+    '-ForceFullValidation'
+)
+$runs.Add((Invoke-ValidationModeRun -Name 'validate-only-forcefull' -RepoRoot $repoRoot -ArgumentList $validateForceArgs -ModeOutputRoot $validateForceRoot -DashboardPath $packageOutputPath -AuditPath $validateForceAuditPath -ResetAuditPath -PollIntervalSeconds $PollIntervalSeconds)) | Out-Null
+
+$validateAttestedArgs = @(
+    '-NoProfile'
+    '-File', $dashboardScript
+    '-DirectoryPath', $resolvedDirectoryPath
+    '-OutputPath', $packageOutputPath
+    '-ValidateOnly'
+    '-ValidationOutputPath', $validateAttestedAuditPath
+    '-ValidationHeartbeatSeconds', $ValidationHeartbeatSeconds
+    '-ValidationPartitionCompareParallelism', $ValidationPartitionCompareParallelism
+)
+$runs.Add((Invoke-ValidationModeRun -Name 'validate-only-attested' -RepoRoot $repoRoot -ArgumentList $validateAttestedArgs -ModeOutputRoot $validateAttestedRoot -DashboardPath $packageOutputPath -AuditPath $validateAttestedAuditPath -ResetAuditPath -PollIntervalSeconds $PollIntervalSeconds)) | Out-Null
+
+$fullForceArgs = @(
+    '-NoProfile'
+    '-File', $dashboardScript
+    '-DirectoryPath', $resolvedDirectoryPath
+    '-OutputPath', $fullForceOutputPath
+    '-ExportMachineData:$false'
+    '-Validate'
+    '-ValidationOutputPath', $fullForceAuditPath
+    '-ValidationHeartbeatSeconds', $ValidationHeartbeatSeconds
+    '-ValidationPartitionCompareParallelism', $ValidationPartitionCompareParallelism
+    '-ForceFullValidation'
+)
+$runs.Add((Invoke-ValidationModeRun -Name 'full-generate-forcefull' -RepoRoot $repoRoot -ArgumentList $fullForceArgs -ModeOutputRoot $fullForceRoot -DashboardPath $fullForceOutputPath -AuditPath $fullForceAuditPath -ResetDashboardPath -ResetAuditPath -PollIntervalSeconds $PollIntervalSeconds)) | Out-Null
+
+$fullDefaultArgs = @(
+    '-NoProfile'
+    '-File', $dashboardScript
+    '-DirectoryPath', $resolvedDirectoryPath
+    '-OutputPath', $fullDefaultOutputPath
+    '-ExportMachineData:$false'
+    '-Validate'
+    '-ValidationOutputPath', $fullDefaultAuditPath
+    '-ValidationHeartbeatSeconds', $ValidationHeartbeatSeconds
+    '-ValidationPartitionCompareParallelism', $ValidationPartitionCompareParallelism
+)
+$runs.Add((Invoke-ValidationModeRun -Name 'full-generate-default' -RepoRoot $repoRoot -ArgumentList $fullDefaultArgs -ModeOutputRoot $fullDefaultRoot -DashboardPath $fullDefaultOutputPath -AuditPath $fullDefaultAuditPath -ResetDashboardPath -ResetAuditPath -PollIntervalSeconds $PollIntervalSeconds)) | Out-Null
+
+$runByName = @{}
+foreach ($run in $runs) {
+    $runByName[[string]$run.name] = $run
+}
+
+$validateForceRun = $runByName['validate-only-forcefull']
+$validateAttestedRun = $runByName['validate-only-attested']
+$fullForceRun = $runByName['full-generate-forcefull']
+$fullDefaultRun = $runByName['full-generate-default']
+
+$summary = [PSCustomObject]@{
+    validateOnlyForceFullSeconds = if ($null -ne $validateForceRun) { $validateForceRun.processMetrics.elapsedSeconds } else { $null }
+    validateOnlyAttestedSeconds = if ($null -ne $validateAttestedRun) { $validateAttestedRun.processMetrics.elapsedSeconds } else { $null }
+    fullGenerateForceFullSeconds = if ($null -ne $fullForceRun) { $fullForceRun.processMetrics.elapsedSeconds } else { $null }
+    fullGenerateDefaultSeconds = if ($null -ne $fullDefaultRun) { $fullDefaultRun.processMetrics.elapsedSeconds } else { $null }
+    attestedValidationSavingsSeconds = if ($null -ne $validateForceRun -and $null -ne $validateAttestedRun) { [math]::Round(($validateForceRun.processMetrics.elapsedSeconds - $validateAttestedRun.processMetrics.elapsedSeconds), 2) } else { $null }
+    attestedFullRunSavingsSeconds = if ($null -ne $fullForceRun -and $null -ne $fullDefaultRun) { [math]::Round(($fullForceRun.processMetrics.elapsedSeconds - $fullDefaultRun.processMetrics.elapsedSeconds), 2) } else { $null }
+    maxPeakRssGb = [math]::Round((@($runs | ForEach-Object { $_.processMetrics.peakTreeRssGb } | Measure-Object -Maximum).Maximum), 3)
+}
+
+$report = [PSCustomObject]@{
+    generatedOnUtc = [datetime]::UtcNow.ToString('o')
+    datasetPath = $resolvedDirectoryPath
+    outputRoot = $resolvedOutputRoot
+    validationHeartbeatSeconds = $ValidationHeartbeatSeconds
+    validationPartitionCompareParallelism = $ValidationPartitionCompareParallelism
+    pollIntervalSeconds = $PollIntervalSeconds
+    runs = @($runs)
+    summary = $summary
+}
+
+$report | ConvertTo-Json -Depth 20 | Set-Content -Path $reportPath -Encoding utf8
+
+Write-Output ''
+Write-Output 'Validation mode comparison completed.'
+Write-Output ("  Force-full validate-only: {0}s" -f $summary.validateOnlyForceFullSeconds)
+Write-Output ("  Attested validate-only: {0}s" -f $summary.validateOnlyAttestedSeconds)
+Write-Output ("  Force-full end-to-end: {0}s" -f $summary.fullGenerateForceFullSeconds)
+Write-Output ("  Default end-to-end: {0}s" -f $summary.fullGenerateDefaultSeconds)
+Write-Output ("  Attested validation savings: {0}s" -f $summary.attestedValidationSavingsSeconds)
+Write-Output ("  Report: {0}" -f $reportPath)

--- a/tests/Invoke-WithPwshMemoryGuard.ps1
+++ b/tests/Invoke-WithPwshMemoryGuard.ps1
@@ -12,8 +12,8 @@ param(
     [string]$WorkingDirectory = (Get-Location).Path,
 
     [Parameter(Mandatory = $false)]
-    [ValidateRange(1, 64)]
-    [int]$MinimumAvailableMemoryGB = 4,
+    [ValidateRange(0.5, 64.0)]
+    [double]$MinimumAvailableMemoryGB = 4,
 
     [Parameter(Mandatory = $false)]
     [ValidateRange(1, 60)]
@@ -129,7 +129,17 @@ function Write-LogTail {
     }
 }
 
-$resolvedFilePath = [System.IO.Path]::GetFullPath((Join-Path $WorkingDirectory $FilePath))
+$resolvedWorkingDirectory = [System.IO.Path]::GetFullPath($WorkingDirectory)
+if (-not (Test-Path -LiteralPath $resolvedWorkingDirectory -PathType Container)) {
+    throw "Working directory '$resolvedWorkingDirectory' was not found."
+}
+
+$resolvedFilePath = if ([System.IO.Path]::IsPathRooted($FilePath)) {
+    [System.IO.Path]::GetFullPath($FilePath)
+}
+else {
+    [System.IO.Path]::GetFullPath((Join-Path $resolvedWorkingDirectory $FilePath))
+}
 if (-not (Test-Path -LiteralPath $resolvedFilePath -PathType Leaf)) {
     throw "File '$resolvedFilePath' was not found."
 }
@@ -139,12 +149,12 @@ $stderrPath = Join-Path ([System.IO.Path]::GetTempPath()) ('pwsh-guard-stderr-' 
 $pwshArgs = @('-NoProfile', '-File', $resolvedFilePath) + @($ArgumentList)
 
 Write-Output ("Starting guarded PowerShell process: {0}" -f $resolvedFilePath)
-Write-Output ("Working directory: {0}" -f $WorkingDirectory)
+Write-Output ("Working directory: {0}" -f $resolvedWorkingDirectory)
 Write-Output ("Minimum available memory threshold: {0} GB" -f $MinimumAvailableMemoryGB)
 
 $process = Start-Process -FilePath 'pwsh' `
     -ArgumentList $pwshArgs `
-    -WorkingDirectory $WorkingDirectory `
+    -WorkingDirectory $resolvedWorkingDirectory `
     -RedirectStandardOutput $stdoutPath `
     -RedirectStandardError $stderrPath `
     -PassThru
@@ -175,7 +185,7 @@ try {
         else {
             'n/a'
         }
-        Write-Output ("Guard status: elapsed={0} tree-procs={1} pwsh={2} tree-ws={3} GB largest={4} available={5} GB" -f $stopwatch.Elapsed.ToString('hh\:mm\:ss'), $processTree.Count, $pwshProcessCount, $treeWorkingSetGB, $largestProcessSummary, $availableMemoryGB)
+        Write-Output ("[{0}] Guard status: elapsed={1} tree-procs={2} pwsh={3} tree-ws={4} GB largest={5} available={6} GB" -f (Get-Date).ToString('yyyy-MM-dd HH:mm:ss'), $stopwatch.Elapsed.ToString('hh\:mm\:ss'), $processTree.Count, $pwshProcessCount, $treeWorkingSetGB, $largestProcessSummary, $availableMemoryGB)
 
         if ($availableMemoryGB -le $MinimumAvailableMemoryGB) {
             $processIds = if ($processTree.Count -gt 0) { ($processTree | ForEach-Object { $_.Id }) -join ', ' } else { [string]$process.Id }

--- a/tests/Measure-BranchVsMainBenchmark.ps1
+++ b/tests/Measure-BranchVsMainBenchmark.ps1
@@ -12,6 +12,9 @@ param(
     [string]$DatasetPath = (Join-Path (Split-Path -Path $PSScriptRoot -Parent) 'exports-synthetic'),
 
     [Parameter(Mandatory = $false)]
+    [string]$BenchmarkDatasetId,
+
+    [Parameter(Mandatory = $false)]
     [string]$AutomationAccountName = 'aa-defender-reporting',
 
     [Parameter(Mandatory = $false)]
@@ -46,8 +49,8 @@ param(
     [int]$PollIntervalSeconds = 15,
 
     [Parameter(Mandatory = $false)]
-    [ValidateRange(1, 256)]
-    [int]$MinimumAvailableMemoryGB = 8,
+    [ValidateRange(0.5, 256.0)]
+    [double]$MinimumAvailableMemoryGB = 8,
 
     [Parameter(Mandatory = $false)]
     [ValidateRange(1, 2048)]
@@ -62,6 +65,12 @@ param(
 
     [Parameter(Mandatory = $false)]
     [switch]$CurrentOnly,
+
+    [Parameter(Mandatory = $false)]
+    [switch]$LocalOnly,
+
+    [Parameter(Mandatory = $false)]
+    [switch]$IncludePersistentLocalWorkflow,
 
     [Parameter(Mandatory = $false)]
     [switch]$SkipRestoreCurrentDeployment
@@ -79,6 +88,166 @@ $script:FunctionAppName = $FunctionAppName
 $script:FunctionAppResourceGroup = $FunctionAppResourceGroup
 $script:FunctionStorageAccountName = $FunctionStorageAccountName
 $script:PollIntervalSeconds = $PollIntervalSeconds
+
+. (Join-Path $PSScriptRoot 'Import-BenchmarkDatasetCatalog.ps1')
+
+function Get-HeartbeatTimestampText {
+    [CmdletBinding()]
+    [OutputType([string])]
+    param()
+
+    return (Get-Date).ToString('yyyy-MM-dd HH:mm:ss')
+}
+
+function ConvertTo-UtcDateTime {
+    [CmdletBinding()]
+    [OutputType([datetime])]
+    param(
+        [Parameter(Mandatory = $false)]
+        [AllowNull()]
+        $Value
+    )
+
+    if ($null -eq $Value) {
+        return $null
+    }
+
+    if ($Value -is [datetime]) {
+        return ([datetime]$Value).ToUniversalTime()
+    }
+
+    if ($Value -is [datetimeoffset]) {
+        return ([datetimeoffset]$Value).UtcDateTime
+    }
+
+    $text = [string]$Value
+    if ([string]::IsNullOrWhiteSpace($text)) {
+        return $null
+    }
+
+    $parsed = [datetimeoffset]::MinValue
+    if ([datetimeoffset]::TryParse($text, [ref]$parsed)) {
+        return $parsed.UtcDateTime
+    }
+
+    return $null
+}
+
+function Get-ObjectPropertyValue {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $false)]
+        [AllowNull()]
+        $InputObject,
+
+        [Parameter(Mandatory = $true)]
+        [string]$Name
+    )
+
+    if ($null -eq $InputObject) {
+        return $null
+    }
+
+    $property = $InputObject.PSObject.Properties[$Name]
+    if ($null -eq $property) {
+        return $null
+    }
+
+    return $property.Value
+}
+
+function Get-TextWithoutAnsiEscape {
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [AllowEmptyString()]
+        [string]$Text
+    )
+
+    return ([regex]::Replace($Text, "`e\[[0-9;]*m", ''))
+}
+
+function Get-LocalPhaseSummaryFromLog {
+    [CmdletBinding()]
+    [OutputType([object[]])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Path
+    )
+
+    if (-not (Test-Path -LiteralPath $Path -PathType Leaf)) {
+        return @()
+    }
+
+    $phaseByName = [ordered]@{}
+    foreach ($rawLine in Get-Content -Path $Path) {
+        $line = Get-TextWithoutAnsiEscape -Text ([string]$rawLine)
+        if ($line -match '^\s*--- Local Phase: (?<name>.+?) ---\s*$') {
+            $phaseName = [string]$matches.name
+            if (-not $phaseByName.Contains($phaseName)) {
+                $phaseByName[$phaseName] = [ordered]@{
+                    name = $phaseName
+                    status = 'started'
+                    elapsedSeconds = $null
+                }
+            }
+
+            continue
+        }
+
+        if ($line -match '^\s*\[(?<name>.+?)\] Elapsed: (?<seconds>[0-9.,]+)s(?:\s*\((?<status>[^)]+)\))?\s*$') {
+            $phaseName = [string]$matches.name
+            if (-not $phaseByName.Contains($phaseName)) {
+                $phaseByName[$phaseName] = [ordered]@{ name = $phaseName }
+            }
+
+            $phaseEntry = $phaseByName[$phaseName]
+            $phaseEntry.elapsedSeconds = [double](($matches.seconds -replace ',', ''))
+            $phaseEntry.status = if ($matches.status) { [string]$matches.status } else { 'completed' }
+        }
+    }
+
+    return @(
+        foreach ($phaseEntry in $phaseByName.Values) {
+            [PSCustomObject]@{
+                name = [string]$phaseEntry.name
+                status = if ($phaseEntry.Contains('status')) { [string]$phaseEntry.status } else { 'unknown' }
+                elapsedSeconds = if ($phaseEntry.Contains('elapsedSeconds')) { $phaseEntry.elapsedSeconds } else { $null }
+            }
+        }
+    )
+}
+
+function Get-LocalBenchmarkLogSummary {
+    [CmdletBinding()]
+    [OutputType([pscustomobject])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$StdoutPath
+    )
+
+    $phaseSummary = [ordered]@{}
+    foreach ($phase in @(Get-LocalPhaseSummaryFromLog -Path $StdoutPath)) {
+        if ($null -ne $phase.elapsedSeconds) {
+            $phaseSummary[[string]$phase.name] = [double]$phase.elapsedSeconds
+        }
+    }
+
+    $stdoutText = if (Test-Path -LiteralPath $StdoutPath -PathType Leaf) {
+        Get-TextWithoutAnsiEscape -Text (Get-Content -LiteralPath $StdoutPath -Raw)
+    }
+    else {
+        ''
+    }
+
+    return [PSCustomObject]@{
+        phase_elapsed_seconds = [PSCustomObject]$phaseSummary
+        used_cached_payload = ($stdoutText -match 'Reusing cached normalized payload')
+        used_cached_vuln_columns = ($stdoutText -match 'Reusing cached normalized vuln columns')
+        published_cached_vuln_columns = ($stdoutText -match 'Cached normalized vuln columns as')
+    }
+}
 
 function Invoke-AzCli {
     [CmdletBinding()]
@@ -154,6 +323,51 @@ function Invoke-RepoScript {
     }
 }
 
+function Write-BaselineBenchmarkHeartbeat {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$BaselineName,
+
+        [Parameter(Mandatory = $true)]
+        [System.Collections.IDictionary]$LocalState,
+
+        [Parameter(Mandatory = $false)]
+        [AllowNull()]
+        $RunbookJob,
+
+        [Parameter(Mandatory = $true)]
+        [string]$FunctionStatus,
+
+        [Parameter(Mandatory = $true)]
+        [datetime]$FunctionInvokeStartedUtc,
+
+        [Parameter(Mandatory = $false)]
+        [AllowNull()]
+        $FunctionExecutionActivity
+    )
+
+    $localElapsedSeconds = [math]::Round($LocalState.stopwatch.Elapsed.TotalSeconds, 2)
+    $localStatus = if ($LocalState.completed) { 'Completed' } else { 'Running' }
+    $localPeakRssGb = [math]::Round(($LocalState.peakRssBytes / 1GB), 3)
+    $runbookStatus = if ($null -ne $RunbookJob -and $RunbookJob.PSObject.Properties['status']) { [string]$RunbookJob.status } else { 'Pending' }
+    $functionElapsedSeconds = [math]::Round((New-TimeSpan -Start $FunctionInvokeStartedUtc -End ([datetime]::UtcNow)).TotalSeconds, 2)
+    $functionExecutionCount = if ($null -ne $FunctionExecutionActivity -and $FunctionExecutionActivity.PSObject.Properties['total_count']) { [int]$FunctionExecutionActivity.total_count } else { 0 }
+
+    $message = "[{0}] {1} heartbeat: local={2} elapsed={3:N0}s peak-rss={4}GB; runbook={5}; function={6} elapsed={7:N0}s exec-count={8}" -f @(
+        (Get-HeartbeatTimestampText)
+        $BaselineName
+        $localStatus
+        $localElapsedSeconds
+        $localPeakRssGb
+        $runbookStatus
+        $FunctionStatus
+        $functionElapsedSeconds
+        $functionExecutionCount
+    )
+    Write-Host $message
+}
+
 function Get-DatasetFiles {
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '', Justification = 'Internal helper intentionally returns a collection of dataset files.')]
     [CmdletBinding()]
@@ -175,6 +389,61 @@ function Get-DatasetFiles {
             } |
             Sort-Object -Property Name
     )
+}
+
+function Copy-BenchmarkDataset {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '', Justification = 'Internal benchmark helper stages a working dataset directory for repeatable local runs.')]
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$SourceDatasetPath,
+
+        [Parameter(Mandatory = $true)]
+        [string]$DestinationDatasetPath
+    )
+
+    if (Test-Path -LiteralPath $DestinationDatasetPath) {
+        Remove-Item -LiteralPath $DestinationDatasetPath -Recurse -Force -ErrorAction SilentlyContinue
+    }
+
+    $null = New-Item -Path $DestinationDatasetPath -ItemType Directory -Force
+    foreach ($datasetFile in Get-DatasetFiles -Path $SourceDatasetPath) {
+        Copy-Item -LiteralPath $datasetFile.FullName -Destination (Join-Path -Path $DestinationDatasetPath -ChildPath $datasetFile.Name) -Force
+    }
+}
+
+function Reset-LocalBenchmarkCache {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '', Justification = 'Internal benchmark helper only clears derived dashboard cache content in the staged benchmark dataset.')]
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$DatasetPath,
+
+        [Parameter(Mandatory = $false)]
+        [ValidateSet('all', 'payload-only', 'none')]
+        [string]$Mode = 'all'
+    )
+
+    if ($Mode -eq 'none') {
+        return
+    }
+
+    $cachePath = Join-Path -Path $DatasetPath -ChildPath '.dashboard-cache'
+    if (-not (Test-Path -LiteralPath $cachePath -PathType Container)) {
+        return
+    }
+
+    switch ($Mode) {
+        'all' {
+            Remove-Item -LiteralPath $cachePath -Recurse -Force -ErrorAction SilentlyContinue
+        }
+        'payload-only' {
+            $payloadPath = Join-Path -Path $cachePath -ChildPath 'payloads'
+            if (Test-Path -LiteralPath $payloadPath -PathType Container) {
+                Remove-Item -LiteralPath $payloadPath -Recurse -Force -ErrorAction SilentlyContinue
+            }
+        }
+    }
 }
 
 function Get-FreeDiskByteCount {
@@ -211,7 +480,7 @@ function Assert-BenchmarkDatasetReady {
         [bool]$AllowLargeDataset,
 
         [Parameter(Mandatory = $true)]
-        [int]$MinimumAvailableMemoryGB,
+        [double]$MinimumAvailableMemoryGB,
 
         [Parameter(Mandatory = $true)]
         [int]$MinimumFreeDiskGB
@@ -298,6 +567,56 @@ function Assert-BenchmarkDatasetReady {
     }
 }
 
+function Get-BenchmarkDatasetResultMetadata {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '', Justification = 'Metadata is a fixed benchmark sidecar concept in this repository and matches benchmark-dataset.json.')]
+    [CmdletBinding()]
+    [OutputType([pscustomobject])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$DatasetPath,
+
+        [Parameter(Mandatory = $true)]
+        $Manifest,
+
+        [Parameter(Mandatory = $false)]
+        [AllowEmptyString()]
+        [string]$BenchmarkDatasetId,
+
+        [Parameter(Mandatory = $true)]
+        [string]$RepoRoot
+    )
+
+    $metadata = Get-BenchmarkDatasetMetadata -DatasetPath $DatasetPath
+    $definition = $null
+
+    if ($null -ne $metadata -and $metadata.PSObject.Properties['id'] -and -not [string]::IsNullOrWhiteSpace([string]$metadata.id)) {
+        $definition = Get-BenchmarkDatasetDefinition -DatasetId ([string]$metadata.id) -RepoRoot $RepoRoot
+    }
+
+    if ($null -eq $definition -and -not [string]::IsNullOrWhiteSpace($BenchmarkDatasetId)) {
+        $definition = Get-BenchmarkDatasetDefinition -DatasetId $BenchmarkDatasetId -RepoRoot $RepoRoot
+    }
+
+    if ($null -eq $definition) {
+        $definition = Find-BenchmarkDatasetDefinitionForManifest -Manifest $Manifest -RepoRoot $RepoRoot
+    }
+
+    if ($null -eq $definition) {
+        return $null
+    }
+
+    return [PSCustomObject]@{
+        id = [string]$definition.id
+        description = [string]$definition.description
+        preset = [string]$definition.preset
+        seed = [int]$definition.seed
+        target_device_count = [int]$definition.targetDeviceCount
+        target_total_vuln_rows = [int]$definition.targetTotalVulnRows
+        output_path = Resolve-BenchmarkDatasetOutputPath -Definition $definition -RepoRoot $RepoRoot
+        history_tags = @($definition.historyTags)
+    }
+}
+
 function Clear-BlobContainer {
     [CmdletBinding()]
     param(
@@ -372,6 +691,67 @@ function Get-BlobDetail {
 
         throw
     }
+}
+
+function Get-BlobTextContent {
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$AccountName,
+
+        [Parameter(Mandatory = $true)]
+        [string]$ContainerName,
+
+        [Parameter(Mandatory = $true)]
+        [string]$BlobName
+    )
+
+    $tempPath = Join-Path ([System.IO.Path]::GetTempPath()) ('blob-' + [guid]::NewGuid().ToString('N') + '.tmp')
+    try {
+        Invoke-AzCli -Arguments @(
+            'storage', 'blob', 'download',
+            '--account-name', $AccountName,
+            '--container-name', $ContainerName,
+            '--name', $BlobName,
+            '--file', $tempPath,
+            '--auth-mode', 'login',
+            '--overwrite',
+            '--output', 'none'
+        ) | Out-Null
+
+        if (-not (Test-Path -LiteralPath $tempPath -PathType Leaf)) {
+            return $null
+        }
+
+        return (Get-Content -LiteralPath $tempPath -Raw)
+    }
+    catch {
+        if ($_.Exception.Message -match 'BlobNotFound|ResourceNotFound|The specified blob does not exist') {
+            return $null
+        }
+
+        throw
+    }
+    finally {
+        Remove-Item -LiteralPath $tempPath -Force -ErrorAction SilentlyContinue
+    }
+}
+
+function Get-FunctionExecutionStatus {
+    [CmdletBinding()]
+    [OutputType([pscustomobject])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$AccountName
+    )
+
+    $statusContent = Get-BlobTextContent -AccountName $AccountName -ContainerName 'dashboards' -BlobName '_diagnostics/ExportAndGenerate.status.json'
+    if ([string]::IsNullOrWhiteSpace($statusContent)) {
+        return $null
+    }
+
+    return ($statusContent | ConvertFrom-Json -Depth 30)
 }
 
 function Get-BlobLengthBytes {
@@ -655,6 +1035,19 @@ function Set-FunctionAppBenchmarkSettings {
         'INCLUDE_ADVANCED_HUNTING=true',
         'USE_EXISTING_EXPORTS_ONLY=true',
         'PIPELINE_FILE_TRACE_ENABLED=true',
+        '--output', 'none'
+    ) | Out-Null
+}
+
+function Restart-FunctionAppForBenchmark {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '', Justification = 'Internal benchmark helper restarts the Function App after changing benchmark-specific settings.')]
+    [CmdletBinding()]
+    param()
+
+    Invoke-AzCli -Arguments @(
+        'functionapp', 'restart',
+        '--name', $FunctionAppName,
+        '--resource-group', $FunctionAppResourceGroup,
         '--output', 'none'
     ) | Out-Null
 }
@@ -1070,23 +1463,32 @@ function Start-LocalBenchmark {
         [string]$BenchmarkDatasetPath,
 
         [Parameter(Mandatory = $true)]
-        [string]$OutputDirectory
+        [string]$OutputDirectory,
+
+        [Parameter(Mandatory = $false)]
+        [AllowEmptyString()]
+        [string]$WorkingDatasetPath,
+
+        [Parameter(Mandatory = $false)]
+        [ValidateSet('all', 'payload-only', 'none')]
+        [string]$CacheResetMode = 'all'
     )
 
-    $localDatasetPath = Join-Path -Path $OutputDirectory -ChildPath ($Name + '.local.dataset')
-    if (Test-Path -LiteralPath $localDatasetPath) {
-        Remove-Item -LiteralPath $localDatasetPath -Recurse -Force -ErrorAction SilentlyContinue
+    $localDatasetPath = if ([string]::IsNullOrWhiteSpace($WorkingDatasetPath)) {
+        Join-Path -Path $OutputDirectory -ChildPath ($Name + '.local.dataset')
+    }
+    else {
+        [System.IO.Path]::GetFullPath($WorkingDatasetPath)
     }
 
-    $null = New-Item -Path $localDatasetPath -ItemType Directory -Force
-    foreach ($datasetFile in Get-DatasetFiles -Path $BenchmarkDatasetPath) {
-        Copy-Item -LiteralPath $datasetFile.FullName -Destination (Join-Path -Path $localDatasetPath -ChildPath $datasetFile.Name) -Force
+    if ([string]::IsNullOrWhiteSpace($WorkingDatasetPath)) {
+        Copy-BenchmarkDataset -SourceDatasetPath $BenchmarkDatasetPath -DestinationDatasetPath $localDatasetPath
+    }
+    elseif (-not (Test-Path -LiteralPath $localDatasetPath -PathType Container)) {
+        throw "Working local benchmark dataset not found: $localDatasetPath"
     }
 
-    $cachePath = Join-Path -Path $localDatasetPath -ChildPath '.dashboard-cache'
-    if (Test-Path -LiteralPath $cachePath) {
-        Remove-Item -LiteralPath $cachePath -Recurse -Force -ErrorAction SilentlyContinue
-    }
+    Reset-LocalBenchmarkCache -DatasetPath $localDatasetPath -Mode $CacheResetMode
 
     if (-not (Test-Path -LiteralPath $OutputDirectory)) {
         $null = New-Item -Path $OutputDirectory -ItemType Directory -Force
@@ -1200,8 +1602,13 @@ function Get-LocalBenchmarkResult {
         [System.Collections.IDictionary]$State,
 
         [Parameter(Mandatory = $true)]
-        [int]$TotalRows
+        [int]$TotalRows,
+
+        [Parameter(Mandatory = $false)]
+        [switch]$KeepDatasetPath
     )
+
+    $logSummary = Get-LocalBenchmarkLogSummary -StdoutPath $State.stdoutPath
 
     $result = [PSCustomObject]@{
         status = if ($State.exitCode -eq 0) { 'Completed' } else { 'Failed' }
@@ -1216,16 +1623,129 @@ function Get-LocalBenchmarkResult {
         sample_count = $State.samples.Count
         dashboard_bytes = if (Test-Path -LiteralPath $State.dashboardPath -PathType Leaf) { (Get-Item -LiteralPath $State.dashboardPath).Length } else { 0 }
         dashboard_mb = if (Test-Path -LiteralPath $State.dashboardPath -PathType Leaf) { [math]::Round(((Get-Item -LiteralPath $State.dashboardPath).Length / 1MB), 2) } else { 0 }
+        phase_elapsed_seconds = $logSummary.phase_elapsed_seconds
+        used_cached_payload = [bool]$logSummary.used_cached_payload
+        used_cached_vuln_columns = [bool]$logSummary.used_cached_vuln_columns
+        published_cached_vuln_columns = [bool]$logSummary.published_cached_vuln_columns
         stdout_path = $State.stdoutPath
         stderr_path = $State.stderrPath
         dashboard_path = $State.dashboardPath
     }
 
-    if ($State.Contains('datasetPath') -and -not [string]::IsNullOrWhiteSpace([string]$State.datasetPath) -and (Test-Path -LiteralPath $State.datasetPath)) {
+    if ((-not $KeepDatasetPath) -and $State.Contains('datasetPath') -and -not [string]::IsNullOrWhiteSpace([string]$State.datasetPath) -and (Test-Path -LiteralPath $State.datasetPath)) {
         Remove-Item -LiteralPath $State.datasetPath -Recurse -Force -ErrorAction SilentlyContinue
     }
 
     return $result
+}
+
+function Wait-LocalBenchmarkCompletion {
+    [CmdletBinding()]
+    [OutputType([pscustomobject])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [System.Collections.IDictionary]$State,
+
+        [Parameter(Mandatory = $true)]
+        [int]$TotalRows,
+
+        [Parameter(Mandatory = $false)]
+        [switch]$KeepDatasetPath
+    )
+
+    while (-not $State.completed) {
+        Update-LocalBenchmark -State $State
+        if (-not $State.completed) {
+            Start-Sleep -Seconds $PollIntervalSeconds
+        }
+    }
+
+    Update-LocalBenchmark -State $State
+    return (Get-LocalBenchmarkResult -State $State -TotalRows $TotalRows -KeepDatasetPath:$KeepDatasetPath)
+}
+
+function Get-PhaseElapsedSecondsValue {
+    [CmdletBinding()]
+    [OutputType([double])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [AllowNull()]
+        $Result,
+
+        [Parameter(Mandatory = $true)]
+        [string]$PhaseName
+    )
+
+    if ($null -eq $Result -or -not $Result.PSObject.Properties['phase_elapsed_seconds']) {
+        return $null
+    }
+
+    $phaseContainer = $Result.phase_elapsed_seconds
+    if ($null -eq $phaseContainer) {
+        return $null
+    }
+
+    $phaseProperty = $phaseContainer.PSObject.Properties[$PhaseName]
+    if ($null -eq $phaseProperty -or $null -eq $phaseProperty.Value) {
+        return $null
+    }
+
+    return [double]$phaseProperty.Value
+}
+
+function Invoke-LocalPersistentCacheWorkflow {
+    [CmdletBinding()]
+    [OutputType([pscustomobject])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$BaselineName,
+
+        [Parameter(Mandatory = $true)]
+        [string]$RepoPath,
+
+        [Parameter(Mandatory = $true)]
+        [string]$BenchmarkDatasetPath,
+
+        [Parameter(Mandatory = $true)]
+        [string]$OutputDirectory,
+
+        [Parameter(Mandatory = $true)]
+        [int]$TotalRows
+    )
+
+    $workflowDatasetPath = Join-Path -Path $OutputDirectory -ChildPath ($BaselineName + '.persistent.local.dataset')
+    Copy-BenchmarkDataset -SourceDatasetPath $BenchmarkDatasetPath -DestinationDatasetPath $workflowDatasetPath
+
+    try {
+        Write-Host 'Running persistent local cache prime pass...'
+        $primeState = Start-LocalBenchmark -RepoPath $RepoPath -Name ($BaselineName + '.persistent-prime') -BenchmarkDatasetPath $BenchmarkDatasetPath -OutputDirectory $OutputDirectory -WorkingDatasetPath $workflowDatasetPath -CacheResetMode 'all'
+        $primeResult = Wait-LocalBenchmarkCompletion -State $primeState -TotalRows $TotalRows -KeepDatasetPath
+
+        Write-Host 'Running persistent local cache reuse pass after payload-cache eviction...'
+        $reuseState = Start-LocalBenchmark -RepoPath $RepoPath -Name ($BaselineName + '.persistent-reuse') -BenchmarkDatasetPath $BenchmarkDatasetPath -OutputDirectory $OutputDirectory -WorkingDatasetPath $workflowDatasetPath -CacheResetMode 'payload-only'
+        $reuseResult = Wait-LocalBenchmarkCompletion -State $reuseState -TotalRows $TotalRows -KeepDatasetPath
+
+        $primeNormalizeSeconds = Get-PhaseElapsedSecondsValue -Result $primeResult -PhaseName 'Normalize source data'
+        $reuseNormalizeSeconds = Get-PhaseElapsedSecondsValue -Result $reuseResult -PhaseName 'Normalize source data'
+        $primePreparePayloadSeconds = Get-PhaseElapsedSecondsValue -Result $primeResult -PhaseName 'Prepare normalized payload'
+        $reusePreparePayloadSeconds = Get-PhaseElapsedSecondsValue -Result $reuseResult -PhaseName 'Prepare normalized payload'
+
+        return [PSCustomObject]@{
+            dataset_path = $workflowDatasetPath
+            prime = $primeResult
+            reuse_after_payload_eviction = $reuseResult
+            comparison = [PSCustomObject]@{
+                elapsed_seconds_delta = [math]::Round(($reuseResult.elapsed_seconds - $primeResult.elapsed_seconds), 2)
+                normalize_source_data_delta = if ($null -ne $primeNormalizeSeconds -and $null -ne $reuseNormalizeSeconds) { [math]::Round(($reuseNormalizeSeconds - $primeNormalizeSeconds), 2) } else { $null }
+                prepare_normalized_payload_delta = if ($null -ne $primePreparePayloadSeconds -and $null -ne $reusePreparePayloadSeconds) { [math]::Round(($reusePreparePayloadSeconds - $primePreparePayloadSeconds), 2) } else { $null }
+            }
+        }
+    }
+    finally {
+        if (Test-Path -LiteralPath $workflowDatasetPath -PathType Container) {
+            Remove-Item -LiteralPath $workflowDatasetPath -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
 }
 
 function Get-PipelineEventSummary {
@@ -1365,22 +1885,60 @@ function Invoke-BaselineBenchmark {
         [Parameter(Mandatory = $true)]
         [string]$OutputRoot,
 
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory = $false)]
+        [AllowEmptyString()]
         [string]$FunctionHostName,
 
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory = $false)]
+        [AllowEmptyString()]
         [string]$FunctionResourceId,
 
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory = $false)]
+        [AllowEmptyString()]
         [string]$SubscriptionId,
 
         [Parameter(Mandatory = $true)]
-        [int]$TotalRows
+        [int]$TotalRows,
+
+        [Parameter(Mandatory = $false)]
+        [switch]$LocalOnly,
+
+        [Parameter(Mandatory = $false)]
+        [switch]$IncludePersistentLocalWorkflow
     )
 
     Write-Host ''
     Write-Host ('=== {0} ===' -f $BaselineName) -ForegroundColor Cyan
     Write-Host ('Repo: {0}' -f $RepoPath)
+
+    $baselineOutputDirectory = Join-Path -Path $OutputRoot -ChildPath $BaselineName
+    if (-not (Test-Path -LiteralPath $baselineOutputDirectory)) {
+        $null = New-Item -Path $baselineOutputDirectory -ItemType Directory -Force
+    }
+
+    $localPersistentCacheResult = $null
+    if ($IncludePersistentLocalWorkflow) {
+        Write-Host 'Exercising persistent local cache workflow before the cold benchmark run...'
+        $localPersistentCacheResult = Invoke-LocalPersistentCacheWorkflow -BaselineName $BaselineName -RepoPath $RepoPath -BenchmarkDatasetPath $DatasetRoot -OutputDirectory $baselineOutputDirectory -TotalRows $TotalRows
+    }
+
+    if ($LocalOnly) {
+        $localState = Start-LocalBenchmark -RepoPath $RepoPath -Name $BaselineName -BenchmarkDatasetPath $DatasetRoot -OutputDirectory $baselineOutputDirectory
+        $localResult = Wait-LocalBenchmarkCompletion -State $localState -TotalRows $TotalRows
+
+        return [PSCustomObject]@{
+            baseline = $BaselineName
+            repo_path = $RepoPath
+            local = $localResult
+            local_persistent_cache = $localPersistentCacheResult
+            runbook = $null
+            function_app = $null
+            runbook_job_name = $null
+            function_invoked_at_utc = $null
+            runbook_events = @()
+            function_events = @()
+        }
+    }
 
     Write-Host 'Deploying runbook artifact...'
     Build-AndDeploy-Runbook -RepoPath $RepoPath
@@ -1388,6 +1946,8 @@ function Invoke-BaselineBenchmark {
     Build-AndDeploy-FunctionApp -RepoPath $RepoPath
     Write-Host 'Applying Function App benchmark settings...'
     Set-FunctionAppBenchmarkSettings
+    Write-Host 'Restarting Function App to apply benchmark settings...'
+    Restart-FunctionAppForBenchmark
 
     Write-Host 'Uploading templates to both storage accounts...'
     Upload-TemplatesForBaseline -RepoPath $RepoPath -StorageAccountName $RunbookStorageAccountName
@@ -1400,11 +1960,6 @@ function Invoke-BaselineBenchmark {
     Write-Host 'Waiting for Function App host readiness...'
     Wait-FunctionHostReady -HostName $FunctionHostName -MasterKey $effectiveFunctionMasterKey
     Remove-FunctionTraceFiles -HostName $FunctionHostName -MasterKey $effectiveFunctionMasterKey
-
-    $baselineOutputDirectory = Join-Path -Path $OutputRoot -ChildPath $BaselineName
-    if (-not (Test-Path -LiteralPath $baselineOutputDirectory)) {
-        $null = New-Item -Path $baselineOutputDirectory -ItemType Directory -Force
-    }
 
     $localState = Start-LocalBenchmark -RepoPath $RepoPath -Name $BaselineName -BenchmarkDatasetPath $DatasetRoot -OutputDirectory $baselineOutputDirectory
     $runbookState = Start-RunbookBenchmark
@@ -1425,6 +1980,11 @@ function Invoke-BaselineBenchmark {
     $functionEvents = @()
     $functionLastTracePollUtc = [datetime]::MinValue
     $functionTraceCompletedUtc = $null
+    $functionLastStatusPollUtc = [datetime]::MinValue
+    $functionPipelineStatus = $null
+    $functionActiveStartedUtc = $null
+    $functionDashboardCompletedUtc = $null
+    $functionCompletionSource = $null
 
     while (-not ($localState.completed -and $runbookCompleted -and $functionCompleted)) {
         Update-LocalBenchmark -State $localState
@@ -1439,13 +1999,49 @@ function Invoke-BaselineBenchmark {
 
         if (-not $functionCompleted) {
             $nowUtc = [datetime]::UtcNow
-            $functionDashboardBlob = Get-BlobDetail -AccountName $FunctionStorageAccountName -ContainerName 'dashboards' -BlobName 'VulnerabilityDashboard.html'
-            if ($null -ne $functionDashboardBlob) {
-                $lastModifiedUtc = ([datetimeoffset]$functionDashboardBlob.properties.lastModified).UtcDateTime
-                if ($lastModifiedUtc -ge $functionInvokeStartedUtc.AddSeconds(-5)) {
-                    $functionCompletedUtc = $lastModifiedUtc
-                    $functionCompleted = $true
-                    $functionStatus = 'Completed'
+
+            if ($nowUtc -ge $functionLastStatusPollUtc.AddSeconds([math]::Max($PollIntervalSeconds, 15))) {
+                $functionPipelineStatus = Get-FunctionExecutionStatus -AccountName $FunctionStorageAccountName
+                $functionLastStatusPollUtc = $nowUtc
+
+                if ($null -ne $functionPipelineStatus) {
+                    $statusStartedUtc = ConvertTo-UtcDateTime -Value (Get-ObjectPropertyValue -InputObject $functionPipelineStatus -Name 'startedOnUtc')
+                    if ($null -ne $statusStartedUtc) {
+                        $functionActiveStartedUtc = $statusStartedUtc
+                    }
+
+                    $statusCompletedUtc = ConvertTo-UtcDateTime -Value (Get-ObjectPropertyValue -InputObject $functionPipelineStatus -Name 'completedOnUtc')
+                    $statusUpdatedUtc = ConvertTo-UtcDateTime -Value (Get-ObjectPropertyValue -InputObject $functionPipelineStatus -Name 'updatedOnUtc')
+                    switch ([string](Get-ObjectPropertyValue -InputObject $functionPipelineStatus -Name 'status')) {
+                        'succeeded' {
+                            $functionCompletedUtc = if ($null -ne $statusCompletedUtc) { $statusCompletedUtc } else { $statusUpdatedUtc }
+                            if ($null -eq $functionCompletedUtc) {
+                                $functionCompletedUtc = $nowUtc
+                            }
+                            $functionCompleted = $true
+                            $functionStatus = 'Completed'
+                            $functionCompletionSource = 'status-blob'
+                        }
+                        'failed' {
+                            $functionCompletedUtc = if ($null -ne $statusCompletedUtc) { $statusCompletedUtc } else { $statusUpdatedUtc }
+                            if ($null -eq $functionCompletedUtc) {
+                                $functionCompletedUtc = $nowUtc
+                            }
+                            $functionCompleted = $true
+                            $functionStatus = 'Failed'
+                            $functionCompletionSource = 'status-blob'
+                        }
+                    }
+                }
+            }
+
+            if (-not $functionCompleted) {
+                $functionDashboardBlob = Get-BlobDetail -AccountName $FunctionStorageAccountName -ContainerName 'dashboards' -BlobName 'VulnerabilityDashboard.html'
+                if ($null -ne $functionDashboardBlob) {
+                    $lastModifiedUtc = ([datetimeoffset]$functionDashboardBlob.properties.lastModified).UtcDateTime
+                    if ($lastModifiedUtc -ge $functionInvokeStartedUtc.AddSeconds(-5)) {
+                        $functionDashboardCompletedUtc = $lastModifiedUtc
+                    }
                 }
             }
 
@@ -1461,6 +2057,7 @@ function Invoke-BaselineBenchmark {
                     }
                     $functionCompleted = $true
                     $functionStatus = 'Failed'
+                    $functionCompletionSource = 'trace-log'
                 }
                 elseif ($functionTraceTerminalStatus -eq 'Completed') {
                     $functionTraceCompletedUtc = @($functionEvents | Where-Object { [string]$_.message -match 'Pipeline Complete!' } | Sort-Object timestamp_utc | Select-Object -Last 1 | ForEach-Object { $_.timestamp_utc }) | Select-Object -First 1
@@ -1476,13 +2073,26 @@ function Invoke-BaselineBenchmark {
                 $functionCompletedUtc = $functionTraceCompletedUtc
                 $functionCompleted = $true
                 $functionStatus = 'FailedNoDashboard'
+                $functionCompletionSource = 'trace-log'
+            }
+
+            if ((-not $functionCompleted) -and $null -ne $functionDashboardCompletedUtc -and (($null -eq $functionPipelineStatus) -or $nowUtc -ge $functionDashboardCompletedUtc.AddMinutes(2))) {
+                $functionCompletedUtc = $functionDashboardCompletedUtc
+                $functionCompleted = $true
+                $functionStatus = 'Completed'
+                $functionCompletionSource = 'dashboard-blob'
             }
 
             if ((-not $functionCompleted) -and [datetime]::UtcNow -ge $functionDeadlineUtc) {
                 $functionCompletedUtc = [datetime]::UtcNow
                 $functionCompleted = $true
                 $functionStatus = 'TimedOut'
+                $functionCompletionSource = 'timeout'
             }
+        }
+
+        if (-not ($localState.completed -and $runbookCompleted -and $functionCompleted)) {
+            Write-BaselineBenchmarkHeartbeat -BaselineName $BaselineName -LocalState $localState -RunbookJob $runbookJob -FunctionStatus $functionStatus -FunctionInvokeStartedUtc $functionInvokeStartedUtc -FunctionExecutionActivity $functionExecutionActivity
         }
 
         if (-not ($localState.completed -and $runbookCompleted -and $functionCompleted)) {
@@ -1502,11 +2112,46 @@ function Invoke-BaselineBenchmark {
         0
     }
 
-    $functionElapsedSeconds = if ($null -ne $functionCompletedUtc) {
+    $functionEndToEndElapsedSeconds = if ($null -ne $functionCompletedUtc) {
         [math]::Round((New-TimeSpan -Start $functionInvokeStartedUtc -End $functionCompletedUtc).TotalSeconds, 2)
     }
     else {
         0
+    }
+
+    $functionActiveElapsedSeconds = if ($null -ne $functionActiveStartedUtc -and $null -ne $functionCompletedUtc) {
+        [math]::Round([math]::Max((New-TimeSpan -Start $functionActiveStartedUtc -End $functionCompletedUtc).TotalSeconds, 0), 2)
+    }
+    else {
+        $null
+    }
+
+    $functionPickupDelaySeconds = if ($null -ne $functionActiveStartedUtc) {
+        [math]::Round([math]::Max((New-TimeSpan -Start $functionInvokeStartedUtc -End $functionActiveStartedUtc).TotalSeconds, 0), 2)
+    }
+    else {
+        $null
+    }
+
+    $functionTimingBasis = if ($null -ne $functionActiveElapsedSeconds -and $functionActiveElapsedSeconds -gt 0) {
+        'active-execution'
+    }
+    else {
+        'invoke-to-finish-fallback'
+    }
+
+    $functionHeadlineElapsedSeconds = if ($functionTimingBasis -eq 'active-execution') {
+        $functionActiveElapsedSeconds
+    }
+    else {
+        $functionEndToEndElapsedSeconds
+    }
+
+    $functionMetricStartUtc = if ($null -ne $functionActiveStartedUtc) {
+        $functionActiveStartedUtc.AddMinutes(-1)
+    }
+    else {
+        $functionInvokeStartedUtc.AddMinutes(-1)
     }
 
     $functionMetricEndUtc = if ($null -ne $functionCompletedUtc) {
@@ -1516,29 +2161,40 @@ function Invoke-BaselineBenchmark {
         [datetime]::UtcNow
     }
     $functionEvents = @(Get-FunctionTraceEvents -HostName $FunctionHostName -MasterKey $effectiveFunctionMasterKey -NotBeforeUtc $functionInvokeStartedUtc)
-    $functionMetricSummary = Get-FunctionMetricSummary -ResourceId $FunctionResourceId -StartTimeUtc $functionInvokeStartedUtc.AddMinutes(-1) -EndTimeUtc $functionMetricEndUtc
+    $functionMetricSummary = Get-FunctionMetricSummary -ResourceId $FunctionResourceId -StartTimeUtc $functionMetricStartUtc -EndTimeUtc $functionMetricEndUtc
 
     $localResult = Get-LocalBenchmarkResult -State $localState -TotalRows $TotalRows
     $runbookResult = Get-PipelineEventSummary -Events $runbookEvents -TotalElapsedSeconds $runbookElapsedSeconds -DashboardBytes (Get-BlobLengthBytes -AccountName $RunbookStorageAccountName -ContainerName 'dashboards' -BlobName 'VulnerabilityDashboard.html') -TotalRows $TotalRows -TerminalStatus ([string]$runbookJob.status)
     $functionDashboardBytes = Get-BlobLengthBytes -AccountName $FunctionStorageAccountName -ContainerName 'dashboards' -BlobName 'VulnerabilityDashboard.html'
     $functionResult = [PSCustomObject]@{
         status = $functionStatus
-        elapsed_seconds = $functionElapsedSeconds
+        timing_basis = $functionTimingBasis
+        elapsed_seconds = $functionHeadlineElapsedSeconds
+        active_elapsed_seconds = $functionActiveElapsedSeconds
+        end_to_end_elapsed_seconds = $functionEndToEndElapsedSeconds
+        pickup_delay_seconds = $functionPickupDelaySeconds
         peak_working_set_mb = $functionMetricSummary.peak_working_set_mb
         average_working_set_mb = $functionMetricSummary.average_working_set_mb
         peak_cpu_percentage = $functionMetricSummary.peak_cpu_percentage
         execution_units = $functionMetricSummary.execution_units
         execution_count = if ($null -ne $functionExecutionActivity) { $functionExecutionActivity.total_count } else { 0 }
-        rows_per_second = if ($functionElapsedSeconds -gt 0 -and $TotalRows -gt 0) { [math]::Round(($TotalRows / $functionElapsedSeconds), 0) } else { 0 }
+        rows_per_second = if ($functionHeadlineElapsedSeconds -gt 0 -and $TotalRows -gt 0) { [math]::Round(($TotalRows / $functionHeadlineElapsedSeconds), 0) } else { 0 }
+        end_to_end_rows_per_second = if ($functionEndToEndElapsedSeconds -gt 0 -and $TotalRows -gt 0) { [math]::Round(($TotalRows / $functionEndToEndElapsedSeconds), 0) } else { 0 }
         dashboard_bytes = $functionDashboardBytes
         dashboard_mb = [math]::Round(($functionDashboardBytes / 1MB), 2)
+        invoke_started_utc = $functionInvokeStartedUtc
+        active_started_utc = $functionActiveStartedUtc
         completion_utc = $functionCompletedUtc
+        completion_source = $functionCompletionSource
+        status_stage = [string](Get-ObjectPropertyValue -InputObject $functionPipelineStatus -Name 'stage')
+        status_message = [string](Get-ObjectPropertyValue -InputObject $functionPipelineStatus -Name 'message')
     }
 
     return [PSCustomObject]@{
         baseline = $BaselineName
         repo_path = $RepoPath
         local = $localResult
+        local_persistent_cache = $localPersistentCacheResult
         runbook = $runbookResult
         function_app = $functionResult
         runbook_job_name = $runbookState.name
@@ -1613,21 +2269,78 @@ function Get-ComparisonBlock {
             peak_rss_gb_delta = [math]::Round(($Current.local.peak_tree_rss_gb - $Main.local.peak_tree_rss_gb), 3)
             peak_private_gb_delta = [math]::Round(($Current.local.peak_tree_private_gb - $Main.local.peak_tree_private_gb), 3)
         }
-        runbook = [PSCustomObject]@{
-            elapsed_seconds_delta = [math]::Round(($Current.runbook.elapsed_seconds - $Main.runbook.elapsed_seconds), 2)
-            peak_working_set_mb_delta = [math]::Round(($Current.runbook.peak_working_set_mb - $Main.runbook.peak_working_set_mb), 1)
-            peak_gc_heap_mb_delta = [math]::Round(($Current.runbook.peak_gc_heap_mb - $Main.runbook.peak_gc_heap_mb), 1)
+        local_persistent_cache = if ($Current.PSObject.Properties['local_persistent_cache'] -and $Main.PSObject.Properties['local_persistent_cache'] -and $null -ne $Current.local_persistent_cache -and $null -ne $Main.local_persistent_cache) {
+            [PSCustomObject]@{
+                prime_elapsed_seconds_delta = [math]::Round(($Current.local_persistent_cache.prime.elapsed_seconds - $Main.local_persistent_cache.prime.elapsed_seconds), 2)
+                reuse_elapsed_seconds_delta = [math]::Round(($Current.local_persistent_cache.reuse_after_payload_eviction.elapsed_seconds - $Main.local_persistent_cache.reuse_after_payload_eviction.elapsed_seconds), 2)
+                reuse_normalize_phase_delta = if (
+                    $null -ne (Get-PhaseElapsedSecondsValue -Result $Current.local_persistent_cache.reuse_after_payload_eviction -PhaseName 'Normalize source data') -and
+                    $null -ne (Get-PhaseElapsedSecondsValue -Result $Main.local_persistent_cache.reuse_after_payload_eviction -PhaseName 'Normalize source data')
+                ) {
+                    [math]::Round(((Get-PhaseElapsedSecondsValue -Result $Current.local_persistent_cache.reuse_after_payload_eviction -PhaseName 'Normalize source data') - (Get-PhaseElapsedSecondsValue -Result $Main.local_persistent_cache.reuse_after_payload_eviction -PhaseName 'Normalize source data')), 2)
+                }
+                else {
+                    $null
+                }
+            }
         }
-        function_app = [PSCustomObject]@{
-            elapsed_seconds_delta = [math]::Round(($Current.function_app.elapsed_seconds - $Main.function_app.elapsed_seconds), 2)
-            peak_working_set_mb_delta = [math]::Round(($Current.function_app.peak_working_set_mb - $Main.function_app.peak_working_set_mb), 1)
-            execution_units_delta = [math]::Round(($Current.function_app.execution_units - $Main.function_app.execution_units), 2)
+        else {
+            $null
+        }
+        runbook = if ($null -ne $Current.runbook -and $null -ne $Main.runbook) {
+            [PSCustomObject]@{
+                elapsed_seconds_delta = [math]::Round(($Current.runbook.elapsed_seconds - $Main.runbook.elapsed_seconds), 2)
+                peak_working_set_mb_delta = [math]::Round(($Current.runbook.peak_working_set_mb - $Main.runbook.peak_working_set_mb), 1)
+                peak_gc_heap_mb_delta = [math]::Round(($Current.runbook.peak_gc_heap_mb - $Main.runbook.peak_gc_heap_mb), 1)
+            }
+        }
+        else {
+            $null
+        }
+        function_app = if ($null -ne $Current.function_app -and $null -ne $Main.function_app) {
+            [PSCustomObject]@{
+                elapsed_seconds_delta = [math]::Round(($Current.function_app.elapsed_seconds - $Main.function_app.elapsed_seconds), 2)
+                active_elapsed_seconds_delta = if ($null -ne $Current.function_app.active_elapsed_seconds -and $null -ne $Main.function_app.active_elapsed_seconds) {
+                    [math]::Round(($Current.function_app.active_elapsed_seconds - $Main.function_app.active_elapsed_seconds), 2)
+                }
+                else {
+                    $null
+                }
+                end_to_end_elapsed_seconds_delta = if ($null -ne $Current.function_app.end_to_end_elapsed_seconds -and $null -ne $Main.function_app.end_to_end_elapsed_seconds) {
+                    [math]::Round(($Current.function_app.end_to_end_elapsed_seconds - $Main.function_app.end_to_end_elapsed_seconds), 2)
+                }
+                else {
+                    $null
+                }
+                pickup_delay_seconds_delta = if ($null -ne $Current.function_app.pickup_delay_seconds -and $null -ne $Main.function_app.pickup_delay_seconds) {
+                    [math]::Round(($Current.function_app.pickup_delay_seconds - $Main.function_app.pickup_delay_seconds), 2)
+                }
+                else {
+                    $null
+                }
+                peak_working_set_mb_delta = [math]::Round(($Current.function_app.peak_working_set_mb - $Main.function_app.peak_working_set_mb), 1)
+                execution_units_delta = [math]::Round(($Current.function_app.execution_units - $Main.function_app.execution_units), 2)
+            }
+        }
+        else {
+            $null
         }
     }
 }
 
+$repoRoot = Split-Path -Path $PSScriptRoot -Parent
 $resolvedCurrentRepoPath = [System.IO.Path]::GetFullPath($CurrentRepoPath)
-$resolvedDatasetPath = [System.IO.Path]::GetFullPath($DatasetPath)
+$datasetDefinition = if (-not [string]::IsNullOrWhiteSpace($BenchmarkDatasetId)) { Get-BenchmarkDatasetDefinition -DatasetId $BenchmarkDatasetId -RepoRoot $repoRoot } else { $null }
+if (-not [string]::IsNullOrWhiteSpace($BenchmarkDatasetId) -and $null -eq $datasetDefinition) {
+    throw "Benchmark dataset definition '$BenchmarkDatasetId' was not found."
+}
+
+$resolvedDatasetPath = if ($null -ne $datasetDefinition -and -not $PSBoundParameters.ContainsKey('DatasetPath')) {
+    Resolve-BenchmarkDatasetOutputPath -Definition $datasetDefinition -RepoRoot $repoRoot
+}
+else {
+    [System.IO.Path]::GetFullPath($DatasetPath)
+}
 $resolvedResultsOutputPath = [System.IO.Path]::GetFullPath($ResultsOutputPath)
 $outputDirectory = Split-Path -Path $resolvedResultsOutputPath -Parent
 
@@ -1661,54 +2374,80 @@ $datasetPreflight = Assert-BenchmarkDatasetReady `
     -MinimumFreeDiskGB $MinimumFreeDiskGB
 
 $datasetManifest = $datasetPreflight.manifest
+$datasetDefinitionMatch = if ($null -ne $datasetDefinition) { Test-BenchmarkDatasetDefinitionMatch -Definition $datasetDefinition -Manifest $datasetManifest } else { $false }
+if ($null -ne $datasetDefinition -and -not $datasetDefinitionMatch) {
+    throw ("Dataset '{0}' does not match benchmark dataset definition '{1}'." -f $resolvedDatasetPath, $BenchmarkDatasetId)
+}
+
+$datasetDefinitionMetadata = Get-BenchmarkDatasetResultMetadata -DatasetPath $resolvedDatasetPath -Manifest $datasetManifest -BenchmarkDatasetId $BenchmarkDatasetId -RepoRoot $repoRoot
 $totalRows = [int]$datasetPreflight.totalRows
 
 Write-Host ("Dataset preflight passed: {0} rows, {1:N2} GB on disk, {2} GB free memory, {3} GB free disk." -f $totalRows, ($datasetPreflight.datasetBytes / 1GB), $datasetPreflight.availableMemoryGB, $datasetPreflight.freeDiskGB)
 
-$subscription = Invoke-AzCli -Arguments @('account', 'show', '-o', 'json') -ExpectJson
-$functionHostName = Get-FunctionHostName
-$functionResourceId = Get-FunctionResourceId
-$originalFunctionTraceSetting = Get-FunctionTraceSetting
+$subscription = if ($LocalOnly) { $null } else { Invoke-AzCli -Arguments @('account', 'show', '-o', 'json') -ExpectJson }
+$functionHostName = if ($LocalOnly) { $null } else { Get-FunctionHostName }
+$functionResourceId = if ($LocalOnly) { $null } else { Get-FunctionResourceId }
+$originalFunctionTraceSetting = if ($LocalOnly) { $null } else { Get-FunctionTraceSetting }
 
 $currentResult = $null
 $mainResult = $null
 
 try {
-    $functionMasterKey = Get-FunctionMasterKey
-    Wait-FunctionHostReady -HostName $functionHostName -MasterKey $functionMasterKey
+    if (-not $LocalOnly) {
+        $functionMasterKey = Get-FunctionMasterKey
+        Wait-FunctionHostReady -HostName $functionHostName -MasterKey $functionMasterKey
+    }
 
-    $currentResult = @(Invoke-BaselineBenchmark -BaselineName $CurrentBaselineName -RepoPath $resolvedCurrentRepoPath -DatasetRoot $resolvedDatasetPath -OutputRoot $outputDirectory -FunctionHostName $functionHostName -FunctionResourceId $functionResourceId -SubscriptionId ([string]$subscription.id) -TotalRows $totalRows) | Select-Object -Last 1
+    $currentResult = @(Invoke-BaselineBenchmark -BaselineName $CurrentBaselineName -RepoPath $resolvedCurrentRepoPath -DatasetRoot $resolvedDatasetPath -OutputRoot $outputDirectory -FunctionHostName $functionHostName -FunctionResourceId $functionResourceId -SubscriptionId $(if ($LocalOnly) { '' } else { [string]$subscription.id }) -TotalRows $totalRows -LocalOnly:$LocalOnly -IncludePersistentLocalWorkflow:$IncludePersistentLocalWorkflow) | Select-Object -Last 1
     $currentResult | ConvertTo-Json -Depth 10 | Set-Content -LiteralPath (Join-Path -Path $outputDirectory -ChildPath ($CurrentBaselineName + '.result.json')) -Encoding utf8
 
     if (-not $CurrentOnly) {
-        $functionMasterKey = Get-FunctionMasterKey
-        Wait-FunctionHostReady -HostName $functionHostName -MasterKey $functionMasterKey
+        if (-not $LocalOnly) {
+            $functionMasterKey = Get-FunctionMasterKey
+            Wait-FunctionHostReady -HostName $functionHostName -MasterKey $functionMasterKey
+        }
 
-        $mainResult = @(Invoke-BaselineBenchmark -BaselineName $MainBaselineName -RepoPath $resolvedMainRepoPath -DatasetRoot $resolvedDatasetPath -OutputRoot $outputDirectory -FunctionHostName $functionHostName -FunctionResourceId $functionResourceId -SubscriptionId ([string]$subscription.id) -TotalRows $totalRows) | Select-Object -Last 1
+        $mainResult = @(Invoke-BaselineBenchmark -BaselineName $MainBaselineName -RepoPath $resolvedMainRepoPath -DatasetRoot $resolvedDatasetPath -OutputRoot $outputDirectory -FunctionHostName $functionHostName -FunctionResourceId $functionResourceId -SubscriptionId $(if ($LocalOnly) { '' } else { [string]$subscription.id }) -TotalRows $totalRows -LocalOnly:$LocalOnly -IncludePersistentLocalWorkflow:$IncludePersistentLocalWorkflow) | Select-Object -Last 1
         $mainResult | ConvertTo-Json -Depth 10 | Set-Content -LiteralPath (Join-Path -Path $outputDirectory -ChildPath ($MainBaselineName + '.result.json')) -Encoding utf8
     }
 }
 finally {
-    try {
-        if (-not $SkipRestoreCurrentDeployment) {
-            Restore-CurrentAzureDeployment -RepoPath $resolvedCurrentRepoPath
+    if (-not $LocalOnly) {
+        try {
+            if (-not $SkipRestoreCurrentDeployment) {
+                Restore-CurrentAzureDeployment -RepoPath $resolvedCurrentRepoPath
+            }
         }
-    }
-    finally {
-        Restore-FunctionTraceSetting -OriginalValue $originalFunctionTraceSetting
+        finally {
+            Restore-FunctionTraceSetting -OriginalValue $originalFunctionTraceSetting
+        }
     }
 }
 
 $result = [PSCustomObject]@{
+    benchmark_schema_version = 2
     generated_utc = [datetime]::UtcNow.ToString('o')
-    benchmark_mode = if ($CurrentOnly) { 'current-only' } else { 'branch-vs-main' }
-    subscription = [PSCustomObject]@{
-        id = [string]$subscription.id
-        name = [string]$subscription.name
-        tenantId = [string]$subscription.tenantId
+    benchmark_mode = if ($LocalOnly) {
+        if ($CurrentOnly) { 'local-current-only' } else { 'local-branch-vs-main' }
+    }
+    else {
+        if ($CurrentOnly) { 'current-only' } else { 'branch-vs-main' }
+    }
+    local_only = ($LocalOnly -eq $true)
+    persistent_local_workflow = ($IncludePersistentLocalWorkflow -eq $true)
+    subscription = if ($null -ne $subscription) {
+        [PSCustomObject]@{
+            id = [string]$subscription.id
+            name = [string]$subscription.name
+            tenantId = [string]$subscription.tenantId
+        }
+    }
+    else {
+        $null
     }
     dataset = [PSCustomObject]@{
         path = $resolvedDatasetPath
+        definition = $datasetDefinitionMetadata
         files = @(Get-DatasetFiles -Path $resolvedDatasetPath | ForEach-Object { $_.Name })
         manifest = $datasetManifest
         total_rows = $totalRows
@@ -1730,8 +2469,30 @@ $result | ConvertTo-Json -Depth 10 | Set-Content -LiteralPath $resolvedResultsOu
 Write-Host ''
 Write-Host ('Benchmark report: {0}' -f $resolvedResultsOutputPath) -ForegroundColor Green
 if ($null -ne $currentResult) {
-    Write-Host ('{0} local/runbook/function elapsed: {1}s / {2}s / {3}s' -f $CurrentBaselineName, $currentResult.local.elapsed_seconds, $currentResult.runbook.elapsed_seconds, $currentResult.function_app.elapsed_seconds)
+    if ($LocalOnly) {
+        Write-Host ('{0} local elapsed: {1}s' -f $CurrentBaselineName, $currentResult.local.elapsed_seconds)
+    }
+    else {
+        Write-Host ('{0} local/runbook/function elapsed: {1}s / {2}s / {3}s ({4})' -f $CurrentBaselineName, $currentResult.local.elapsed_seconds, $currentResult.runbook.elapsed_seconds, $currentResult.function_app.elapsed_seconds, $currentResult.function_app.timing_basis)
+        if ($null -ne $currentResult.function_app.end_to_end_elapsed_seconds) {
+            Write-Host ('{0} function end-to-end/pickup delay: {1}s / {2}s' -f $CurrentBaselineName, $currentResult.function_app.end_to_end_elapsed_seconds, $currentResult.function_app.pickup_delay_seconds)
+        }
+    }
+    if ($null -ne $currentResult.local_persistent_cache) {
+        Write-Host ('{0} persistent local prime/reuse elapsed: {1}s / {2}s' -f $CurrentBaselineName, $currentResult.local_persistent_cache.prime.elapsed_seconds, $currentResult.local_persistent_cache.reuse_after_payload_eviction.elapsed_seconds)
+    }
 }
 if ($null -ne $mainResult) {
-    Write-Host ('{0} local/runbook/function elapsed: {1}s / {2}s / {3}s' -f $MainBaselineName, $mainResult.local.elapsed_seconds, $mainResult.runbook.elapsed_seconds, $mainResult.function_app.elapsed_seconds)
+    if ($LocalOnly) {
+        Write-Host ('{0} local elapsed: {1}s' -f $MainBaselineName, $mainResult.local.elapsed_seconds)
+    }
+    else {
+        Write-Host ('{0} local/runbook/function elapsed: {1}s / {2}s / {3}s ({4})' -f $MainBaselineName, $mainResult.local.elapsed_seconds, $mainResult.runbook.elapsed_seconds, $mainResult.function_app.elapsed_seconds, $mainResult.function_app.timing_basis)
+        if ($null -ne $mainResult.function_app.end_to_end_elapsed_seconds) {
+            Write-Host ('{0} function end-to-end/pickup delay: {1}s / {2}s' -f $MainBaselineName, $mainResult.function_app.end_to_end_elapsed_seconds, $mainResult.function_app.pickup_delay_seconds)
+        }
+    }
+    if ($null -ne $mainResult.local_persistent_cache) {
+        Write-Host ('{0} persistent local prime/reuse elapsed: {1}s / {2}s' -f $MainBaselineName, $mainResult.local_persistent_cache.prime.elapsed_seconds, $mainResult.local_persistent_cache.reuse_after_payload_eviction.elapsed_seconds)
+    }
 }

--- a/tests/Measure-StressRun.ps1
+++ b/tests/Measure-StressRun.ps1
@@ -41,6 +41,80 @@ function Get-AvailableMemoryGB {
     return [math]::Round(($os.FreePhysicalMemory / 1MB), 2)
 }
 
+function Get-HeartbeatTimestampText {
+    [CmdletBinding()]
+    [OutputType([string])]
+    param()
+
+    return (Get-Date).ToString('yyyy-MM-dd HH:mm:ss')
+}
+
+function Get-HeartbeatFileStatus {
+    [CmdletBinding()]
+    [OutputType([pscustomobject])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Path
+    )
+
+    if (-not (Test-Path -LiteralPath $Path -PathType Leaf)) {
+        return [PSCustomObject]@{
+            bytes = 0L
+            ageSeconds = $null
+        }
+    }
+
+    $item = Get-Item -LiteralPath $Path
+    return [PSCustomObject]@{
+        bytes = [int64]$item.Length
+        ageSeconds = [math]::Round(((Get-Date).ToUniversalTime() - $item.LastWriteTimeUtc).TotalSeconds, 1)
+    }
+}
+
+function Write-StressHeartbeat {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Name,
+
+        [Parameter(Mandatory = $true)]
+        [System.Diagnostics.Stopwatch]$Stopwatch,
+
+        [Parameter(Mandatory = $false)]
+        [System.Collections.Generic.List[object]]$Samples,
+
+        [Parameter(Mandatory = $true)]
+        [string]$StdoutPath,
+
+        [Parameter(Mandatory = $true)]
+        [string]$DashboardPath,
+
+        [Parameter(Mandatory = $true)]
+        [int64]$PeakRssBytes,
+
+        [Parameter(Mandatory = $true)]
+        [int64]$PeakPrivateBytes
+    )
+
+    $lastSample = if ($null -ne $Samples -and $Samples.Count -gt 0) { $Samples[$Samples.Count - 1] } else { $null }
+    $stdoutStatus = Get-HeartbeatFileStatus -Path $StdoutPath
+    $availableMemory = if ($null -ne $lastSample) { [double]$lastSample.available_memory_gb } else { Get-AvailableMemoryGB }
+    $stdoutAgeText = if ($null -ne $stdoutStatus.ageSeconds) { ('{0:N1}s' -f $stdoutStatus.ageSeconds) } else { 'n/a' }
+
+    $message = "[{0}] Stress heartbeat ({1}): elapsed={2} peak-rss={3}GB peak-private={4}GB available={5}GB dashboard-exists={6} stdout-bytes={7} stdout-age={8}" -f @(
+        (Get-HeartbeatTimestampText)
+        $Name
+        $Stopwatch.Elapsed.ToString('hh\:mm\:ss')
+        [math]::Round(($PeakRssBytes / 1GB), 3)
+        [math]::Round(($PeakPrivateBytes / 1GB), 3)
+        $availableMemory
+        (Test-Path -LiteralPath $DashboardPath -PathType Leaf)
+        $stdoutStatus.bytes
+        $stdoutAgeText
+    )
+    Write-Output $message
+}
+
 function Get-ProcessTree {
     [CmdletBinding()]
     [OutputType([System.Diagnostics.Process[]])]
@@ -210,11 +284,15 @@ function Add-MeasurementSample {
 }
 
 Add-MeasurementSample -Samples $samples -Process $process -Stopwatch $stopwatch -PeakRssBytes ([ref]$peakRssBytes) -PeakRssAt ([ref]$peakRssAt) -PeakPrivateBytes ([ref]$peakPrivateBytes) -PeakPrivateAt ([ref]$peakPrivateAt)
+Write-StressHeartbeat -Name $Name -Stopwatch $stopwatch -Samples $samples -StdoutPath $stdoutPath -DashboardPath $resolvedDashboardPath -PeakRssBytes $peakRssBytes -PeakPrivateBytes $peakPrivateBytes
 
 while (-not $process.HasExited) {
     Start-Sleep -Seconds $PollIntervalSeconds
     $process.Refresh()
     Add-MeasurementSample -Samples $samples -Process $process -Stopwatch $stopwatch -PeakRssBytes ([ref]$peakRssBytes) -PeakRssAt ([ref]$peakRssAt) -PeakPrivateBytes ([ref]$peakPrivateBytes) -PeakPrivateAt ([ref]$peakPrivateAt)
+    if (-not $process.HasExited) {
+        Write-StressHeartbeat -Name $Name -Stopwatch $stopwatch -Samples $samples -StdoutPath $stdoutPath -DashboardPath $resolvedDashboardPath -PeakRssBytes $peakRssBytes -PeakPrivateBytes $peakPrivateBytes
+    }
 }
 
 $process.WaitForExit()

--- a/tests/New-BenchmarkDataset.ps1
+++ b/tests/New-BenchmarkDataset.ps1
@@ -1,0 +1,106 @@
+﻿#Requires -Version 7.0
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $false)]
+    [string]$DatasetId = 'benchmark-medium-v1',
+
+    [Parameter(Mandatory = $false)]
+    [string]$OutputPath,
+
+    [Parameter(Mandatory = $false)]
+    [ValidateRange(0.5, 256.0)]
+    [double]$MinimumAvailableMemoryGB = 3,
+
+    [Parameter(Mandatory = $false)]
+    [ValidateRange(1, 2048)]
+    [int]$MinimumFreeDiskGB = 10,
+
+    [Parameter(Mandatory = $false)]
+    [switch]$Force
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+. (Join-Path $PSScriptRoot 'Import-BenchmarkDatasetCatalog.ps1')
+
+$repoRoot = Split-Path -Path $PSScriptRoot -Parent
+$definition = Get-BenchmarkDatasetDefinition -DatasetId $DatasetId -RepoRoot $repoRoot
+if ($null -eq $definition) {
+    throw "Benchmark dataset definition '$DatasetId' was not found."
+}
+
+$resolvedOutputPath = if ([string]::IsNullOrWhiteSpace($OutputPath)) {
+    Resolve-BenchmarkDatasetOutputPath -Definition $definition -RepoRoot $repoRoot
+}
+else {
+    [System.IO.Path]::GetFullPath($OutputPath)
+}
+
+$manifestPath = Join-Path $resolvedOutputPath 'synthetic-manifest.json'
+$metadataPath = Get-BenchmarkDatasetMetadataPath -DatasetPath $resolvedOutputPath
+
+if ((-not $Force) -and (Test-Path -LiteralPath $manifestPath -PathType Leaf)) {
+    $existingManifest = Get-Content -LiteralPath $manifestPath -Raw | ConvertFrom-Json -Depth 20
+    if (Test-BenchmarkDatasetDefinitionMatch -Definition $definition -Manifest $existingManifest) {
+        if (-not (Test-Path -LiteralPath $metadataPath -PathType Leaf)) {
+            $metadata = [ordered]@{
+                id = [string]$definition.id
+                description = [string]$definition.description
+                preset = [string]$definition.preset
+                seed = [int]$definition.seed
+                targetDeviceCount = [int]$definition.targetDeviceCount
+                targetTotalVulnRows = [int]$definition.targetTotalVulnRows
+                sourcePath = Resolve-BenchmarkDatasetSourcePath -Definition $definition -RepoRoot $repoRoot
+                datasetPath = $resolvedOutputPath
+                generatedBy = 'New-BenchmarkDataset.ps1'
+                generatedOnUtc = [datetime]::UtcNow.ToString('o')
+                historyTags = @($definition.historyTags)
+            }
+            $metadata | ConvertTo-Json -Depth 20 | Set-Content -LiteralPath $metadataPath -Encoding utf8
+        }
+
+        Write-Host ('Benchmark dataset already present: {0}' -f $resolvedOutputPath) -ForegroundColor Green
+        return
+    }
+}
+
+$sourcePath = Resolve-BenchmarkDatasetSourcePath -Definition $definition -RepoRoot $repoRoot
+$generatorScriptPath = Join-Path $repoRoot 'tests\Generate-SyntheticLargeExports.ps1'
+
+if (-not (Test-Path -LiteralPath $generatorScriptPath -PathType Leaf)) {
+    throw "Synthetic dataset generator not found: $generatorScriptPath"
+}
+
+if ((Test-Path -LiteralPath $resolvedOutputPath) -and $Force) {
+    Remove-Item -LiteralPath $resolvedOutputPath -Recurse -Force -ErrorAction SilentlyContinue
+}
+
+& $generatorScriptPath `
+    -Preset ([string]$definition.preset) `
+    -SourcePath $sourcePath `
+    -OutputPath $resolvedOutputPath `
+    -TargetDeviceCount ([int]$definition.targetDeviceCount) `
+    -TargetTotalVulnRows ([int]$definition.targetTotalVulnRows) `
+    -Seed ([int]$definition.seed) `
+    -MinimumAvailableMemoryGB $MinimumAvailableMemoryGB `
+    -MinimumFreeDiskGB $MinimumFreeDiskGB `
+    -CleanOutput
+
+$metadata = [ordered]@{
+    id = [string]$definition.id
+    description = [string]$definition.description
+    preset = [string]$definition.preset
+    seed = [int]$definition.seed
+    targetDeviceCount = [int]$definition.targetDeviceCount
+    targetTotalVulnRows = [int]$definition.targetTotalVulnRows
+    sourcePath = $sourcePath
+    datasetPath = $resolvedOutputPath
+    generatedBy = 'New-BenchmarkDataset.ps1'
+    generatedOnUtc = [datetime]::UtcNow.ToString('o')
+    historyTags = @($definition.historyTags)
+}
+$metadata | ConvertTo-Json -Depth 20 | Set-Content -LiteralPath $metadataPath -Encoding utf8
+
+Write-Host ('Benchmark dataset ready: {0}' -f $resolvedOutputPath) -ForegroundColor Green

--- a/tests/README.md
+++ b/tests/README.md
@@ -70,6 +70,7 @@ That command:
 - regenerates the synthetic exports
 - runs `Generate-VulnerabilityDashboard.ps1` against them
 - writes `synthetic-manifest.json` and `stress-validation-report.json` under `exports-synthetic/`
+- writes `dashboard-audit.json` under `exports-synthetic/` when `-Validate` is set
 
 Supported presets:
 - `DeviceCardinalityFirst`
@@ -91,7 +92,74 @@ Defaults:
 
 `-SkipContentStoreSidecars` keeps the output in raw-export form so downstream validation paths can rebuild sidecars on demand.
 
+## Hot phase review
+
+Review the local generator and validation hot phases with:
+
+```powershell
+pwsh -NoProfile -File .\tests\Invoke-HotPhaseReview.ps1 -DirectoryPath .\exports
+```
+
+That command:
+- runs `Generate-VulnerabilityDashboard.ps1` with validation enabled
+- captures local process memory samples plus the generator stdout and stderr logs
+- parses the local phase markers emitted by `Generate-VulnerabilityDashboard.ps1`
+- extracts the audit `PhaseTimings` block for any validation mode and falls back to `SemanticParity.PhaseTimings` for older audit shapes
+- writes `hot-phase-review.json` under `.local/hot-phase-review/<timestamp>/`
+
+Long-running review, stress, and benchmark wrappers now emit timestamped heartbeat lines at their poll interval so you can confirm they are still making progress even when the child process is temporarily quiet.
+
+Use a smaller synthetic dataset while iterating, then move to the benchmark and Azure validation entrypoints once the local hot phases improve.
+
+## Validation mode comparison
+
+Split packaging, full validation, and attested validation into separate measured runs with:
+
+```powershell
+pwsh -NoProfile -File .\tests\Invoke-ValidationModeComparison.ps1 -DirectoryPath .\exports
+```
+
+That command:
+- warms a reusable normalized payload artifact with `-NormalizeOnly`
+- measures `-PackageOnly` against that payload artifact
+- measures `-ValidateOnly -ForceFullValidation` and the attested `-ValidateOnly` fast path against the same packaged dashboard
+- measures end-to-end `-Validate -ForceFullValidation` and the default `-Validate` path
+- writes `validation-mode-comparison.json` under `.local/validation-mode-comparison/<timestamp>/`
+
+Use this workflow when validation is the dominant hot phase and you need to distinguish package cost from semantic replay cost.
+
 ## Benchmarking
+
+Create or refresh the durable benchmark dataset with:
+
+```powershell
+pwsh -NoProfile -File .\tests\New-BenchmarkDataset.ps1 -DatasetId benchmark-medium-v1
+```
+
+That dataset definition currently maps to:
+- dataset id: `benchmark-medium-v1`
+- preset: `BalancedMediumHeavy`
+- target devices: `1,500`
+- target vulnerability rows: `120,000`
+- seed: `20260322`
+- output path: `.local\benchmark-datasets\benchmark-medium-v1`
+
+Capture a repeatable multi-run benchmark series against the standard dataset with:
+
+```powershell
+pwsh -NoProfile -File .\tests\Invoke-BenchmarkSeries.ps1 -BenchmarkDatasetId benchmark-medium-v1 -Iterations 3 -IncludePersistentLocalWorkflow
+```
+
+That command:
+- ensures the durable benchmark dataset exists
+- records each benchmark JSON under `.local\benchmark-series\`
+- appends each run to `.local\benchmark-history\benchmark-history.jsonl`
+- writes aggregate `series-summary.json` and `series-summary.md` artifacts
+
+Function App timing semantics:
+- `function_app.elapsed_seconds` now tracks active execution time when the runtime status blob is available
+- `function_app.end_to_end_elapsed_seconds` retains invoke-to-finish timing for queue and cold-start review
+- `function_app.pickup_delay_seconds` records the gap between admin invocation and active execution start
 
 Capture a current-branch-only benchmark baseline with:
 
@@ -100,7 +168,15 @@ $stamp = Get-Date -Format 'yyyyMMdd-HHmmss'
 pwsh -NoProfile -File .\tests\Measure-BranchVsMainBenchmark.ps1 -CurrentOnly -CurrentBaselineName 'current-live' -DatasetPath .\exports-synthetic-live -ResultsOutputPath (Join-Path $PWD ('.local\current-baseline-live-' + $stamp + '.json'))
 ```
 
+Append a normalized local history entry after a benchmark completes with:
+
+```powershell
+pwsh -NoProfile -File .\tests\Record-BenchmarkHistory.ps1 -BenchmarkResultPath .\.local\current-baseline-live-<timestamp>.json
+```
+
 Recommendations:
 - keep raw benchmark outputs under `.local/`
+- use `.local\benchmark-history\benchmark-history.jsonl` plus `.local\benchmark-history\latest-summary.md` for repeated review and Azure acceptance captures that you want to compare over time
+- prefer `benchmark-medium-v1` plus `Invoke-BenchmarkSeries.ps1` when you need the durable, merge-tracked benchmark cadence instead of an ad hoc review capture
 - use the staged local copy behavior in `Measure-BranchVsMainBenchmark.ps1` when benchmarking raw datasets without sidecars
-- use `docs/performance-baselines.md` for the merge-tracked summary of recorded baseline numbers
+- use `docs/performance-baselines.md` only for accepted durable datasets that should remain merge-tracked as baseline documentation

--- a/tests/Record-BenchmarkHistory.ps1
+++ b/tests/Record-BenchmarkHistory.ps1
@@ -1,0 +1,522 @@
+﻿#Requires -Version 7.0
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$BenchmarkResultPath,
+
+    [Parameter(Mandatory = $false)]
+    [string]$HistoryPath = (Join-Path (Split-Path -Path $PSScriptRoot -Parent) '.local\benchmark-history\benchmark-history.jsonl'),
+
+    [Parameter(Mandatory = $false)]
+    [string]$SummaryOutputPath = (Join-Path (Split-Path -Path $PSScriptRoot -Parent) '.local\benchmark-history\latest-summary.md'),
+
+    [Parameter(Mandatory = $false, ValueFromRemainingArguments = $true)]
+    [string[]]$Tags = @()
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+. (Join-Path $PSScriptRoot 'Import-BenchmarkDatasetCatalog.ps1')
+
+function Get-ObjectPropertyValue {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $false)]
+        [AllowNull()]
+        $InputObject,
+
+        [Parameter(Mandatory = $true)]
+        [string]$Name
+    )
+
+    if ($null -eq $InputObject) {
+        return $null
+    }
+
+    $property = $InputObject.PSObject.Properties[$Name]
+    if ($null -eq $property) {
+        return $null
+    }
+
+    return $property.Value
+}
+
+function Format-DateTimeValue {
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory = $false)]
+        [AllowNull()]
+        $Value
+    )
+
+    if ($null -eq $Value) {
+        return $null
+    }
+
+    if ($Value -is [datetime]) {
+        return ([datetime]$Value).ToString('o')
+    }
+
+    if ($Value -is [datetimeoffset]) {
+        return ([datetimeoffset]$Value).ToString('o')
+    }
+
+    $text = [string]$Value
+    if ([string]::IsNullOrWhiteSpace($text)) {
+        return $null
+    }
+
+    $parsed = [datetimeoffset]::MinValue
+    if ([datetimeoffset]::TryParse($text, [ref]$parsed)) {
+        return $parsed.ToString('o')
+    }
+
+    return $text
+}
+
+function Invoke-GitText {
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$RepoPath,
+
+        [Parameter(Mandatory = $true)]
+        [string[]]$Arguments
+    )
+
+    if (-not (Test-Path -LiteralPath $RepoPath -PathType Container)) {
+        return $null
+    }
+
+    $output = (& git -C $RepoPath @Arguments 2>$null | Out-String)
+    if ($LASTEXITCODE -ne 0) {
+        return $null
+    }
+
+    $trimmed = $output.Trim()
+    if ([string]::IsNullOrWhiteSpace($trimmed)) {
+        return $null
+    }
+
+    return $trimmed
+}
+
+function Get-RepoSnapshot {
+    [CmdletBinding()]
+    [OutputType([pscustomobject])]
+    param(
+        [Parameter(Mandatory = $false)]
+        [AllowEmptyString()]
+        [string]$RepoPath
+    )
+
+    if ([string]::IsNullOrWhiteSpace($RepoPath)) {
+        return $null
+    }
+
+    $resolvedRepoPath = [System.IO.Path]::GetFullPath($RepoPath)
+    $branch = Invoke-GitText -RepoPath $resolvedRepoPath -Arguments @('rev-parse', '--abbrev-ref', 'HEAD')
+    $commit = Invoke-GitText -RepoPath $resolvedRepoPath -Arguments @('rev-parse', 'HEAD')
+    $commitShort = Invoke-GitText -RepoPath $resolvedRepoPath -Arguments @('rev-parse', '--short', 'HEAD')
+    $status = Invoke-GitText -RepoPath $resolvedRepoPath -Arguments @('status', '--short', '--untracked-files=no')
+
+    return [PSCustomObject]@{
+        repo_path = $resolvedRepoPath
+        branch = $branch
+        commit = $commit
+        commit_short = $commitShort
+        dirty = (-not [string]::IsNullOrWhiteSpace($status))
+    }
+}
+
+function Get-DatasetSummary {
+    [CmdletBinding()]
+    [OutputType([pscustomobject])]
+    param(
+        [Parameter(Mandatory = $true)]
+        $Result
+    )
+
+    $dataset = Get-ObjectPropertyValue -InputObject $Result -Name 'dataset'
+    $manifest = Get-ObjectPropertyValue -InputObject $dataset -Name 'manifest'
+    $definition = Get-ObjectPropertyValue -InputObject $dataset -Name 'definition'
+    $datasetPath = [string](Get-ObjectPropertyValue -InputObject $dataset -Name 'path')
+    $datasetLeaf = if ([string]::IsNullOrWhiteSpace($datasetPath)) { $null } else { Split-Path -Path $datasetPath -Leaf }
+    $preset = [string](Get-ObjectPropertyValue -InputObject $manifest -Name 'preset')
+    $totalRows = Get-ObjectPropertyValue -InputObject $dataset -Name 'total_rows'
+    $actualDeviceCount = Get-ObjectPropertyValue -InputObject $manifest -Name 'actualDeviceCount'
+    $definitionId = [string](Get-ObjectPropertyValue -InputObject $definition -Name 'id')
+
+    if ([string]::IsNullOrWhiteSpace($definitionId) -and $null -ne $manifest) {
+        $resolvedDefinition = Find-BenchmarkDatasetDefinitionForManifest -Manifest $manifest
+        if ($null -ne $resolvedDefinition) {
+            $definitionId = [string]$resolvedDefinition.id
+            $definition = $resolvedDefinition
+        }
+    }
+
+    $datasetIdentityParts = [System.Collections.Generic.List[string]]::new()
+    foreach ($part in @($definitionId, $datasetLeaf, $preset, $totalRows, $actualDeviceCount)) {
+        if (-not [string]::IsNullOrWhiteSpace([string]$part)) {
+            $datasetIdentityParts.Add([string]$part) | Out-Null
+        }
+    }
+
+    return [PSCustomObject]@{
+        identity = if ($datasetIdentityParts.Count -gt 0) { $datasetIdentityParts -join '|' } else { $datasetPath }
+        definition_id = $definitionId
+        definition_description = [string](Get-ObjectPropertyValue -InputObject $definition -Name 'description')
+        path = $datasetPath
+        leaf = $datasetLeaf
+        preset = $preset
+        seed = Get-ObjectPropertyValue -InputObject $manifest -Name 'seed'
+        generated_on_utc = Get-ObjectPropertyValue -InputObject $manifest -Name 'generatedOnUtc'
+        total_rows = $totalRows
+        dataset_bytes = Get-ObjectPropertyValue -InputObject $dataset -Name 'dataset_bytes'
+        actual_device_count = $actualDeviceCount
+        actual_current_rows = Get-ObjectPropertyValue -InputObject $manifest -Name 'actualCurrentRows'
+        actual_history_rows = Get-ObjectPropertyValue -InputObject $manifest -Name 'actualHistoryRows'
+        advanced_hunting_rows = Get-ObjectPropertyValue -InputObject $manifest -Name 'advancedHuntingRows'
+        history_periods = @((Get-ObjectPropertyValue -InputObject $manifest -Name 'historyPeriods') | ForEach-Object { [string]$_ })
+    }
+}
+
+function Get-BaselineSummary {
+    [CmdletBinding()]
+    [OutputType([pscustomobject])]
+    param(
+        [Parameter(Mandatory = $false)]
+        [AllowNull()]
+        $BaselineResult
+    )
+
+    if ($null -eq $BaselineResult) {
+        return $null
+    }
+
+    $local = Get-ObjectPropertyValue -InputObject $BaselineResult -Name 'local'
+    $runbook = Get-ObjectPropertyValue -InputObject $BaselineResult -Name 'runbook'
+    $functionApp = Get-ObjectPropertyValue -InputObject $BaselineResult -Name 'function_app'
+    $localPersistentCache = Get-ObjectPropertyValue -InputObject $BaselineResult -Name 'local_persistent_cache'
+    $localPersistentPrime = Get-ObjectPropertyValue -InputObject $localPersistentCache -Name 'prime'
+    $localPersistentReuse = Get-ObjectPropertyValue -InputObject $localPersistentCache -Name 'reuse_after_payload_eviction'
+    $localPersistentComparison = Get-ObjectPropertyValue -InputObject $localPersistentCache -Name 'comparison'
+    $repoPath = [string](Get-ObjectPropertyValue -InputObject $BaselineResult -Name 'repo_path')
+
+    return [PSCustomObject]@{
+        baseline = [string](Get-ObjectPropertyValue -InputObject $BaselineResult -Name 'baseline')
+        repo_path = $repoPath
+        repo = Get-RepoSnapshot -RepoPath $repoPath
+        local_elapsed_seconds = Get-ObjectPropertyValue -InputObject $local -Name 'elapsed_seconds'
+        local_rows_per_second = Get-ObjectPropertyValue -InputObject $local -Name 'rows_per_second'
+        local_peak_rss_gb = Get-ObjectPropertyValue -InputObject $local -Name 'peak_tree_rss_gb'
+        local_peak_private_gb = Get-ObjectPropertyValue -InputObject $local -Name 'peak_tree_private_gb'
+        runbook_elapsed_seconds = Get-ObjectPropertyValue -InputObject $runbook -Name 'elapsed_seconds'
+        runbook_rows_per_second = Get-ObjectPropertyValue -InputObject $runbook -Name 'rows_per_second'
+        runbook_peak_working_set_mb = Get-ObjectPropertyValue -InputObject $runbook -Name 'peak_working_set_mb'
+        runbook_peak_gc_heap_mb = Get-ObjectPropertyValue -InputObject $runbook -Name 'peak_gc_heap_mb'
+        function_timing_basis = [string](Get-ObjectPropertyValue -InputObject $functionApp -Name 'timing_basis')
+        function_elapsed_seconds = Get-ObjectPropertyValue -InputObject $functionApp -Name 'elapsed_seconds'
+        function_active_elapsed_seconds = Get-ObjectPropertyValue -InputObject $functionApp -Name 'active_elapsed_seconds'
+        function_end_to_end_elapsed_seconds = Get-ObjectPropertyValue -InputObject $functionApp -Name 'end_to_end_elapsed_seconds'
+        function_pickup_delay_seconds = Get-ObjectPropertyValue -InputObject $functionApp -Name 'pickup_delay_seconds'
+        function_rows_per_second = Get-ObjectPropertyValue -InputObject $functionApp -Name 'rows_per_second'
+        function_peak_working_set_mb = Get-ObjectPropertyValue -InputObject $functionApp -Name 'peak_working_set_mb'
+        function_average_working_set_mb = Get-ObjectPropertyValue -InputObject $functionApp -Name 'average_working_set_mb'
+        function_execution_units = Get-ObjectPropertyValue -InputObject $functionApp -Name 'execution_units'
+        persistent_prime_elapsed_seconds = Get-ObjectPropertyValue -InputObject $localPersistentPrime -Name 'elapsed_seconds'
+        persistent_reuse_elapsed_seconds = Get-ObjectPropertyValue -InputObject $localPersistentReuse -Name 'elapsed_seconds'
+        persistent_elapsed_delta_seconds = Get-ObjectPropertyValue -InputObject $localPersistentComparison -Name 'elapsed_seconds_delta'
+        persistent_normalize_delta_seconds = Get-ObjectPropertyValue -InputObject $localPersistentComparison -Name 'normalize_source_data_delta'
+        persistent_prepare_payload_delta_seconds = Get-ObjectPropertyValue -InputObject $localPersistentComparison -Name 'prepare_normalized_payload_delta'
+        persistent_used_cached_vuln_columns = if ($null -ne $localPersistentReuse) { [bool](Get-ObjectPropertyValue -InputObject $localPersistentReuse -Name 'used_cached_vuln_columns') } else { $false }
+    }
+}
+
+function Get-BenchmarkHistoryEntry {
+    [CmdletBinding()]
+    [OutputType([pscustomobject])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$ResultPath,
+
+        [Parameter(Mandatory = $true)]
+        $Result,
+
+        [Parameter(Mandatory = $false)]
+        [string[]]$Tags = @()
+    )
+
+    $subscription = Get-ObjectPropertyValue -InputObject $Result -Name 'subscription'
+    $normalizedTags = @($Tags | Where-Object { -not [string]::IsNullOrWhiteSpace([string]$_) } | ForEach-Object { [string]$_ } | Select-Object -Unique)
+    $subscriptionSummary = $null
+    if ($null -ne $subscription) {
+        $subscriptionSummary = [PSCustomObject]@{
+            id = [string](Get-ObjectPropertyValue -InputObject $subscription -Name 'id')
+            name = [string](Get-ObjectPropertyValue -InputObject $subscription -Name 'name')
+            tenantId = [string](Get-ObjectPropertyValue -InputObject $subscription -Name 'tenantId')
+        }
+    }
+
+    return [PSCustomObject][ordered]@{
+        benchmark_schema_version = Get-ObjectPropertyValue -InputObject $Result -Name 'benchmark_schema_version'
+        recorded_utc = [datetime]::UtcNow.ToString('o')
+        benchmark_result_path = $ResultPath
+        benchmark_generated_utc = Format-DateTimeValue -Value (Get-ObjectPropertyValue -InputObject $Result -Name 'generated_utc')
+        benchmark_mode = [string](Get-ObjectPropertyValue -InputObject $Result -Name 'benchmark_mode')
+        local_only = [bool](Get-ObjectPropertyValue -InputObject $Result -Name 'local_only')
+        persistent_local_workflow = [bool](Get-ObjectPropertyValue -InputObject $Result -Name 'persistent_local_workflow')
+        subscription = $subscriptionSummary
+        dataset = Get-DatasetSummary -Result $Result
+        current = Get-BaselineSummary -BaselineResult (Get-ObjectPropertyValue -InputObject $Result -Name 'current')
+        main = Get-BaselineSummary -BaselineResult (Get-ObjectPropertyValue -InputObject $Result -Name 'main')
+        comparison = Get-ObjectPropertyValue -InputObject $Result -Name 'comparison'
+        tags = $normalizedTags
+    }
+}
+
+function Import-BenchmarkHistoryEntries {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '', Justification = 'Internal helper reads the full set of locally recorded benchmark history entries.')]
+    [CmdletBinding()]
+    [OutputType([object[]])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Path
+    )
+
+    if (-not (Test-Path -LiteralPath $Path -PathType Leaf)) {
+        return @()
+    }
+
+    $entries = [System.Collections.Generic.List[object]]::new()
+    foreach ($line in Get-Content -LiteralPath $Path) {
+        if ([string]::IsNullOrWhiteSpace($line)) {
+            continue
+        }
+
+        $entries.Add(($line | ConvertFrom-Json -Depth 30)) | Out-Null
+    }
+
+    return @($entries)
+}
+
+function Find-PreviousMatchingEntry {
+    [CmdletBinding()]
+    [OutputType([pscustomobject])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [AllowEmptyCollection()]
+        [object[]]$Entries,
+
+        [Parameter(Mandatory = $true)]
+        $CurrentEntry
+    )
+
+    $candidateEntries = @(
+        $Entries | Where-Object {
+            ([string]$_.benchmark_result_path -ne [string]$CurrentEntry.benchmark_result_path) -and
+            ([string]$_.benchmark_mode -eq [string]$CurrentEntry.benchmark_mode) -and
+            ([bool]$_.local_only -eq [bool]$CurrentEntry.local_only) -and
+            ([bool]$_.persistent_local_workflow -eq [bool]$CurrentEntry.persistent_local_workflow) -and
+            ([string]$_.dataset.identity -eq [string]$CurrentEntry.dataset.identity) -and
+            ([string]$_.current.baseline -eq [string]$CurrentEntry.current.baseline) -and
+            ([string]$_.current.function_timing_basis -eq [string]$CurrentEntry.current.function_timing_basis)
+        }
+    )
+
+    if ($candidateEntries.Count -eq 0) {
+        return $null
+    }
+
+    return @($candidateEntries | Sort-Object { [datetime]$_.recorded_utc })[-1]
+}
+
+function Format-SecondsValue {
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory = $false)]
+        [AllowNull()]
+        $Value
+    )
+
+    if ($null -eq $Value) {
+        return 'n/a'
+    }
+
+    return ('{0:N2}s' -f [double]$Value)
+}
+
+function Format-DeltaValue {
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory = $false)]
+        [AllowNull()]
+        $CurrentValue,
+
+        [Parameter(Mandatory = $false)]
+        [AllowNull()]
+        $PreviousValue
+    )
+
+    if ($null -eq $CurrentValue -or $null -eq $PreviousValue) {
+        return 'n/a'
+    }
+
+    $delta = [math]::Round(([double]$CurrentValue - [double]$PreviousValue), 2)
+    $deltaText = if ($delta -gt 0) {
+        '+' + ('{0:N2}' -f $delta)
+    }
+    else {
+        ('{0:N2}' -f $delta)
+    }
+
+    $trend = if ($delta -lt 0) {
+        'faster'
+    }
+    elseif ($delta -gt 0) {
+        'slower'
+    }
+    else {
+        'unchanged'
+    }
+
+    return ('{0}s ({1})' -f $deltaText, $trend)
+}
+
+function Write-BenchmarkHistorySummary {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Path,
+
+        [Parameter(Mandatory = $true)]
+        $Entry,
+
+        [Parameter(Mandatory = $false)]
+        [AllowNull()]
+        $PreviousEntry,
+
+        [Parameter(Mandatory = $true)]
+        [string]$HistoryPath,
+
+        [Parameter(Mandatory = $true)]
+        [bool]$WasAppended
+    )
+
+    $lines = [System.Collections.Generic.List[string]]::new()
+    $entryRecordedUtc = Format-DateTimeValue -Value $Entry.recorded_utc
+    $previousEntryRecordedUtc = Format-DateTimeValue -Value $(if ($null -ne $PreviousEntry) { $PreviousEntry.recorded_utc } else { $null })
+    $lines.Add('# Benchmark History Summary') | Out-Null
+    $lines.Add('') | Out-Null
+    $lines.Add('Latest capture') | Out-Null
+    $lines.Add('') | Out-Null
+    $lines.Add(('- Recorded: `{0}`' -f $entryRecordedUtc)) | Out-Null
+    $lines.Add(('- Result file: `{0}`' -f $Entry.benchmark_result_path)) | Out-Null
+    $lines.Add(('- History action: {0}' -f $(if ($WasAppended) { 'appended' } else { 'already present' }))) | Out-Null
+    $lines.Add(('- Benchmark mode: `{0}`' -f $Entry.benchmark_mode)) | Out-Null
+    $datasetLabel = if (-not [string]::IsNullOrWhiteSpace([string]$Entry.dataset.definition_id)) { [string]$Entry.dataset.definition_id } else { [string]$Entry.dataset.leaf }
+    $lines.Add(('- Dataset: `{0}` | preset `{1}` | `{2}` rows | `{3}` devices' -f $datasetLabel, $Entry.dataset.preset, $Entry.dataset.total_rows, $Entry.dataset.actual_device_count)) | Out-Null
+    $lines.Add(('- Current baseline: `{0}`' -f $Entry.current.baseline)) | Out-Null
+    if ($null -ne $Entry.current.repo) {
+        $lines.Add(('- Current git: `{0}` @ `{1}` ({2})' -f $Entry.current.repo.branch, $Entry.current.repo.commit_short, $(if ($Entry.current.repo.dirty) { 'dirty' } else { 'clean' }))) | Out-Null
+    }
+    $lines.Add(('- Local elapsed: {0}' -f (Format-SecondsValue -Value $Entry.current.local_elapsed_seconds))) | Out-Null
+    $lines.Add(('- Runbook elapsed: {0}' -f (Format-SecondsValue -Value $Entry.current.runbook_elapsed_seconds))) | Out-Null
+    $lines.Add(('- Function elapsed: {0} ({1})' -f (Format-SecondsValue -Value $Entry.current.function_elapsed_seconds), $(if ([string]::IsNullOrWhiteSpace([string]$Entry.current.function_timing_basis)) { 'legacy' } else { [string]$Entry.current.function_timing_basis }))) | Out-Null
+    if ($null -ne $Entry.current.function_end_to_end_elapsed_seconds) {
+        $lines.Add(('- Function end-to-end / pickup delay: {0} / {1}' -f (Format-SecondsValue -Value $Entry.current.function_end_to_end_elapsed_seconds), (Format-SecondsValue -Value $Entry.current.function_pickup_delay_seconds))) | Out-Null
+    }
+    if ($Entry.persistent_local_workflow) {
+        $lines.Add(('- Persistent local prime/reuse: {0} / {1}' -f (Format-SecondsValue -Value $Entry.current.persistent_prime_elapsed_seconds), (Format-SecondsValue -Value $Entry.current.persistent_reuse_elapsed_seconds))) | Out-Null
+        $lines.Add(('- Persistent local elapsed delta: {0}' -f (Format-SecondsValue -Value $Entry.current.persistent_elapsed_delta_seconds))) | Out-Null
+    }
+    if (@($Entry.tags).Count -gt 0) {
+        $lines.Add(('- Tags: `{0}`' -f (@($Entry.tags) -join '`, `'))) | Out-Null
+    }
+    $lines.Add(('- History file: `{0}`' -f $HistoryPath)) | Out-Null
+
+    if ($null -ne $PreviousEntry) {
+        $lines.Add('') | Out-Null
+        $lines.Add('Previous matching capture') | Out-Null
+        $lines.Add('') | Out-Null
+        $lines.Add(('- Recorded: `{0}`' -f $previousEntryRecordedUtc)) | Out-Null
+        $lines.Add(('- Result file: `{0}`' -f $PreviousEntry.benchmark_result_path)) | Out-Null
+        $lines.Add(('- Local delta: {0}' -f (Format-DeltaValue -CurrentValue $Entry.current.local_elapsed_seconds -PreviousValue $PreviousEntry.current.local_elapsed_seconds))) | Out-Null
+        $lines.Add(('- Runbook delta: {0}' -f (Format-DeltaValue -CurrentValue $Entry.current.runbook_elapsed_seconds -PreviousValue $PreviousEntry.current.runbook_elapsed_seconds))) | Out-Null
+        $lines.Add(('- Function delta: {0}' -f (Format-DeltaValue -CurrentValue $Entry.current.function_elapsed_seconds -PreviousValue $PreviousEntry.current.function_elapsed_seconds))) | Out-Null
+        if ($null -ne $Entry.current.function_end_to_end_elapsed_seconds -and $null -ne $PreviousEntry.current.function_end_to_end_elapsed_seconds) {
+            $lines.Add(('- Function end-to-end delta: {0}' -f (Format-DeltaValue -CurrentValue $Entry.current.function_end_to_end_elapsed_seconds -PreviousValue $PreviousEntry.current.function_end_to_end_elapsed_seconds))) | Out-Null
+        }
+        if ($Entry.persistent_local_workflow) {
+            $lines.Add(('- Persistent reuse delta: {0}' -f (Format-DeltaValue -CurrentValue $Entry.current.persistent_reuse_elapsed_seconds -PreviousValue $PreviousEntry.current.persistent_reuse_elapsed_seconds))) | Out-Null
+        }
+    }
+    else {
+        $lines.Add('') | Out-Null
+        $lines.Add('Previous matching capture') | Out-Null
+        $lines.Add('') | Out-Null
+        $lines.Add('- None yet for this dataset and benchmark mode.') | Out-Null
+    }
+
+    $outputDirectory = Split-Path -Path $Path -Parent
+    if (-not (Test-Path -LiteralPath $outputDirectory -PathType Container)) {
+        $null = New-Item -Path $outputDirectory -ItemType Directory -Force
+    }
+
+    [System.IO.File]::WriteAllLines($Path, $lines, [System.Text.UTF8Encoding]::new($false))
+}
+
+$resolvedBenchmarkResultPath = [System.IO.Path]::GetFullPath($BenchmarkResultPath)
+$resolvedHistoryPath = [System.IO.Path]::GetFullPath($HistoryPath)
+$resolvedSummaryOutputPath = [System.IO.Path]::GetFullPath($SummaryOutputPath)
+
+if (-not (Test-Path -LiteralPath $resolvedBenchmarkResultPath -PathType Leaf)) {
+    throw "Benchmark result file not found: $resolvedBenchmarkResultPath"
+}
+
+$historyDirectory = Split-Path -Path $resolvedHistoryPath -Parent
+if (-not (Test-Path -LiteralPath $historyDirectory -PathType Container)) {
+    $null = New-Item -Path $historyDirectory -ItemType Directory -Force
+}
+
+$result = Get-Content -LiteralPath $resolvedBenchmarkResultPath -Raw | ConvertFrom-Json -Depth 50
+$historyEntries = @(Import-BenchmarkHistoryEntries -Path $resolvedHistoryPath)
+$entry = Get-BenchmarkHistoryEntry -ResultPath $resolvedBenchmarkResultPath -Result $result -Tags $Tags
+
+$existingEntry = @(
+    $historyEntries | Where-Object {
+        ([string]$_.benchmark_result_path -eq [string]$entry.benchmark_result_path) -or
+        (([string]$_.benchmark_generated_utc -eq [string]$entry.benchmark_generated_utc) -and ([string]$_.current.baseline -eq [string]$entry.current.baseline) -and ([string]$_.dataset.identity -eq [string]$entry.dataset.identity))
+    }
+) | Select-Object -First 1
+
+$wasAppended = $false
+if ($null -eq $existingEntry) {
+    ($entry | ConvertTo-Json -Compress -Depth 30) | Add-Content -LiteralPath $resolvedHistoryPath -Encoding utf8
+    $historyEntries += $entry
+    $wasAppended = $true
+}
+else {
+    $entry = $existingEntry
+}
+
+$previousEntry = Find-PreviousMatchingEntry -Entries $historyEntries -CurrentEntry $entry
+Write-BenchmarkHistorySummary -Path $resolvedSummaryOutputPath -Entry $entry -PreviousEntry $previousEntry -HistoryPath $resolvedHistoryPath -WasAppended $wasAppended
+
+Write-Host ('Benchmark history: {0}' -f $resolvedHistoryPath) -ForegroundColor Green
+Write-Host ('History summary: {0}' -f $resolvedSummaryOutputPath) -ForegroundColor Green
+if ($wasAppended) {
+    Write-Host ('Recorded benchmark result: {0}' -f $resolvedBenchmarkResultPath)
+}
+else {
+    Write-Host ('Benchmark result already recorded: {0}' -f $resolvedBenchmarkResultPath)
+}
+if ($null -ne $previousEntry) {
+    Write-Host ('Previous matching capture: {0}' -f [string]$previousEntry.benchmark_result_path)
+}

--- a/tests/Run-SharedHelperRegression.ps1
+++ b/tests/Run-SharedHelperRegression.ps1
@@ -897,6 +897,233 @@ function Test-WriteCombinedPayloadGzipPreservesColumnPayload {
     }
 }
 
+function Test-NormalizedVulnColumnCacheRebuildsPayloadWithFreshLookups {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '', Justification = 'Regression test name is intentionally plural because it validates payload rebuild behavior across cached lookup inputs.')]
+    [CmdletBinding()]
+    param()
+
+    $tempRoot = Join-Path ([System.IO.Path]::GetTempPath()) ('normalized-column-cache-' + [guid]::NewGuid().ToString('N'))
+    [void](New-Item -Path $tempRoot -ItemType Directory -Force)
+    $outputPath = Join-Path $tempRoot 'normalized-vulns.json'
+    $columnPath = Join-Path $tempRoot 'columns'
+    $originalPayloadPath = Join-Path $tempRoot 'original-payload.json.gz'
+    $reusedPayloadPath = Join-Path $tempRoot 'reused-payload.json.gz'
+
+    try {
+        $currentRow = Get-TestVulnRow -Id 'column-cache-001' -CveId 'CVE-2026-0511' -SnapshotDate '2026-03-21' -Version '6.0.0'
+        $historyRow = Get-TestVulnRow -Id 'column-cache-002' -CveId 'CVE-2026-0512' -SnapshotDate '2026-03-19' -Version '6.1.0'
+        $historyRow.DeviceId = 'device-002'
+        $historyRow.DeviceName = 'device02.contoso.com'
+        $historyRow.MachineTags = @('Pilot', 'Prod')
+
+        Write-NdjsonRecordsFile -Path (Get-VulnCurrentPath -BasePath $tempRoot) -Records @($currentRow)
+        [void](New-Item -Path (Get-VulnHistoryPath -BasePath $tempRoot -PeriodKey '2026Q1') -ItemType File -Force)
+        Write-NdjsonRecordsFile -Path (Get-VulnHistoryRowsPath -BasePath $tempRoot -PeriodKey '2026Q1') -Records @($historyRow)
+        Write-NdjsonRecordsFile -Path (Get-AdvancedHuntingCurrentPath -BasePath $tempRoot) -Records @(
+            [PSCustomObject]@{
+                CveId = 'CVE-2026-0511'
+                PublishedDate = '2026-03-20'
+                VulnerabilityDescription = 'Column cache rebuild regression.'
+                EpssScore = 0.31
+                AffectedSoftware = @('contoso:legacy_agent')
+            }
+            [PSCustomObject]@{
+                CveId = 'CVE-2026-0512'
+                PublishedDate = '2026-03-18'
+                VulnerabilityDescription = 'Column cache rebuild regression history row.'
+                EpssScore = 0.22
+                AffectedSoftware = @('contoso:legacy_agent')
+            }
+        )
+
+        Publish-VulnContentStoreUnlocked -BasePath $tempRoot
+
+        $advancedHuntingData = Read-AdvancedHuntingData -Path $tempRoot
+        $advancedHuntingDeviceUsers = Read-AdvancedHuntingDeviceUserMap -Path $tempRoot
+        $advancedHuntingInventoryData = Read-AdvancedHuntingInventoryData -Path $tempRoot
+        $normalizedResult = ConvertTo-NormalizedData `
+            -DataPath $tempRoot `
+            -VulnOutputPath $outputPath `
+            -VulnColumnDirectoryPath $columnPath `
+            -Machines @{} `
+            -AdvancedHuntingData $advancedHuntingData `
+            -AdvancedHuntingDeviceUsers $advancedHuntingDeviceUsers `
+            -AdvancedHuntingInventoryData $advancedHuntingInventoryData `
+            -SkipObservedWindowMerge
+        Write-CombinedPayloadGzip -Lookups $normalizedResult.Lookups -VulnColumnPaths $normalizedResult.VulnColumnPaths -OutputPath $originalPayloadPath
+
+        $cacheEntry = Publish-NormalizedVulnColumnCache `
+            -BasePath $tempRoot `
+            -VulnColumnPaths $normalizedResult.VulnColumnPaths `
+            -VulnCount $normalizedResult.VulnCount `
+            -Dates @($normalizedResult.Lookups.dates) `
+            -Quality $normalizedResult.Quality `
+            -SkipObservedWindowMerge `
+            -InventoryTupleCount $advancedHuntingInventoryData.Count
+        $restoredCacheEntry = Get-NormalizedVulnColumnCacheEntry -BasePath $tempRoot -SkipObservedWindowMerge
+        $restoredLookups = Restore-ContentStoreNormalizedLookupsFromColumnCache `
+            -DataPath $tempRoot `
+            -Machines @{} `
+            -AdvancedHuntingData $advancedHuntingData `
+            -AdvancedHuntingDeviceUsers $advancedHuntingDeviceUsers `
+            -AdvancedHuntingInventoryData $advancedHuntingInventoryData `
+            -CachedDates @($restoredCacheEntry.Manifest.Dates)
+        Write-CombinedPayloadGzip -Lookups $restoredLookups.Lookups -VulnColumnPaths $restoredCacheEntry.ColumnPaths -OutputPath $reusedPayloadPath
+
+        $originalPayloadJson = Read-GzipTextFile -Path $originalPayloadPath
+        $reusedPayloadJson = Read-GzipTextFile -Path $reusedPayloadPath
+
+        Assert-True ($null -ne $cacheEntry) 'Expected normalized vuln column cache publish to succeed.'
+        Assert-True ($null -ne $restoredCacheEntry) 'Expected normalized vuln column cache retrieval to succeed.'
+        Assert-True ($advancedHuntingInventoryData.Count -eq 0) 'Expected test fixture to avoid Advanced Hunting inventory tuples so column cache reuse stays valid.'
+        Assert-True ((Get-CompressedPayloadVulnCount -Path $originalPayloadPath) -eq (Get-CompressedPayloadVulnCount -Path $reusedPayloadPath)) 'Expected cached column payload rebuild to preserve vulnerability row count.'
+        Assert-True ($originalPayloadJson -eq $reusedPayloadJson) 'Expected cached normalized vuln columns plus rebuilt lookups to reproduce the same payload JSON.'
+    }
+    finally {
+        if (Test-Path -LiteralPath $tempRoot) {
+            Remove-Item -LiteralPath $tempRoot -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+}
+
+function Test-NormalizedVulnColumnCacheRefreshesInventoryColumn {
+    [CmdletBinding()]
+    param()
+
+    $tempRoot = Join-Path ([System.IO.Path]::GetTempPath()) ('normalized-column-cache-inventory-' + [guid]::NewGuid().ToString('N'))
+    [void](New-Item -Path $tempRoot -ItemType Directory -Force)
+    $outputPath = Join-Path $tempRoot 'normalized-vulns.json'
+    $columnPath = Join-Path $tempRoot 'columns'
+    $refreshedColumnPath = Join-Path $tempRoot 'refreshed-columns'
+    $originalPayloadPath = Join-Path $tempRoot 'original-payload.json.gz'
+    $reusedPayloadPath = Join-Path $tempRoot 'reused-payload.json.gz'
+
+    try {
+        $currentRow = Get-TestVulnRow -Id 'column-cache-inventory-001' -CveId 'CVE-2026-0611' -SnapshotDate '2026-03-21' -Version '6.0.0'
+        Write-NdjsonRecordsFile -Path (Get-VulnCurrentPath -BasePath $tempRoot) -Records @($currentRow)
+
+        Write-NdjsonRecordsFile -Path (Get-AdvancedHuntingCurrentPath -BasePath $tempRoot) -Records @(
+            [PSCustomObject]@{
+                CveId = 'CVE-2026-0611'
+                PublishedDate = '2026-03-20'
+                VulnerabilityDescription = 'Column cache inventory regression.'
+                EpssScore = 0.31
+                AffectedSoftware = @('contoso:legacy_agent')
+            }
+            [PSCustomObject]@{
+                DeviceId = 'device-001'
+                SoftwareVendor = 'contoso'
+                SoftwareName = 'legacy_agent'
+                SoftwareVersion = '6.0.0'
+                ProductCodeCpe = 'cpe:/a:contoso:legacy_agent:6.0.0'
+                EndOfSupportStatus = 'supported'
+                EndOfSupportDate = '2027-10-01'
+            }
+        )
+
+        Publish-VulnContentStoreUnlocked -BasePath $tempRoot
+
+        $advancedHuntingData = Read-AdvancedHuntingData -Path $tempRoot
+        $advancedHuntingDeviceUsers = Read-AdvancedHuntingDeviceUserMap -Path $tempRoot
+        $advancedHuntingInventoryData = Read-AdvancedHuntingInventoryData -Path $tempRoot
+        $normalizedResult = ConvertTo-NormalizedData `
+            -DataPath $tempRoot `
+            -VulnOutputPath $outputPath `
+            -VulnColumnDirectoryPath $columnPath `
+            -Machines @{} `
+            -AdvancedHuntingData $advancedHuntingData `
+            -AdvancedHuntingDeviceUsers $advancedHuntingDeviceUsers `
+            -AdvancedHuntingInventoryData $advancedHuntingInventoryData `
+            -SkipObservedWindowMerge
+        Write-CombinedPayloadGzip -Lookups $normalizedResult.Lookups -VulnColumnPaths $normalizedResult.VulnColumnPaths -OutputPath $originalPayloadPath
+
+        $cacheEntry = Publish-NormalizedVulnColumnCache `
+            -BasePath $tempRoot `
+            -VulnColumnPaths $normalizedResult.VulnColumnPaths `
+            -VulnCount $normalizedResult.VulnCount `
+            -Dates @($normalizedResult.Lookups.dates) `
+            -Quality $normalizedResult.Quality `
+            -SkipObservedWindowMerge `
+            -InventoryTupleCount $advancedHuntingInventoryData.Count
+        $restoredCacheEntry = Get-NormalizedVulnColumnCacheEntry -BasePath $tempRoot -SkipObservedWindowMerge
+        $restoredLookups = Restore-ContentStoreNormalizedLookupsFromColumnCache `
+            -DataPath $tempRoot `
+            -Machines @{} `
+            -AdvancedHuntingData $advancedHuntingData `
+            -AdvancedHuntingDeviceUsers $advancedHuntingDeviceUsers `
+            -AdvancedHuntingInventoryData $advancedHuntingInventoryData `
+            -CachedDates @($restoredCacheEntry.Manifest.Dates)
+        $restoredColumnPaths = Restore-NormalizedVulnColumnPathsFromCache `
+            -CachedColumnPaths $restoredCacheEntry.ColumnPaths `
+            -RestoredLookupsResult $restoredLookups `
+            -OutputDirectoryPath $refreshedColumnPath `
+            -CachedInventoryTupleCount ([int]$restoredCacheEntry.Manifest.InventoryTupleCount)
+        Write-CombinedPayloadGzip -Lookups $restoredLookups.Lookups -VulnColumnPaths $restoredColumnPaths.ColumnPaths -OutputPath $reusedPayloadPath
+
+        $originalPayloadJson = Read-GzipTextFile -Path $originalPayloadPath
+        $reusedPayloadJson = Read-GzipTextFile -Path $reusedPayloadPath
+
+        Assert-True ($null -ne $cacheEntry) 'Expected normalized vuln column cache publish to succeed for an inventory-backed fixture.'
+        Assert-True ($null -ne $restoredCacheEntry) 'Expected normalized vuln column cache retrieval to succeed for an inventory-backed fixture.'
+        Assert-True ($advancedHuntingInventoryData.Count -eq 1) 'Expected the inventory-backed fixture to produce one Advanced Hunting inventory tuple.'
+        Assert-True ($restoredColumnPaths.RefreshedInventoryColumn -eq $true) 'Expected cached inventory column regeneration to run for an inventory-backed fixture.'
+        Assert-True ($restoredLookups.Lookups.inventory.Count -eq $normalizedResult.Lookups.inventory.Count) 'Expected refreshed inventory lookups to preserve the same lookup cardinality as the original normalization.'
+        Assert-True ((Get-CompressedPayloadVulnCount -Path $originalPayloadPath) -eq (Get-CompressedPayloadVulnCount -Path $reusedPayloadPath)) 'Expected refreshed inventory-column payload rebuild to preserve vulnerability row count.'
+        Assert-True ($originalPayloadJson -eq $reusedPayloadJson) 'Expected cached normalized vuln columns plus refreshed inventory column to reproduce the same payload JSON.'
+    }
+    finally {
+        if (Test-Path -LiteralPath $tempRoot) {
+            Remove-Item -LiteralPath $tempRoot -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+}
+
+function Test-WriteBase64FileContentMatchesReferenceOutput {
+    [CmdletBinding()]
+    param()
+
+    $tempRoot = Join-Path ([System.IO.Path]::GetTempPath()) ('base64-writer-regression-' + [guid]::NewGuid().ToString('N'))
+    [void](New-Item -Path $tempRoot -ItemType Directory -Force)
+    $filePath = Join-Path $tempRoot 'fixture.bin'
+
+    try {
+        $bytes = [byte[]]::new(8195)
+        for ($index = 0; $index -lt $bytes.Length; $index++) {
+            $bytes[$index] = [byte](($index * 17 + 29) % 256)
+        }
+        [System.IO.File]::WriteAllBytes($filePath, $bytes)
+
+        $singleLineWriter = [System.IO.StringWriter]::new([System.Globalization.CultureInfo]::InvariantCulture)
+        try {
+            Write-Base64FileContent -Writer $singleLineWriter -FilePath $filePath
+            $singleLineActual = $singleLineWriter.ToString()
+        }
+        finally {
+            $singleLineWriter.Dispose()
+        }
+
+        $wrappedWriter = [System.IO.StringWriter]::new([System.Globalization.CultureInfo]::InvariantCulture)
+        try {
+            Write-Base64FileContent -Writer $wrappedWriter -FilePath $filePath -InsertLineBreaks
+            $wrappedActual = $wrappedWriter.ToString()
+        }
+        finally {
+            $wrappedWriter.Dispose()
+        }
+
+        $singleLineExpected = Get-Base64FileContent -FilePath $filePath
+        $wrappedExpected = Get-Base64FileContent -FilePath $filePath -InsertLineBreaks
+
+        Assert-True ($singleLineActual -eq $singleLineExpected) 'Expected streamed base64 writer to match the reference single-line output.'
+        Assert-True ($wrappedActual -eq $wrappedExpected) 'Expected streamed base64 writer to match the reference wrapped output.'
+    }
+    finally {
+        if (Test-Path -LiteralPath $tempRoot) {
+            Remove-Item -LiteralPath $tempRoot -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+}
+
 function Test-ValidationHelperPayloadCanonicalization {
     [CmdletBinding()]
     param()
@@ -1101,27 +1328,98 @@ function Test-StreamingDashboardAuditDetectsSourceMismatchDespitePayloadParity {
         ) -join [Environment]::NewLine
         [System.IO.File]::WriteAllText($htmlPath, $dashboardHtml, [System.Text.UTF8Encoding]::new($false))
 
-        $mutatedRow = Get-TestVulnRow -Id 'streaming-audit-002' -CveId 'CVE-2026-0322' -SnapshotDate '2026-03-21' -Version '4.1.0'
-        Write-NdjsonRecordsFile -Path (Get-VulnCurrentPath -BasePath $tempRoot) -Records @($currentRow, $mutatedRow)
+        $previousForceFull = $Script:DashboardValidationForceFull
+        $Script:DashboardValidationForceFull = $true
+        try {
+            $primeAudit = Get-StreamingDashboardAuditResult -ResolvedHtmlPath $htmlPath -ResolvedExportsPath $tempRoot -PayloadCacheEntry $payloadCacheEntry
 
-        $contentStoreFiles = @(
-            Get-VulnContentDictionaryPath -BasePath $tempRoot
-            Get-VulnCurrentRefsPath -BasePath $tempRoot
-            Get-VulnHistoryRefsPath -BasePath $tempRoot -PeriodKey '2026Q1'
-        )
-        foreach ($contentStoreFile in $contentStoreFiles) {
-            if (-not [string]::IsNullOrWhiteSpace($contentStoreFile) -and (Test-Path -LiteralPath $contentStoreFile -PathType Leaf)) {
-                Remove-Item -LiteralPath $contentStoreFile -Force -ErrorAction SilentlyContinue
+            $mutatedRow = Get-TestVulnRow -Id 'streaming-audit-002' -CveId 'CVE-2026-0322' -SnapshotDate '2026-03-21' -Version '4.1.0'
+            Write-NdjsonRecordsFile -Path (Get-VulnCurrentPath -BasePath $tempRoot) -Records @($currentRow, $mutatedRow)
+
+            $contentStoreFiles = @(
+                Get-VulnContentDictionaryPath -BasePath $tempRoot
+                Get-VulnCurrentRefsPath -BasePath $tempRoot
+                Get-VulnHistoryRefsPath -BasePath $tempRoot -PeriodKey '2026Q1'
+            )
+            foreach ($contentStoreFile in $contentStoreFiles) {
+                if (-not [string]::IsNullOrWhiteSpace($contentStoreFile) -and (Test-Path -LiteralPath $contentStoreFile -PathType Leaf)) {
+                    Remove-Item -LiteralPath $contentStoreFile -Force -ErrorAction SilentlyContinue
+                }
             }
+
+            $audit = Get-StreamingDashboardAuditResult -ResolvedHtmlPath $htmlPath -ResolvedExportsPath $tempRoot -PayloadCacheEntry $payloadCacheEntry
+        }
+        finally {
+            $Script:DashboardValidationForceFull = $previousForceFull
         }
 
-        $audit = Get-StreamingDashboardAuditResult -ResolvedHtmlPath $htmlPath -ResolvedExportsPath $tempRoot -PayloadCacheEntry $payloadCacheEntry
-
+        Assert-True ($primeAudit.RowComparison.Match -eq $true) 'Expected the priming forced streaming audit to succeed before the source exports diverge.'
+        Assert-True ($primeAudit.SemanticParity.SourceSignatureCacheUsed -eq $false) 'Expected the priming forced streaming audit to build the source signature cache.'
         Assert-True ($audit.PayloadParity.Match -eq $true) 'Expected dashboard payload bytes to remain equal to the cached normalized payload.'
         Assert-True ($audit.SemanticParity.PayloadByteParityMatch -eq $true) 'Expected streaming audit diagnostics to record dashboard payload byte parity.'
         Assert-True ($audit.RowComparison.Match -eq $false) 'Expected streaming semantic parity to fail when the source exports diverge from the dashboard payload.'
         Assert-True ($audit.RowComparison.MissingCount -eq 1) 'Expected the extra source row to be reported as missing from the dashboard payload.'
         Assert-True ([string]$audit.SemanticParity.ComparisonPayloadSource -eq 'cached-payload') 'Expected source streaming audit to reuse the cached payload when byte parity proves dashboard equivalence.'
+        Assert-True ($audit.SemanticParity.SourceSignatureCacheUsed -eq $false) 'Expected the streaming audit to bypass the cached source signature set after the source exports fingerprint changes.'
+    }
+    finally {
+        if (Test-Path -LiteralPath $tempRoot) {
+            Remove-Item -LiteralPath $tempRoot -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+}
+
+function Test-StreamingDashboardAuditReusesCachedPayloadSignatureSet {
+    [CmdletBinding()]
+    param()
+
+    $tempRoot = Join-Path ([System.IO.Path]::GetTempPath()) ('streaming-dashboard-payload-signatures-' + [guid]::NewGuid().ToString('N'))
+    [void](New-Item -Path $tempRoot -ItemType Directory -Force)
+    $repoRoot = Split-Path -Path $PSScriptRoot -Parent
+    $payloadPath = Join-Path $tempRoot 'payload.json.gz'
+    $vulnOutputPath = Join-Path $tempRoot 'normalized-vulns.json'
+    $htmlPath = Join-Path $tempRoot 'dashboard.html'
+
+    try {
+        . (Join-Path $repoRoot 'build\Import-ValidationHelpers.ps1')
+
+        $currentRow = Get-TestVulnRow -Id 'streaming-cache-001' -CveId 'CVE-2026-0421' -SnapshotDate '2026-03-20' -Version '5.0.0'
+        Write-NdjsonRecordsFile -Path (Get-VulnCurrentPath -BasePath $tempRoot) -Records @($currentRow)
+
+        $normalizedResult = ConvertTo-NormalizedData -DataPath $tempRoot -VulnOutputPath $vulnOutputPath -PayloadOutputPath $payloadPath -Machines @{} -AdvancedHuntingData @{}
+        $payloadCacheEntry = Publish-NormalizedPayloadCache -BasePath $tempRoot -PayloadPath $normalizedResult.PayloadPath -VulnCount $normalizedResult.VulnCount -DeviceCount $normalizedResult.Lookups.devices.Count -CveCount $normalizedResult.Lookups.cves.Count -Quality $normalizedResult.Quality
+
+        $dashboardConfigJson = ([ordered]@{ payloadUrl = 'payload.json.gz' } | ConvertTo-Json -Compress)
+        $dashboardHtml = @(
+            '<!DOCTYPE html>'
+            '<html lang="en">'
+            '<head><meta charset="utf-8"><title>Streaming Audit Cache Fixture</title></head>'
+            '<body>'
+            '<script id="dataFormat" type="application/json">external-compressed</script>'
+            ('<script id="dashboardConfig" type="application/json">' + $dashboardConfigJson + '</script>')
+            '</body>'
+            '</html>'
+        ) -join [Environment]::NewLine
+        [System.IO.File]::WriteAllText($htmlPath, $dashboardHtml, [System.Text.UTF8Encoding]::new($false))
+
+        $previousForceFull = $Script:DashboardValidationForceFull
+        $Script:DashboardValidationForceFull = $true
+        try {
+            $firstAudit = Get-StreamingDashboardAuditResult -ResolvedHtmlPath $htmlPath -ResolvedExportsPath $tempRoot -PayloadCacheEntry $payloadCacheEntry
+            $secondAudit = Get-StreamingDashboardAuditResult -ResolvedHtmlPath $htmlPath -ResolvedExportsPath $tempRoot -PayloadCacheEntry $payloadCacheEntry
+        }
+        finally {
+            $Script:DashboardValidationForceFull = $previousForceFull
+        }
+
+        Assert-True ($firstAudit.RowComparison.Match -eq $true) 'Expected the initial forced streaming audit to succeed before caching payload signatures.'
+        Assert-True ($firstAudit.SemanticParity.SourceSignatureCacheUsed -eq $false) 'Expected the initial forced streaming audit to build the source signature cache.'
+        Assert-True ($firstAudit.SemanticParity.PayloadSignatureCacheUsed -eq $false) 'Expected the initial forced streaming audit to build the payload signature cache.'
+        Assert-True ($secondAudit.RowComparison.Match -eq $true) 'Expected the repeated forced streaming audit to preserve semantic parity.'
+        Assert-True ($secondAudit.SemanticParity.SourceSignatureCacheUsed -eq $true) 'Expected the repeated forced streaming audit to reuse the cached source signature set.'
+        Assert-True ($secondAudit.SemanticParity.PayloadSignatureCacheUsed -eq $true) 'Expected the repeated forced streaming audit to reuse the cached payload signature set.'
+        Assert-True ([double]$secondAudit.SemanticParity.SourceSignatureElapsedSeconds -lt [double]$firstAudit.SemanticParity.SourceSignatureElapsedSeconds) 'Expected cached source signature reuse to reduce the source signature phase time on the repeated forced streaming audit.'
+        Assert-True ([double]$secondAudit.SemanticParity.PayloadSignatureElapsedSeconds -lt [double]$firstAudit.SemanticParity.PayloadSignatureElapsedSeconds) 'Expected cached payload signature reuse to reduce the payload signature phase time on the repeated forced streaming audit.'
     }
     finally {
         if (Test-Path -LiteralPath $tempRoot) {
@@ -1523,6 +1821,12 @@ Test-ConvertToNormalizedDataIncludesAdvancedHuntingDeviceUserMap
 Write-Output '  Advanced Hunting device-user normalization checks passed.'
 Test-WriteCombinedPayloadGzipPreservesColumnPayload
 Write-Output '  Combined payload writer column-path checks passed.'
+Test-NormalizedVulnColumnCacheRebuildsPayloadWithFreshLookups
+Write-Output '  Normalized vuln column cache reuse checks passed.'
+Test-NormalizedVulnColumnCacheRefreshesInventoryColumn
+Write-Output '  Inventory-backed normalized vuln column cache reuse checks passed.'
+Test-WriteBase64FileContentMatchesReferenceOutput
+Write-Output '  Streamed base64 writer checks passed.'
 Test-ValidationHelperPayloadCanonicalization
 Write-Output '  Validation helper payload-format checks passed.'
 Test-ValidationHelperStandaloneImport
@@ -1531,6 +1835,8 @@ Test-DashboardValidationFailureExtendedEnrichmentGate
 Write-Output '  Validation helper failure-gate checks passed.'
 Test-StreamingDashboardAuditDetectsSourceMismatchDespitePayloadParity
 Write-Output '  Streaming dashboard source-parity checks passed.'
+Test-StreamingDashboardAuditReusesCachedPayloadSignatureSet
+Write-Output '  Streaming dashboard payload-signature reuse checks passed.'
 Test-DashboardValidationUsesStableFallbackDeviceProfile
 Write-Output '  Dashboard validation fallback device profile checks passed.'
 Test-DashboardOpenStateAuditUsesPatchEvidenceAndInactivityCutoff

--- a/tests/benchmark-datasets.json
+++ b/tests/benchmark-datasets.json
@@ -1,0 +1,16 @@
+﻿[
+  {
+    "id": "benchmark-medium-v1",
+    "description": "Durable benchmark baseline dataset for Azure and local performance review.",
+    "preset": "BalancedMediumHeavy",
+    "seed": 20260322,
+    "targetDeviceCount": 1500,
+    "targetTotalVulnRows": 120000,
+    "sourceRelativePath": "exports",
+    "outputRelativePath": ".local/benchmark-datasets/benchmark-medium-v1",
+    "historyTags": [
+      "benchmark-medium-v1",
+      "durable-baseline"
+    ]
+  }
+]


### PR DESCRIPTION
## Summary
This PR completes the source-first helper decomposition across the dashboard, validation, and provisioning paths, removes duplicated entrypoint logic, hardens hosted Azure validation and diagnostics, and adds repeatable benchmark tooling for durable performance review.

## What changed
- Refactored shared PowerShell logic into manifest-driven helper domains for dashboard generation, enrichment, provisioning, and validation.
- Simplified the top-level entrypoints and Azure pipeline scripts to consume the shared helper surface instead of maintaining duplicate implementations.
- Hardened hosted validation and Azure deployment verification, including Function App execution diagnostics, status/control blob handling, seeded export validation, template refresh, and safer Azure CLI token fallback handling.
- Added benchmark dataset cataloging, benchmark series capture, history recording, hot-phase review, and validation-mode comparison tooling.
- Updated regression coverage and performance documentation, including the performance gate playbook and durable benchmark baseline guidance.
- Fixed the local PowerShell memory-guard wrapper so absolute child-script paths resolve correctly.

## Validation
- `pwsh -NoProfile -File .\build\Invoke-RegressionValidation.ps1`
- `pwsh -NoProfile -File c:\GitHub\defender-reporting\tests\Measure-BranchVsMainBenchmark.ps1 -CurrentOnly -LocalOnly -DatasetPath c:\GitHub\defender-reporting\.local\benchmark-datasets\benchmark-medium-v1 -ResultsOutputPath c:\GitHub\defender-reporting\.local\smoke-benchmark.json -MinimumAvailableMemoryGB 0.5`
- `pwsh -NoProfile -File c:\GitHub\defender-reporting\tests\Record-BenchmarkHistory.ps1 -BenchmarkResultPath c:\GitHub\defender-reporting\.local\smoke-benchmark.json`
- `pwsh -NoProfile -File c:\GitHub\defender-reporting\tests\Invoke-WithPwshMemoryGuard.ps1 -FilePath c:\GitHub\defender-reporting\tests\Import-BenchmarkDatasetCatalog.ps1 -WorkingDirectory c:\GitHub\defender-reporting`

## Notes
- The remaining VS Code PowerShell language-service warning in `tests/Record-BenchmarkHistory.ps1` does not reproduce with the native parser, ScriptAnalyzer, or direct execution and appears to be a stale/false editor diagnostic.