### PR TITLE
Optimize normalization hot paths

### DIFF
--- a/Generate-VulnerabilityDashboard.ps1
+++ b/Generate-VulnerabilityDashboard.ps1
@@ -30,6 +30,11 @@
     The path where the generated HTML dashboard will be saved.
     Default: ".\VulnerabilityDashboard.html"
 
+.PARAMETER DiagnosticPhaseLogPath
+    Optional path for writing a lightweight UTC phase log. When provided, the generator appends
+    tab-delimited phase start/end markers owned by the process itself so benchmark tooling can
+    derive timings without relying on external polling.
+
 .PARAMETER SplitAssets
     If specified, writes a hosted split-assets dashboard alongside the HTML output instead of
     embedding all CSS, JavaScript, libraries, and payload data directly in the HTML file.
@@ -119,6 +124,10 @@ param(
         return $true
     })]
     [string]$OutputPath = ".\VulnerabilityDashboard.html",
+
+    [Parameter(Mandatory = $false, HelpMessage = "Optional output path for a lightweight UTC phase log")]
+    [AllowEmptyString()]
+    [string]$DiagnosticPhaseLogPath,
     
     [Parameter(Mandatory = $false, HelpMessage = "Export fresh machine data from Defender API")]
     [bool]$ExportMachineData = $true,
@@ -292,6 +301,58 @@ function Write-LocalDiagnosticMemoryMarker {
     return $snapshot
 }
 
+function Initialize-LocalDiagnosticPhaseLog {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $false)]
+        [AllowEmptyString()]
+        [string]$Path
+    )
+
+    if ([string]::IsNullOrWhiteSpace($Path)) {
+        $script:LocalDiagnosticPhaseLogPath = $null
+        return
+    }
+
+    $resolvedPath = [System.IO.Path]::GetFullPath($Path)
+    $parentPath = Split-Path -Path $resolvedPath -Parent
+    if (-not [string]::IsNullOrWhiteSpace($parentPath) -and -not (Test-Path -LiteralPath $parentPath -PathType Container)) {
+        $null = New-Item -Path $parentPath -ItemType Directory -Force
+    }
+
+    [System.IO.File]::WriteAllText($resolvedPath, '', [System.Text.UTF8Encoding]::new($false))
+    $script:LocalDiagnosticPhaseLogPath = $resolvedPath
+}
+
+function Write-LocalDiagnosticPhaseLogEvent {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$EventType,
+
+        [Parameter(Mandatory = $true)]
+        [string]$Name,
+
+        [Parameter(Mandatory = $false)]
+        [AllowEmptyString()]
+        [string]$Status
+    )
+
+    if ([string]::IsNullOrWhiteSpace($script:LocalDiagnosticPhaseLogPath)) {
+        return
+    }
+
+    $fields = [System.Collections.Generic.List[string]]::new()
+    $fields.Add([datetime]::UtcNow.ToString('o')) | Out-Null
+    $fields.Add($EventType) | Out-Null
+    $fields.Add($Name) | Out-Null
+    if (-not [string]::IsNullOrWhiteSpace($Status)) {
+        $fields.Add($Status) | Out-Null
+    }
+
+    [System.IO.File]::AppendAllText($script:LocalDiagnosticPhaseLogPath, (($fields -join "`t") + [System.Environment]::NewLine), [System.Text.UTF8Encoding]::new($false))
+}
+
 function Get-LocalDiagnosticPhaseContext {
     [CmdletBinding()]
     [OutputType([System.Collections.IDictionary])]
@@ -301,6 +362,7 @@ function Get-LocalDiagnosticPhaseContext {
     )
 
     Write-Host ("`n--- Local Phase: {0} ---" -f $Name) -ForegroundColor DarkCyan
+    Write-LocalDiagnosticPhaseLogEvent -EventType 'phase-start' -Name $Name
     $startSnapshot = Write-LocalDiagnosticMemoryMarker -PhaseName $Name -Checkpoint 'start'
     return [ordered]@{
         Name = $Name
@@ -326,6 +388,7 @@ function Complete-LocalDiagnosticPhase {
 
     $endSnapshot = Write-LocalDiagnosticMemoryMarker -PhaseName $PhaseContext.Name -Checkpoint 'end'
     $elapsedSeconds = [math]::Round($PhaseContext.Stopwatch.Elapsed.TotalSeconds, 2)
+    Write-LocalDiagnosticPhaseLogEvent -EventType 'phase-end' -Name $PhaseContext.Name -Status $Status
     Write-Host ("  [{0}] Elapsed: {1:N2}s ({2})" -f $PhaseContext.Name, $elapsedSeconds, $Status) -ForegroundColor DarkGray
 
     return [PSCustomObject]@{
@@ -484,8 +547,13 @@ function Get-DashboardPackagingPlan {
 
 $tempRoot = $null
 $localPhaseTimings = [System.Collections.Generic.List[object]]::new()
+$script:LocalDiagnosticPhaseLogPath = $null
+$localDiagnosticPipelineStatus = 'completed'
 
 try {
+    Initialize-LocalDiagnosticPhaseLog -Path $DiagnosticPhaseLogPath
+    Write-LocalDiagnosticPhaseLogEvent -EventType 'pipeline-start' -Name 'dashboard-generation'
+
     if ($Validate -and $ValidateOnly) {
         throw 'Specify either -Validate or -ValidateOnly, not both.'
     }
@@ -1022,6 +1090,7 @@ try {
     }
 }
 catch {
+    $localDiagnosticPipelineStatus = 'failed'
     Write-Host "`n========================================" -ForegroundColor Red
     Write-Host "  Dashboard generation failed!" -ForegroundColor Red
     Write-Host "========================================" -ForegroundColor Red
@@ -1031,6 +1100,7 @@ catch {
     exit 1
 }
 finally {
+    Write-LocalDiagnosticPhaseLogEvent -EventType 'pipeline-end' -Name 'dashboard-generation' -Status $localDiagnosticPipelineStatus
     Write-LocalDiagnosticSummary -PhaseSummaries @($localPhaseTimings)
     if ($tempRoot -and (Test-Path -Path $tempRoot)) {
         Remove-Item -Path $tempRoot -Recurse -Force -ErrorAction SilentlyContinue

--- a/azure/Invoke-DashboardPipeline.ps1
+++ b/azure/Invoke-DashboardPipeline.ps1
@@ -13235,35 +13235,6 @@ function Add-NormalizedDevice {
     )
 
     $lookups = $Context.Lookups
-
-    function Get-NormalizationMachinePropertyValue {
-        [CmdletBinding()]
-        param(
-            [Parameter(Mandatory = $false)]
-            [AllowNull()]
-            [object]$Machine,
-
-            [Parameter(Mandatory = $false)]
-            [AllowNull()]
-            [object[]]$MachineTuple,
-
-            [Parameter(Mandatory = $true)]
-            [string]$PropertyName,
-
-            [Parameter(Mandatory = $false)]
-            [int]$TupleIndex = -1
-        )
-
-        if ($null -ne $MachineTuple -and $TupleIndex -ge 0) {
-            return $MachineTuple[$TupleIndex]
-        }
-
-        if ($null -eq $Machine -or $null -ne $MachineTuple) {
-            return $null
-        }
-
-        return $Machine.PSObject.Properties[$PropertyName]?.Value
-    }
     $deviceIndex = $Context.Indexes.devices
     $groupIndex = $Context.Indexes.groups
     $platformIndex = $Context.Indexes.platforms
@@ -13283,7 +13254,7 @@ function Add-NormalizedDevice {
 
     if (-not $deviceIndex.ContainsKey($deviceKey)) {
         $machine = if (-not [string]::IsNullOrWhiteSpace($DeviceId)) { $Context.Machines[$DeviceId] } else { $null }
-        $machineTuple = if ($machine -is [System.Array] -and $machine.Length -ge 10) { [object[]]$machine } else { $null }
+        $machineTuple = if ($machine -is [System.Array] -and $machine.Length -ge 10) { $machine } else { $null }
         $machineUsers = [string[]]@()
         if ($null -ne $Context.AdvancedHuntingDeviceUsers -and -not [string]::IsNullOrWhiteSpace($DeviceId)) {
             $rawMachineUsers = $Context.AdvancedHuntingDeviceUsers[[string]$DeviceId]
@@ -13317,18 +13288,18 @@ function Add-NormalizedDevice {
 
         $machineInfo = $null
         if ($machine -or $machineUsers.Count -gt 0) {
-            $machineLastSeen = Get-NormalizationMachinePropertyValue -Machine $machine -MachineTuple $machineTuple -PropertyName 'lastSeen' -TupleIndex 8
-            $machineFirstSeen = Get-NormalizationMachinePropertyValue -Machine $machine -MachineTuple $machineTuple -PropertyName 'firstSeen' -TupleIndex 9
+            $machineLastSeen = if ($machineTuple) { $machineTuple[8] } elseif ($machine) { $machine.PSObject.Properties['lastSeen']?.Value } else { $null }
+            $machineFirstSeen = if ($machineTuple) { $machineTuple[9] } elseif ($machine) { $machine.PSObject.Properties['firstSeen']?.Value } else { $null }
             $machineInfo = [PSCustomObject]@{
-                ip = Get-NormalizationMachinePropertyValue -Machine $machine -MachineTuple $machineTuple -PropertyName 'lastIpAddress' -TupleIndex 0
-                eip = Get-NormalizationMachinePropertyValue -Machine $machine -MachineTuple $machineTuple -PropertyName 'lastExternalIpAddress' -TupleIndex 1
+                ip = if ($machineTuple) { $machineTuple[0] } elseif ($machine) { $machine.PSObject.Properties['lastIpAddress']?.Value } else { $null }
+                eip = if ($machineTuple) { $machineTuple[1] } elseif ($machine) { $machine.PSObject.Properties['lastExternalIpAddress']?.Value } else { $null }
                 u = if ($machineUsers.Count -gt 0) { @($machineUsers) } else { $null }
-                hs = Get-NormalizationMachinePropertyValue -Machine $machine -MachineTuple $machineTuple -PropertyName 'healthStatus' -TupleIndex 2
-                rs = Get-NormalizationMachinePropertyValue -Machine $machine -MachineTuple $machineTuple -PropertyName 'riskScore' -TupleIndex 3
-                el = Get-NormalizationMachinePropertyValue -Machine $machine -MachineTuple $machineTuple -PropertyName 'exposureLevel' -TupleIndex 4
-                dv = Get-NormalizationMachinePropertyValue -Machine $machine -MachineTuple $machineTuple -PropertyName 'deviceValue' -TupleIndex 5
-                mb = Get-NormalizationMachinePropertyValue -Machine $machine -MachineTuple $machineTuple -PropertyName 'managedBy' -TupleIndex 6
-                aad = Get-NormalizationMachinePropertyValue -Machine $machine -MachineTuple $machineTuple -PropertyName 'isAadJoined' -TupleIndex 7
+                hs = if ($machineTuple) { $machineTuple[2] } elseif ($machine) { $machine.PSObject.Properties['healthStatus']?.Value } else { $null }
+                rs = if ($machineTuple) { $machineTuple[3] } elseif ($machine) { $machine.PSObject.Properties['riskScore']?.Value } else { $null }
+                el = if ($machineTuple) { $machineTuple[4] } elseif ($machine) { $machine.PSObject.Properties['exposureLevel']?.Value } else { $null }
+                dv = if ($machineTuple) { $machineTuple[5] } elseif ($machine) { $machine.PSObject.Properties['deviceValue']?.Value } else { $null }
+                mb = if ($machineTuple) { $machineTuple[6] } elseif ($machine) { $machine.PSObject.Properties['managedBy']?.Value } else { $null }
+                aad = if ($machineTuple) { $machineTuple[7] } elseif ($machine) { $machine.PSObject.Properties['isAadJoined']?.Value } else { $null }
                 ls = Get-NormalizationCachedYmdDate -Context $Context -DateValue $machineLastSeen
                 fs = Get-NormalizationCachedYmdDate -Context $Context -DateValue $machineFirstSeen
             }
@@ -13336,10 +13307,10 @@ function Add-NormalizedDevice {
 
         $lookups.devices.Add([PSCustomObject]@{
             id = $DeviceId
-            n = if ($DeviceName) { $DeviceName } elseif ($machine -and -not $machineTuple) { Get-NormalizationMachinePropertyValue -Machine $machine -MachineTuple $machineTuple -PropertyName 'computerDnsName' } else { '(no machine data)' }
+            n = if ($DeviceName) { $DeviceName } elseif ($machine -and -not $machineTuple) { $machine.PSObject.Properties['computerDnsName']?.Value } else { '(no machine data)' }
             g = $groupIdx
             o = $platIdx
-            ov = if ($OsVersion) { $OsVersion } elseif ($machine -and -not $machineTuple) { Get-NormalizationMachinePropertyValue -Machine $machine -MachineTuple $machineTuple -PropertyName 'osVersion' } else { $null }
+            ov = if ($OsVersion) { $OsVersion } elseif ($machine -and -not $machineTuple) { $machine.PSObject.Properties['osVersion']?.Value } else { $null }
             t = $tagIndices
             m = $machineInfo
         })

--- a/azure/Invoke-DashboardPipeline.ps1
+++ b/azure/Invoke-DashboardPipeline.ps1
@@ -12449,7 +12449,7 @@ function Get-GzipLine {
 function Get-OrCreateIndex {
     param($value, $list, $indexMap)
     if ($null -eq $value -or $value -eq '') { return -1 }
-    $key = $value.ToString()
+    $key = if ($value -is [string]) { $value } else { $value.ToString() }
     if (-not $indexMap.ContainsKey($key)) {
         $indexMap[$key] = $list.Count
         $list.Add($key)
@@ -13383,7 +13383,7 @@ function Resolve-NormalizedSeenWindowIndexSet {
     $firstSeen = Get-NormalizationCachedYmdDate -Context $Context -DateValue $FirstSeenValue
     $lastSeen = Get-NormalizationCachedYmdDate -Context $Context -DateValue $LastSeenValue
 
-    if ($firstSeen -and $lastSeen -and [datetime]$firstSeen -gt [datetime]$lastSeen) {
+    if ($firstSeen -and $lastSeen -and $firstSeen -gt $lastSeen) {
         $temp = $firstSeen
         $firstSeen = $lastSeen
         $lastSeen = $temp
@@ -13624,12 +13624,23 @@ function Get-NormalizedRecordLookup {
         -SecurityUpdateAvailable $SecurityUpdateAvailable `
         -Context $Context
 
-    Add-Member -InputObject $contentLookup -NotePropertyName inv -NotePropertyValue (Resolve-NormalizedInventoryLookup `
+    $inventoryLookup = Resolve-NormalizedInventoryLookup `
         -DeviceId $DeviceId `
         -SoftwareVendor $SoftwareVendor `
         -SoftwareName $SoftwareName `
         -SoftwareVersion $SoftwareVersion `
-        -Context $Context) -Force
+        -Context $Context
+
+    $contentLookup = [PSCustomObject]@{
+        sw = $contentLookup.sw
+        cve = $contentLookup.cve
+        ver = $contentLookup.ver
+        upd = $contentLookup.upd
+        ua = $contentLookup.ua
+        dp = $contentLookup.dp
+        rp = $contentLookup.rp
+        inv = $inventoryLookup
+    }
 
     return [PSCustomObject]@{
         DeviceIndex = Add-NormalizedDevice `

--- a/azure/Invoke-DashboardPipeline.ps1
+++ b/azure/Invoke-DashboardPipeline.ps1
@@ -5101,6 +5101,101 @@ function Get-MachineJsonElementScalarValue {
     }
 }
 
+function Get-MachineJsonElementStringArrayValue {
+    [CmdletBinding()]
+    [OutputType([string[]])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [System.Text.Json.JsonElement]$Element,
+
+        [Parameter(Mandatory = $true)]
+        [string]$Name
+    )
+
+    $property = [System.Text.Json.JsonElement]::new()
+    if (-not $Element.TryGetProperty($Name, [ref]$property)) {
+        return [string[]]@()
+    }
+
+    switch ($property.ValueKind) {
+        ([System.Text.Json.JsonValueKind]::Undefined) { return [string[]]@() }
+        ([System.Text.Json.JsonValueKind]::Null) { return [string[]]@() }
+        ([System.Text.Json.JsonValueKind]::String) { return (Get-NormalizedMachineTag -Tags $property.GetString()) }
+        ([System.Text.Json.JsonValueKind]::Array) {
+            $tagList = [System.Collections.Generic.List[string]]::new()
+            foreach ($item in $property.EnumerateArray()) {
+                $tagValue = switch ($item.ValueKind) {
+                    ([System.Text.Json.JsonValueKind]::String) { $item.GetString() }
+                    ([System.Text.Json.JsonValueKind]::Null) { $null }
+                    ([System.Text.Json.JsonValueKind]::Undefined) { $null }
+                    default { $item.GetRawText() }
+                }
+
+                if (-not [string]::IsNullOrWhiteSpace([string]$tagValue)) {
+                    $tagList.Add([string]$tagValue) | Out-Null
+                }
+            }
+
+            return (Get-NormalizedMachineTag -Tags @($tagList))
+        }
+        default { return (Get-NormalizedMachineTag -Tags (Get-MachineJsonElementScalarValue -Element $Element -Name $Name)) }
+    }
+}
+
+function ConvertFrom-MachineJsonElementToCompactMachineRecord {
+    [CmdletBinding()]
+    [OutputType([pscustomobject])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [System.Text.Json.JsonElement]$MachineElement
+    )
+
+    $machineId = [string](Get-MachineJsonElementScalarValue -Element $MachineElement -Name 'id')
+    if ([string]::IsNullOrWhiteSpace($machineId)) {
+        return $null
+    }
+
+    $observedOn = Get-MachineJsonElementScalarValue -Element $MachineElement -Name 'observedOn'
+    $stateHash = Get-MachineJsonElementScalarValue -Element $MachineElement -Name 'stateHash'
+    if ((Get-MachineJsonElementScalarValue -Element $MachineElement -Name 'removed') -eq $true) {
+        return [PSCustomObject]@{
+            id = $machineId
+            observedOn = $observedOn
+            removed = $true
+            stateHash = $stateHash
+        }
+    }
+
+    $record = [PSCustomObject]@{
+        id                    = $machineId
+        computerDnsName       = Get-MachineJsonElementScalarValue -Element $MachineElement -Name 'computerDnsName'
+        rbacGroupName         = Get-MachineJsonElementScalarValue -Element $MachineElement -Name 'rbacGroupName'
+        osPlatform            = Get-MachineJsonElementScalarValue -Element $MachineElement -Name 'osPlatform'
+        osVersion             = Get-MachineJsonElementScalarValue -Element $MachineElement -Name 'osVersion'
+        machineTags           = Get-MachineJsonElementStringArrayValue -Element $MachineElement -Name 'machineTags'
+        lastIpAddress         = Get-MachineJsonElementScalarValue -Element $MachineElement -Name 'lastIpAddress'
+        lastExternalIpAddress = Get-MachineJsonElementScalarValue -Element $MachineElement -Name 'lastExternalIpAddress'
+        healthStatus          = Get-MachineJsonElementScalarValue -Element $MachineElement -Name 'healthStatus'
+        riskScore             = Get-MachineJsonElementScalarValue -Element $MachineElement -Name 'riskScore'
+        exposureLevel         = Get-MachineJsonElementScalarValue -Element $MachineElement -Name 'exposureLevel'
+        deviceValue           = Get-MachineJsonElementScalarValue -Element $MachineElement -Name 'deviceValue'
+        managedBy             = Get-MachineJsonElementScalarValue -Element $MachineElement -Name 'managedBy'
+        isAadJoined           = Get-MachineJsonElementScalarValue -Element $MachineElement -Name 'isAadJoined'
+        lastSeen              = Get-MachineJsonElementScalarValue -Element $MachineElement -Name 'lastSeen'
+        firstSeen             = Get-MachineJsonElementScalarValue -Element $MachineElement -Name 'firstSeen'
+    }
+
+    if (-not [string]::IsNullOrWhiteSpace([string]$stateHash)) {
+        Add-Member -InputObject $record -NotePropertyName stateHash -NotePropertyValue $stateHash
+    }
+
+    if (-not [string]::IsNullOrWhiteSpace([string]$observedOn)) {
+        Add-Member -InputObject $record -NotePropertyName observedOn -NotePropertyValue $observedOn
+    }
+
+    return $record
+}
+
 function ConvertFrom-MachineJsonElementToNormalizationEntry {
     [CmdletBinding()]
     [OutputType([pscustomobject])]
@@ -5156,75 +5251,69 @@ function Read-MachineNormalizationEntriesFromFile {
         [string]$Path
     )
 
-    $fileMode = Get-JsonFileMode -Path $Path
-    if ($fileMode -eq 'Empty') {
-        return
-    }
-
-    if ($fileMode -eq 'Array') {
-        $rawContent = Read-TextFileContent -Path $Path
-        if ([string]::IsNullOrWhiteSpace($rawContent)) {
+    $readContext = Open-JsonFileReadContext -Path $Path
+    try {
+        if ($readContext.Mode -eq 'Empty') {
             return
         }
 
-        $jsonDocument = [System.Text.Json.JsonDocument]::Parse($rawContent)
-        $rawContent = $null
-        try {
-            if ($jsonDocument.RootElement.ValueKind -ne [System.Text.Json.JsonValueKind]::Array) {
+        if ($readContext.Mode -eq 'Array') {
+            $rawContent = Read-JsonFileRemainingContent -Context $readContext
+            if ([string]::IsNullOrWhiteSpace($rawContent)) {
                 return
             }
 
-            foreach ($machineElement in $jsonDocument.RootElement.EnumerateArray()) {
-                $entry = ConvertFrom-MachineJsonElementToNormalizationEntry -MachineElement $machineElement
+            $jsonDocument = [System.Text.Json.JsonDocument]::Parse($rawContent)
+            $rawContent = $null
+            try {
+                if ($jsonDocument.RootElement.ValueKind -ne [System.Text.Json.JsonValueKind]::Array) {
+                    return
+                }
+
+                foreach ($machineElement in $jsonDocument.RootElement.EnumerateArray()) {
+                    $entry = ConvertFrom-MachineJsonElementToNormalizationEntry -MachineElement $machineElement
+                    if ($null -ne $entry) {
+                        $entry
+                    }
+                }
+            }
+            finally {
+                $jsonDocument.Dispose()
+            }
+
+            return
+        }
+
+        $isFirstLine = [ref]$true
+        while (-not $readContext.Reader.EndOfStream) {
+            $line = Read-JsonFileLine -Context $readContext -IsFirstLine $isFirstLine
+            if ([string]::IsNullOrWhiteSpace($line)) { continue }
+
+            $jsonDocument = $null
+            try {
+                $jsonDocument = [System.Text.Json.JsonDocument]::Parse($line)
+            }
+            catch {
+                Write-Warning "Failed to parse machine line in $(Split-Path -Leaf $Path): $_"
+                continue
+            }
+
+            try {
+                $entry = ConvertFrom-MachineJsonElementToNormalizationEntry -MachineElement $jsonDocument.RootElement
                 if ($null -ne $entry) {
                     $entry
                 }
             }
-        }
-        finally {
-            $jsonDocument.Dispose()
-        }
-
-        return
-    }
-
-    $fileStream = [System.IO.File]::OpenRead($Path)
-    try {
-        $contentStream = if ($Path.EndsWith('.gz', [System.StringComparison]::OrdinalIgnoreCase)) {
-            [System.IO.Compression.GZipStream]::new($fileStream, [System.IO.Compression.CompressionMode]::Decompress)
-        } else { $fileStream }
-        try {
-            $reader = [System.IO.StreamReader]::new($contentStream, [System.Text.UTF8Encoding]::new($false))
-            try {
-                while (-not $reader.EndOfStream) {
-                    $line = $reader.ReadLine()
-                    if ([string]::IsNullOrWhiteSpace($line)) { continue }
-
-                    $jsonDocument = $null
-                    try {
-                        $jsonDocument = [System.Text.Json.JsonDocument]::Parse($line)
-                    }
-                    catch {
-                        Write-Warning "Failed to parse machine line in $(Split-Path -Leaf $Path): $_"
-                        continue
-                    }
-
-                    try {
-                        $entry = ConvertFrom-MachineJsonElementToNormalizationEntry -MachineElement $jsonDocument.RootElement
-                        if ($null -ne $entry) {
-                            $entry
-                        }
-                    }
-                    finally {
-                        $jsonDocument.Dispose()
-                    }
+            finally {
+                if ($null -ne $jsonDocument) {
+                    $jsonDocument.Dispose()
                 }
             }
-            finally { $reader.Dispose() }
         }
-        finally { if ($contentStream -ne $fileStream) { $contentStream.Dispose() } }
     }
-    finally { $fileStream.Dispose() }
+    finally {
+        Close-JsonFileReadContext -Context $readContext
+    }
 }
 
 function Get-NormalizedMachineTag {
@@ -5485,38 +5574,145 @@ function Read-TextFileContent {
     return (Get-Content -Path $Path -Raw)
 }
 
-function Get-JsonFileMode {
+function Open-JsonFileReadContext {
     [CmdletBinding()]
-    [OutputType([string])]
+    [OutputType([pscustomobject])]
     param(
         [Parameter(Mandatory = $true)]
         [string]$Path
     )
 
-    $fileStream = [System.IO.File]::OpenRead($Path)
+    $fileStream = $null
+    $contentStream = $null
+    $reader = $null
     try {
+        $fileStream = [System.IO.File]::OpenRead($Path)
         $contentStream = if ($Path.EndsWith('.gz', [System.StringComparison]::OrdinalIgnoreCase)) {
             [System.IO.Compression.GZipStream]::new($fileStream, [System.IO.Compression.CompressionMode]::Decompress)
-        } else { $fileStream }
-        try {
-            $reader = [System.IO.StreamReader]::new($contentStream, [System.Text.Encoding]::UTF8, $true)
-            try {
-                while (-not $reader.EndOfStream) {
-                    $charValue = $reader.Read()
-                    if ($charValue -lt 0) { break }
-                    $char = [char]$charValue
-                    if (-not [char]::IsWhiteSpace($char)) {
-                        if ($char -eq '[') { return 'Array' }
-                        return 'Ndjson'
-                    }
-                }
-                return 'Empty'
-            }
-            finally { $reader.Dispose() }
         }
-        finally { if ($contentStream -ne $fileStream) { $contentStream.Dispose() } }
+        else {
+            $fileStream
+        }
+
+        $reader = [System.IO.StreamReader]::new($contentStream, [System.Text.Encoding]::UTF8, $true)
+        $mode = 'Empty'
+        $firstContentText = $null
+        while (-not $reader.EndOfStream) {
+            $charValue = $reader.Read()
+            if ($charValue -lt 0) {
+                break
+            }
+
+            $char = [char]$charValue
+            if (-not [char]::IsWhiteSpace($char)) {
+                $mode = if ($char -eq '[') { 'Array' } else { 'Ndjson' }
+                $firstContentText = [string]$char
+                break
+            }
+        }
+
+        $context = [PSCustomObject]@{
+            Path = $Path
+            Mode = $mode
+            Reader = $reader
+            ContentStream = $contentStream
+            FileStream = $fileStream
+            FirstContentText = $firstContentText
+        }
+
+        $reader = $null
+        $contentStream = $null
+        $fileStream = $null
+        return $context
     }
-    finally { $fileStream.Dispose() }
+    finally {
+        if ($null -ne $reader) {
+            $reader.Dispose()
+        }
+        elseif ($null -ne $contentStream -and $contentStream -ne $fileStream) {
+            $contentStream.Dispose()
+        }
+
+        if ($null -ne $fileStream) {
+            $fileStream.Dispose()
+        }
+    }
+}
+
+function Close-JsonFileReadContext {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $false)]
+        [AllowNull()]
+        $Context
+    )
+
+    if ($null -eq $Context) {
+        return
+    }
+
+    $reader = $Context.PSObject.Properties['Reader']?.Value
+    if ($null -ne $reader) {
+        $reader.Dispose()
+        return
+    }
+
+    $contentStream = $Context.PSObject.Properties['ContentStream']?.Value
+    $fileStream = $Context.PSObject.Properties['FileStream']?.Value
+    if ($null -ne $contentStream -and $contentStream -ne $fileStream) {
+        $contentStream.Dispose()
+    }
+
+    if ($null -ne $fileStream) {
+        $fileStream.Dispose()
+    }
+}
+
+function Read-JsonFileRemainingContent {
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory = $true)]
+        $Context
+    )
+
+    if ($null -eq $Context -or $Context.Mode -eq 'Empty') {
+        return $null
+    }
+
+    $builder = [System.Text.StringBuilder]::new()
+    if (-not [string]::IsNullOrEmpty([string]$Context.FirstContentText)) {
+        [void]$builder.Append([string]$Context.FirstContentText)
+    }
+
+    [void]$builder.Append($Context.Reader.ReadToEnd())
+    return $builder.ToString()
+}
+
+function Read-JsonFileLine {
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory = $true)]
+        $Context,
+
+        [Parameter(Mandatory = $true)]
+        [ref]$IsFirstLine
+    )
+
+    $line = $Context.Reader.ReadLine()
+    if ($null -eq $line) {
+        return $null
+    }
+
+    if ($IsFirstLine.Value) {
+        $IsFirstLine.Value = $false
+        if (-not [string]::IsNullOrEmpty([string]$Context.FirstContentText)) {
+            return ([string]$Context.FirstContentText + $line)
+        }
+    }
+
+    return $line
 }
 
 function Read-MachineRecordsFromFile {
@@ -5526,82 +5722,69 @@ function Read-MachineRecordsFromFile {
         [string]$Path
     )
 
-    $fileMode = Get-JsonFileMode -Path $Path
-    if ($fileMode -eq 'Empty') {
-        return
-    }
-
-    if ($fileMode -eq 'Array') {
-        $rawContent = Read-TextFileContent -Path $Path
-        $machineList = $rawContent | ConvertFrom-Json
-        $rawContent = $null
-        if ($null -eq $machineList) { return }
-        if ($machineList -isnot [System.Array]) { $machineList = @($machineList) }
-
-        foreach ($machine in $machineList) {
-            if ($null -eq $machine) { continue }
-            if ($machine.PSObject.Properties['removed']?.Value -eq $true) {
-                ([PSCustomObject]@{
-                    id = $machine.PSObject.Properties['id']?.Value
-                    observedOn = $machine.PSObject.Properties['observedOn']?.Value
-                    removed = $true
-                    stateHash = $machine.PSObject.Properties['stateHash']?.Value
-                })
-                continue
-            }
-            $record = ConvertTo-CompactMachineRecord -Machine $machine
-            $stateHash = $machine.PSObject.Properties['stateHash']?.Value
-            $observedOn = $machine.PSObject.Properties['observedOn']?.Value
-            if ($stateHash) { Add-Member -InputObject $record -NotePropertyName stateHash -NotePropertyValue $stateHash }
-            if ($observedOn) { Add-Member -InputObject $record -NotePropertyName observedOn -NotePropertyValue $observedOn }
-            $record
+    $readContext = Open-JsonFileReadContext -Path $Path
+    try {
+        if ($readContext.Mode -eq 'Empty') {
+            return
         }
 
-        return
-    }
+        if ($readContext.Mode -eq 'Array') {
+            $rawContent = Read-JsonFileRemainingContent -Context $readContext
+            if ([string]::IsNullOrWhiteSpace($rawContent)) {
+                return
+            }
 
-    $fileStream = [System.IO.File]::OpenRead($Path)
-    try {
-        $contentStream = if ($Path.EndsWith('.gz', [System.StringComparison]::OrdinalIgnoreCase)) {
-            [System.IO.Compression.GZipStream]::new($fileStream, [System.IO.Compression.CompressionMode]::Decompress)
-        } else { $fileStream }
-        try {
-            $reader = [System.IO.StreamReader]::new($contentStream, [System.Text.UTF8Encoding]::new($false))
+            $jsonDocument = [System.Text.Json.JsonDocument]::Parse($rawContent)
+            $rawContent = $null
             try {
-                while (-not $reader.EndOfStream) {
-                    $line = $reader.ReadLine()
-                    if ([string]::IsNullOrWhiteSpace($line)) { continue }
-                    try {
-                        $machine = $line | ConvertFrom-Json
-                    }
-                    catch {
-                        Write-Warning "Failed to parse machine line in $(Split-Path -Leaf $Path): $_"
-                        continue
-                    }
+                if ($jsonDocument.RootElement.ValueKind -ne [System.Text.Json.JsonValueKind]::Array) {
+                    return
+                }
 
-                    if ($null -eq $machine) { continue }
-                    if ($machine.PSObject.Properties['removed']?.Value -eq $true) {
-                        ([PSCustomObject]@{
-                            id = $machine.PSObject.Properties['id']?.Value
-                            observedOn = $machine.PSObject.Properties['observedOn']?.Value
-                            removed = $true
-                            stateHash = $machine.PSObject.Properties['stateHash']?.Value
-                        })
-                        continue
+                foreach ($machineElement in $jsonDocument.RootElement.EnumerateArray()) {
+                    $record = ConvertFrom-MachineJsonElementToCompactMachineRecord -MachineElement $machineElement
+                    if ($null -ne $record) {
+                        $record
                     }
-                    $record = ConvertTo-CompactMachineRecord -Machine $machine
-                    $stateHash = $machine.PSObject.Properties['stateHash']?.Value
-                    $observedOn = $machine.PSObject.Properties['observedOn']?.Value
-                    if ($stateHash) { Add-Member -InputObject $record -NotePropertyName stateHash -NotePropertyValue $stateHash }
-                    if ($observedOn) { Add-Member -InputObject $record -NotePropertyName observedOn -NotePropertyValue $observedOn }
+                }
+            }
+            finally {
+                $jsonDocument.Dispose()
+            }
+
+            return
+        }
+
+        $isFirstLine = [ref]$true
+        while (-not $readContext.Reader.EndOfStream) {
+            $line = Read-JsonFileLine -Context $readContext -IsFirstLine $isFirstLine
+            if ([string]::IsNullOrWhiteSpace($line)) { continue }
+
+            $jsonDocument = $null
+            try {
+                $jsonDocument = [System.Text.Json.JsonDocument]::Parse($line)
+            }
+            catch {
+                Write-Warning "Failed to parse machine line in $(Split-Path -Leaf $Path): $_"
+                continue
+            }
+
+            try {
+                $record = ConvertFrom-MachineJsonElementToCompactMachineRecord -MachineElement $jsonDocument.RootElement
+                if ($null -ne $record) {
                     $record
                 }
             }
-            finally { $reader.Dispose() }
+            finally {
+                if ($null -ne $jsonDocument) {
+                    $jsonDocument.Dispose()
+                }
+            }
         }
-        finally { if ($contentStream -ne $fileStream) { $contentStream.Dispose() } }
     }
-    finally { $fileStream.Dispose() }
+    finally {
+        Close-JsonFileReadContext -Context $readContext
+    }
 }
 
 function Get-MachineStateHash {
@@ -6124,52 +6307,48 @@ function Read-AdvancedHuntingRecordsFromFile {
         [string]$Path
     )
 
-    $fileMode = Get-JsonFileMode -Path $Path
-    if ($fileMode -eq 'Empty') {
-        return
-    }
-
-    if ($fileMode -eq 'Array') {
-        $rawContent = Read-TextFileContent -Path $Path
-        $records = $rawContent | ConvertFrom-Json
-        $rawContent = $null
-        if ($null -eq $records) { return }
-        if ($records -isnot [System.Array]) { $records = @($records) }
-
-        foreach ($record in $records) {
-            if ($null -ne $record) {
-                $record
-            }
+    $readContext = Open-JsonFileReadContext -Path $Path
+    try {
+        if ($readContext.Mode -eq 'Empty') {
+            return
         }
 
-        return
-    }
+        if ($readContext.Mode -eq 'Array') {
+            $rawContent = Read-JsonFileRemainingContent -Context $readContext
+            if ([string]::IsNullOrWhiteSpace($rawContent)) {
+                return
+            }
 
-    $fileStream = [System.IO.File]::OpenRead($Path)
-    try {
-        $contentStream = if ($Path.EndsWith('.gz', [System.StringComparison]::OrdinalIgnoreCase)) {
-            [System.IO.Compression.GZipStream]::new($fileStream, [System.IO.Compression.CompressionMode]::Decompress)
-        } else { $fileStream }
-        try {
-            $reader = [System.IO.StreamReader]::new($contentStream, [System.Text.UTF8Encoding]::new($false))
-            try {
-                while (-not $reader.EndOfStream) {
-                    $line = $reader.ReadLine()
-                    if ([string]::IsNullOrWhiteSpace($line)) { continue }
-                    try {
-                        $record = $line | ConvertFrom-Json
-                        if ($null -ne $record) { $record }
-                    }
-                    catch {
-                        Write-Warning "Failed to parse Advanced Hunting line in $(Split-Path -Leaf $Path): $_"
-                    }
+            $records = $rawContent | ConvertFrom-Json
+            $rawContent = $null
+            if ($null -eq $records) { return }
+            if ($records -isnot [System.Array]) { $records = @($records) }
+
+            foreach ($record in $records) {
+                if ($null -ne $record) {
+                    $record
                 }
             }
-            finally { $reader.Dispose() }
+
+            return
         }
-        finally { if ($contentStream -ne $fileStream) { $contentStream.Dispose() } }
+
+        $isFirstLine = [ref]$true
+        while (-not $readContext.Reader.EndOfStream) {
+            $line = Read-JsonFileLine -Context $readContext -IsFirstLine $isFirstLine
+            if ([string]::IsNullOrWhiteSpace($line)) { continue }
+            try {
+                $record = $line | ConvertFrom-Json
+                if ($null -ne $record) { $record }
+            }
+            catch {
+                Write-Warning "Failed to parse Advanced Hunting line in $(Split-Path -Leaf $Path): $_"
+            }
+        }
     }
-    finally { $fileStream.Dispose() }
+    finally {
+        Close-JsonFileReadContext -Context $readContext
+    }
 }
 
 function Initialize-AdvancedHuntingStore {

--- a/azure/Invoke-DashboardPipeline.ps1
+++ b/azure/Invoke-DashboardPipeline.ps1
@@ -13046,6 +13046,35 @@ function Add-NormalizedDevice {
     )
 
     $lookups = $Context.Lookups
+
+    function Get-NormalizationMachinePropertyValue {
+        [CmdletBinding()]
+        param(
+            [Parameter(Mandatory = $false)]
+            [AllowNull()]
+            [object]$Machine,
+
+            [Parameter(Mandatory = $false)]
+            [AllowNull()]
+            [object[]]$MachineTuple,
+
+            [Parameter(Mandatory = $true)]
+            [string]$PropertyName,
+
+            [Parameter(Mandatory = $false)]
+            [int]$TupleIndex = -1
+        )
+
+        if ($null -ne $MachineTuple -and $TupleIndex -ge 0) {
+            return $MachineTuple[$TupleIndex]
+        }
+
+        if ($null -eq $Machine -or $null -ne $MachineTuple) {
+            return $null
+        }
+
+        return $Machine.PSObject.Properties[$PropertyName]?.Value
+    }
     $deviceIndex = $Context.Indexes.devices
     $groupIndex = $Context.Indexes.groups
     $platformIndex = $Context.Indexes.platforms
@@ -13065,7 +13094,7 @@ function Add-NormalizedDevice {
 
     if (-not $deviceIndex.ContainsKey($deviceKey)) {
         $machine = if (-not [string]::IsNullOrWhiteSpace($DeviceId)) { $Context.Machines[$DeviceId] } else { $null }
-        $machineTuple = if ($machine -is [System.Array] -and $machine.Length -ge 10) { $machine } else { $null }
+        $machineTuple = if ($machine -is [System.Array] -and $machine.Length -ge 10) { [object[]]$machine } else { $null }
         $machineUsers = [string[]]@()
         if ($null -ne $Context.AdvancedHuntingDeviceUsers -and -not [string]::IsNullOrWhiteSpace($DeviceId)) {
             $rawMachineUsers = $Context.AdvancedHuntingDeviceUsers[[string]$DeviceId]
@@ -13099,18 +13128,18 @@ function Add-NormalizedDevice {
 
         $machineInfo = $null
         if ($machine -or $machineUsers.Count -gt 0) {
-            $machineLastSeen = if ($machineTuple) { $machineTuple[8] } elseif ($machine) { $machine.PSObject.Properties['lastSeen']?.Value } else { $null }
-            $machineFirstSeen = if ($machineTuple) { $machineTuple[9] } elseif ($machine) { $machine.PSObject.Properties['firstSeen']?.Value } else { $null }
+            $machineLastSeen = Get-NormalizationMachinePropertyValue -Machine $machine -MachineTuple $machineTuple -PropertyName 'lastSeen' -TupleIndex 8
+            $machineFirstSeen = Get-NormalizationMachinePropertyValue -Machine $machine -MachineTuple $machineTuple -PropertyName 'firstSeen' -TupleIndex 9
             $machineInfo = [PSCustomObject]@{
-                ip = if ($machineTuple) { $machineTuple[0] } elseif ($machine) { $machine.PSObject.Properties['lastIpAddress']?.Value } else { $null }
-                eip = if ($machineTuple) { $machineTuple[1] } elseif ($machine) { $machine.PSObject.Properties['lastExternalIpAddress']?.Value } else { $null }
+                ip = Get-NormalizationMachinePropertyValue -Machine $machine -MachineTuple $machineTuple -PropertyName 'lastIpAddress' -TupleIndex 0
+                eip = Get-NormalizationMachinePropertyValue -Machine $machine -MachineTuple $machineTuple -PropertyName 'lastExternalIpAddress' -TupleIndex 1
                 u = if ($machineUsers.Count -gt 0) { @($machineUsers) } else { $null }
-                hs = if ($machineTuple) { $machineTuple[2] } elseif ($machine) { $machine.PSObject.Properties['healthStatus']?.Value } else { $null }
-                rs = if ($machineTuple) { $machineTuple[3] } elseif ($machine) { $machine.PSObject.Properties['riskScore']?.Value } else { $null }
-                el = if ($machineTuple) { $machineTuple[4] } elseif ($machine) { $machine.PSObject.Properties['exposureLevel']?.Value } else { $null }
-                dv = if ($machineTuple) { $machineTuple[5] } elseif ($machine) { $machine.PSObject.Properties['deviceValue']?.Value } else { $null }
-                mb = if ($machineTuple) { $machineTuple[6] } elseif ($machine) { $machine.PSObject.Properties['managedBy']?.Value } else { $null }
-                aad = if ($machineTuple) { $machineTuple[7] } elseif ($machine) { $machine.PSObject.Properties['isAadJoined']?.Value } else { $null }
+                hs = Get-NormalizationMachinePropertyValue -Machine $machine -MachineTuple $machineTuple -PropertyName 'healthStatus' -TupleIndex 2
+                rs = Get-NormalizationMachinePropertyValue -Machine $machine -MachineTuple $machineTuple -PropertyName 'riskScore' -TupleIndex 3
+                el = Get-NormalizationMachinePropertyValue -Machine $machine -MachineTuple $machineTuple -PropertyName 'exposureLevel' -TupleIndex 4
+                dv = Get-NormalizationMachinePropertyValue -Machine $machine -MachineTuple $machineTuple -PropertyName 'deviceValue' -TupleIndex 5
+                mb = Get-NormalizationMachinePropertyValue -Machine $machine -MachineTuple $machineTuple -PropertyName 'managedBy' -TupleIndex 6
+                aad = Get-NormalizationMachinePropertyValue -Machine $machine -MachineTuple $machineTuple -PropertyName 'isAadJoined' -TupleIndex 7
                 ls = Get-NormalizationCachedYmdDate -Context $Context -DateValue $machineLastSeen
                 fs = Get-NormalizationCachedYmdDate -Context $Context -DateValue $machineFirstSeen
             }
@@ -13118,10 +13147,10 @@ function Add-NormalizedDevice {
 
         $lookups.devices.Add([PSCustomObject]@{
             id = $DeviceId
-            n = if ($DeviceName) { $DeviceName } elseif ($machine -and -not $machineTuple) { $machine.PSObject.Properties['computerDnsName']?.Value } else { '(no machine data)' }
+            n = if ($DeviceName) { $DeviceName } elseif ($machine -and -not $machineTuple) { Get-NormalizationMachinePropertyValue -Machine $machine -MachineTuple $machineTuple -PropertyName 'computerDnsName' } else { '(no machine data)' }
             g = $groupIdx
             o = $platIdx
-            ov = if ($OsVersion) { $OsVersion } elseif ($machine -and -not $machineTuple) { $machine.PSObject.Properties['osVersion']?.Value } else { $null }
+            ov = if ($OsVersion) { $OsVersion } elseif ($machine -and -not $machineTuple) { Get-NormalizationMachinePropertyValue -Machine $machine -MachineTuple $machineTuple -PropertyName 'osVersion' } else { $null }
             t = $tagIndices
             m = $machineInfo
         })

--- a/azure/Invoke-DashboardPipeline.ps1
+++ b/azure/Invoke-DashboardPipeline.ps1
@@ -13235,6 +13235,35 @@ function Add-NormalizedDevice {
     )
 
     $lookups = $Context.Lookups
+
+    function Get-NormalizationMachinePropertyValue {
+        [CmdletBinding()]
+        param(
+            [Parameter(Mandatory = $false)]
+            [AllowNull()]
+            [object]$Machine,
+
+            [Parameter(Mandatory = $false)]
+            [AllowNull()]
+            [object[]]$MachineTuple,
+
+            [Parameter(Mandatory = $true)]
+            [string]$PropertyName,
+
+            [Parameter(Mandatory = $false)]
+            [int]$TupleIndex = -1
+        )
+
+        if ($null -ne $MachineTuple -and $TupleIndex -ge 0) {
+            return $MachineTuple[$TupleIndex]
+        }
+
+        if ($null -eq $Machine -or $null -ne $MachineTuple) {
+            return $null
+        }
+
+        return $Machine.PSObject.Properties[$PropertyName]?.Value
+    }
     $deviceIndex = $Context.Indexes.devices
     $groupIndex = $Context.Indexes.groups
     $platformIndex = $Context.Indexes.platforms
@@ -13254,7 +13283,7 @@ function Add-NormalizedDevice {
 
     if (-not $deviceIndex.ContainsKey($deviceKey)) {
         $machine = if (-not [string]::IsNullOrWhiteSpace($DeviceId)) { $Context.Machines[$DeviceId] } else { $null }
-        $machineTuple = if ($machine -is [System.Array] -and $machine.Length -ge 10) { $machine } else { $null }
+        $machineTuple = if ($machine -is [System.Array] -and $machine.Length -ge 10) { [object[]]$machine } else { $null }
         $machineUsers = [string[]]@()
         if ($null -ne $Context.AdvancedHuntingDeviceUsers -and -not [string]::IsNullOrWhiteSpace($DeviceId)) {
             $rawMachineUsers = $Context.AdvancedHuntingDeviceUsers[[string]$DeviceId]
@@ -13288,18 +13317,18 @@ function Add-NormalizedDevice {
 
         $machineInfo = $null
         if ($machine -or $machineUsers.Count -gt 0) {
-            $machineLastSeen = if ($machineTuple) { $machineTuple[8] } elseif ($machine) { $machine.PSObject.Properties['lastSeen']?.Value } else { $null }
-            $machineFirstSeen = if ($machineTuple) { $machineTuple[9] } elseif ($machine) { $machine.PSObject.Properties['firstSeen']?.Value } else { $null }
+            $machineLastSeen = Get-NormalizationMachinePropertyValue -Machine $machine -MachineTuple $machineTuple -PropertyName 'lastSeen' -TupleIndex 8
+            $machineFirstSeen = Get-NormalizationMachinePropertyValue -Machine $machine -MachineTuple $machineTuple -PropertyName 'firstSeen' -TupleIndex 9
             $machineInfo = [PSCustomObject]@{
-                ip = if ($machineTuple) { $machineTuple[0] } elseif ($machine) { $machine.PSObject.Properties['lastIpAddress']?.Value } else { $null }
-                eip = if ($machineTuple) { $machineTuple[1] } elseif ($machine) { $machine.PSObject.Properties['lastExternalIpAddress']?.Value } else { $null }
+                ip = Get-NormalizationMachinePropertyValue -Machine $machine -MachineTuple $machineTuple -PropertyName 'lastIpAddress' -TupleIndex 0
+                eip = Get-NormalizationMachinePropertyValue -Machine $machine -MachineTuple $machineTuple -PropertyName 'lastExternalIpAddress' -TupleIndex 1
                 u = if ($machineUsers.Count -gt 0) { @($machineUsers) } else { $null }
-                hs = if ($machineTuple) { $machineTuple[2] } elseif ($machine) { $machine.PSObject.Properties['healthStatus']?.Value } else { $null }
-                rs = if ($machineTuple) { $machineTuple[3] } elseif ($machine) { $machine.PSObject.Properties['riskScore']?.Value } else { $null }
-                el = if ($machineTuple) { $machineTuple[4] } elseif ($machine) { $machine.PSObject.Properties['exposureLevel']?.Value } else { $null }
-                dv = if ($machineTuple) { $machineTuple[5] } elseif ($machine) { $machine.PSObject.Properties['deviceValue']?.Value } else { $null }
-                mb = if ($machineTuple) { $machineTuple[6] } elseif ($machine) { $machine.PSObject.Properties['managedBy']?.Value } else { $null }
-                aad = if ($machineTuple) { $machineTuple[7] } elseif ($machine) { $machine.PSObject.Properties['isAadJoined']?.Value } else { $null }
+                hs = Get-NormalizationMachinePropertyValue -Machine $machine -MachineTuple $machineTuple -PropertyName 'healthStatus' -TupleIndex 2
+                rs = Get-NormalizationMachinePropertyValue -Machine $machine -MachineTuple $machineTuple -PropertyName 'riskScore' -TupleIndex 3
+                el = Get-NormalizationMachinePropertyValue -Machine $machine -MachineTuple $machineTuple -PropertyName 'exposureLevel' -TupleIndex 4
+                dv = Get-NormalizationMachinePropertyValue -Machine $machine -MachineTuple $machineTuple -PropertyName 'deviceValue' -TupleIndex 5
+                mb = Get-NormalizationMachinePropertyValue -Machine $machine -MachineTuple $machineTuple -PropertyName 'managedBy' -TupleIndex 6
+                aad = Get-NormalizationMachinePropertyValue -Machine $machine -MachineTuple $machineTuple -PropertyName 'isAadJoined' -TupleIndex 7
                 ls = Get-NormalizationCachedYmdDate -Context $Context -DateValue $machineLastSeen
                 fs = Get-NormalizationCachedYmdDate -Context $Context -DateValue $machineFirstSeen
             }
@@ -13307,10 +13336,10 @@ function Add-NormalizedDevice {
 
         $lookups.devices.Add([PSCustomObject]@{
             id = $DeviceId
-            n = if ($DeviceName) { $DeviceName } elseif ($machine -and -not $machineTuple) { $machine.PSObject.Properties['computerDnsName']?.Value } else { '(no machine data)' }
+            n = if ($DeviceName) { $DeviceName } elseif ($machine -and -not $machineTuple) { Get-NormalizationMachinePropertyValue -Machine $machine -MachineTuple $machineTuple -PropertyName 'computerDnsName' } else { '(no machine data)' }
             g = $groupIdx
             o = $platIdx
-            ov = if ($OsVersion) { $OsVersion } elseif ($machine -and -not $machineTuple) { $machine.PSObject.Properties['osVersion']?.Value } else { $null }
+            ov = if ($OsVersion) { $OsVersion } elseif ($machine -and -not $machineTuple) { Get-NormalizationMachinePropertyValue -Machine $machine -MachineTuple $machineTuple -PropertyName 'osVersion' } else { $null }
             t = $tagIndices
             m = $machineInfo
         })

--- a/azure/Invoke-DashboardPipeline.ps1
+++ b/azure/Invoke-DashboardPipeline.ps1
@@ -11276,6 +11276,49 @@ function Get-FileSha256Hex {
     }
 }
 
+function Get-FileSetFingerprint {
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Version,
+
+        [Parameter(Mandatory = $true)]
+        [System.IO.FileInfo[]]$Files,
+
+        [Parameter(Mandatory = $false)]
+        [string[]]$MetadataLines,
+
+        [Parameter(Mandatory = $false)]
+        [ValidateSet('FullName', 'Name')]
+        [string]$FileIdentityProperty = 'FullName'
+    )
+
+    $uniqueFiles = @($Files | Where-Object { $null -ne $_ } | Sort-Object FullName -Unique)
+    if ($uniqueFiles.Count -eq 0) {
+        return $null
+    }
+
+    $builder = [System.Text.StringBuilder]::new()
+    [void]$builder.AppendLine($Version)
+    foreach ($line in @($MetadataLines)) {
+        [void]$builder.AppendLine([string]$line)
+    }
+
+    foreach ($file in $uniqueFiles) {
+        $hash = Get-FileSha256Hex -Path $file.FullName
+        $fileIdentity = if ($FileIdentityProperty -eq 'Name') { $file.Name } else { $file.FullName }
+        [void]$builder.Append($fileIdentity).Append('|')
+        [void]$builder.Append($file.Length).Append('|')
+        [void]$builder.Append($file.LastWriteTimeUtc.Ticks).Append('|')
+        [void]$builder.AppendLine($hash)
+    }
+
+    $fingerprintBytes = [System.Text.Encoding]::UTF8.GetBytes($builder.ToString())
+    $fingerprintHash = [System.Security.Cryptography.SHA256]::HashData($fingerprintBytes)
+    return ([System.BitConverter]::ToString($fingerprintHash)).Replace('-', '').ToLowerInvariant()
+}
+
 function Sync-VulnContentStoreSidecar {
     [CmdletBinding()]
     [OutputType([bool])]
@@ -11352,21 +11395,10 @@ function Get-VulnObservedWindowCacheFingerprint {
         return $null
     }
 
-    $builder = [System.Text.StringBuilder]::new()
-    [void]$builder.AppendLine('observed-window-cache-v2')
-    [void]$builder.AppendLine(('AllowedGapDays=' + $AllowedGapDays))
-    [void]$builder.AppendLine(('CacheShape=' + $(if ($contentStoreExists) { 'compact-ref-array-v1' } else { 'row-object-v1' })))
-    foreach ($file in @($sourceFiles | Sort-Object FullName -Unique)) {
-        $hash = Get-FileSha256Hex -Path $file.FullName
-        [void]$builder.Append($file.Name).Append('|')
-        [void]$builder.Append($file.Length).Append('|')
-        [void]$builder.Append($file.LastWriteTimeUtc.Ticks).Append('|')
-        [void]$builder.AppendLine($hash)
-    }
-
-    $fingerprintBytes = [System.Text.Encoding]::UTF8.GetBytes($builder.ToString())
-    $fingerprintHash = [System.Security.Cryptography.SHA256]::HashData($fingerprintBytes)
-    return ([System.BitConverter]::ToString($fingerprintHash)).Replace('-', '').ToLowerInvariant()
+    return (Get-FileSetFingerprint -Version 'observed-window-cache-v2' -Files @($sourceFiles) -MetadataLines @(
+            ('AllowedGapDays=' + $AllowedGapDays)
+            ('CacheShape=' + $(if ($contentStoreExists) { 'compact-ref-array-v1' } else { 'row-object-v1' }))
+        ) -FileIdentityProperty Name)
 }
 
 function Get-VulnObservedWindowCachePath {
@@ -11838,20 +11870,9 @@ function Get-NormalizedVulnColumnCacheFingerprint {
             return $null
         }
 
-        $builder = [System.Text.StringBuilder]::new()
-        [void]$builder.AppendLine('dashboard-vuln-column-cache-v1')
-        [void]$builder.AppendLine(('SkipObservedWindowMerge=' + ($SkipObservedWindowMerge -eq $true)))
-        foreach ($file in @($files | Sort-Object FullName -Unique)) {
-            $hash = Get-FileSha256Hex -Path $file.FullName
-            [void]$builder.Append($file.FullName).Append('|')
-            [void]$builder.Append($file.Length).Append('|')
-            [void]$builder.Append($file.LastWriteTimeUtc.Ticks).Append('|')
-            [void]$builder.AppendLine($hash)
-        }
-
-    $fingerprintBytes = [System.Text.Encoding]::UTF8.GetBytes($builder.ToString())
-    $fingerprintHash = [System.Security.Cryptography.SHA256]::HashData($fingerprintBytes)
-    return ([System.BitConverter]::ToString($fingerprintHash)).Replace('-', '').ToLowerInvariant()
+        return (Get-FileSetFingerprint -Version 'dashboard-vuln-column-cache-v1' -Files @($files) -MetadataLines @(
+                ('SkipObservedWindowMerge=' + ($SkipObservedWindowMerge -eq $true))
+            ))
 }
 
 function Get-NormalizedVulnColumnCacheDirectoryPath {
@@ -12090,20 +12111,9 @@ function Get-DashboardPayloadCacheFingerprint {
         return $null
     }
 
-    $builder = [System.Text.StringBuilder]::new()
-    [void]$builder.AppendLine('dashboard-payload-cache-v5')
-    [void]$builder.AppendLine(('SkipObservedWindowMerge=' + ($SkipObservedWindowMerge -eq $true)))
-    foreach ($file in @($files | Sort-Object FullName -Unique)) {
-        $hash = Get-FileSha256Hex -Path $file.FullName
-        [void]$builder.Append($file.FullName).Append('|')
-        [void]$builder.Append($file.Length).Append('|')
-        [void]$builder.Append($file.LastWriteTimeUtc.Ticks).Append('|')
-        [void]$builder.AppendLine($hash)
-    }
-
-    $fingerprintBytes = [System.Text.Encoding]::UTF8.GetBytes($builder.ToString())
-    $fingerprintHash = [System.Security.Cryptography.SHA256]::HashData($fingerprintBytes)
-    return ([System.BitConverter]::ToString($fingerprintHash)).Replace('-', '').ToLowerInvariant()
+    return (Get-FileSetFingerprint -Version 'dashboard-payload-cache-v5' -Files @($files) -MetadataLines @(
+            ('SkipObservedWindowMerge=' + ($SkipObservedWindowMerge -eq $true))
+        ))
 }
 
 function Get-NormalizedPayloadCachePath {

--- a/build/Import-SharedHelpers.ps1
+++ b/build/Import-SharedHelpers.ps1
@@ -1,40 +1,20 @@
 ﻿[CmdletBinding()]
 param()
 
-$__generatedHelperPath = & {
-    param(
-        [Parameter(Mandatory = $true)]
-        [string]$RepoRoot
-    )
+$__repoRoot = Split-Path -Path $PSScriptRoot -Parent
+$__buildRoot = Join-Path $__repoRoot 'build'
+$__manifestToolsPath = Join-Path $__buildRoot 'private\ArtifactManifestTools.ps1'
 
-    $buildRoot = Join-Path $RepoRoot 'build'
-    $buildPath = Join-Path $RepoRoot 'build\Build-SharedHelpers.ps1'
-    $manifestToolsPath = Join-Path $buildRoot 'private\ArtifactManifestTools.ps1'
-    $manifestPath = Join-Path $buildRoot 'manifests\shared-helpers.json'
+if (-not (Test-Path -LiteralPath $__manifestToolsPath -PathType Leaf)) {
+    throw "Artifact manifest helper script not found at '$__manifestToolsPath'."
+}
 
-    if (-not (Test-Path -LiteralPath $buildPath -PathType Leaf)) {
-        throw "Shared helper build script not found at '$buildPath'."
-    }
+. $__manifestToolsPath
 
-    if (-not (Test-Path -LiteralPath $manifestToolsPath -PathType Leaf)) {
-        throw "Artifact manifest helper script not found at '$manifestToolsPath'."
-    }
-
-    . $manifestToolsPath
-
-    $artifactManifest = Read-PowerShellArtifactManifest -ManifestPath $manifestPath -RepoRoot $RepoRoot
-    $requiresBuild = Test-PowerShellArtifactRequiresBuild -ManifestPath $manifestPath -RepoRoot $RepoRoot -BuildScriptPath $buildPath
-
-    if ($requiresBuild) {
-        & $buildPath
-    }
-
-    if (-not (Test-Path -LiteralPath $artifactManifest.OutputPath -PathType Leaf)) {
-        throw "Shared helpers were not generated at '$($artifactManifest.OutputPath)'."
-    }
-
-    return $artifactManifest.OutputPath
-} (Split-Path -Path $PSScriptRoot -Parent)
+$__generatedHelperPath = Resolve-PowerShellArtifactOutputPath -ManifestPath (Join-Path $__buildRoot 'manifests\shared-helpers.json') -RepoRoot $__repoRoot -BuildScriptPath (Join-Path $__buildRoot 'Build-SharedHelpers.ps1') -BuildScriptNotFoundMessage "Shared helper build script not found at '{0}'." -MissingOutputMessage "Shared helpers were not generated at '{0}'."
 
 . $__generatedHelperPath
+Remove-Variable -Name __repoRoot -ErrorAction Ignore
+Remove-Variable -Name __buildRoot -ErrorAction Ignore
+Remove-Variable -Name __manifestToolsPath -ErrorAction Ignore
 Remove-Variable -Name __generatedHelperPath -ErrorAction Ignore

--- a/build/Import-ValidationHelpers.ps1
+++ b/build/Import-ValidationHelpers.ps1
@@ -1,51 +1,27 @@
 ﻿[CmdletBinding()]
 param()
 
-$__repoRoot = Split-Path -Path $PSScriptRoot -Parent
-$__sharedImportPath = Join-Path $__repoRoot 'build\Import-SharedHelpers.ps1'
+$__validationRepoRoot = Split-Path -Path $PSScriptRoot -Parent
+$__validationBuildRoot = Join-Path $__validationRepoRoot 'build'
+$__validationSharedImportPath = Join-Path $__validationRepoRoot 'build\Import-SharedHelpers.ps1'
+$__validationManifestToolsPath = Join-Path $__validationBuildRoot 'private\ArtifactManifestTools.ps1'
 
-if (-not (Test-Path -LiteralPath $__sharedImportPath -PathType Leaf)) {
-    throw "Shared helper import script not found at '$__sharedImportPath'."
+if (-not (Test-Path -LiteralPath $__validationSharedImportPath -PathType Leaf)) {
+    throw "Shared helper import script not found at '$__validationSharedImportPath'."
 }
 
-. $__sharedImportPath
+if (-not (Test-Path -LiteralPath $__validationManifestToolsPath -PathType Leaf)) {
+    throw "Artifact manifest helper script not found at '$__validationManifestToolsPath'."
+}
 
-$__generatedHelperPath = & {
-    param(
-        [Parameter(Mandatory = $true)]
-        [string]$RepoRoot
-    )
+. $__validationSharedImportPath
+. $__validationManifestToolsPath
 
-    $buildRoot = Join-Path $RepoRoot 'build'
-    $buildPath = Join-Path $RepoRoot 'build\Build-ValidationHelpers.ps1'
-    $manifestToolsPath = Join-Path $buildRoot 'private\ArtifactManifestTools.ps1'
-    $manifestPath = Join-Path $buildRoot 'manifests\validation-helpers.json'
+$__validationGeneratedHelperPath = Resolve-PowerShellArtifactOutputPath -ManifestPath (Join-Path $__validationBuildRoot 'manifests\validation-helpers.json') -RepoRoot $__validationRepoRoot -BuildScriptPath (Join-Path $__validationBuildRoot 'Build-ValidationHelpers.ps1') -BuildScriptNotFoundMessage "Validation helper build script not found at '{0}'." -MissingOutputMessage "Validation helpers were not generated at '{0}'."
 
-    if (-not (Test-Path -LiteralPath $buildPath -PathType Leaf)) {
-        throw "Validation helper build script not found at '$buildPath'."
-    }
-
-    if (-not (Test-Path -LiteralPath $manifestToolsPath -PathType Leaf)) {
-        throw "Artifact manifest helper script not found at '$manifestToolsPath'."
-    }
-
-    . $manifestToolsPath
-
-    $artifactManifest = Read-PowerShellArtifactManifest -ManifestPath $manifestPath -RepoRoot $RepoRoot
-    $requiresBuild = Test-PowerShellArtifactRequiresBuild -ManifestPath $manifestPath -RepoRoot $RepoRoot -BuildScriptPath $buildPath
-
-    if ($requiresBuild) {
-        & $buildPath
-    }
-
-    if (-not (Test-Path -LiteralPath $artifactManifest.OutputPath -PathType Leaf)) {
-        throw "Validation helpers were not generated at '$($artifactManifest.OutputPath)'."
-    }
-
-    return $artifactManifest.OutputPath
-} $__repoRoot
-
-. $__generatedHelperPath
-Remove-Variable -Name __repoRoot -ErrorAction Ignore
-Remove-Variable -Name __sharedImportPath -ErrorAction Ignore
-Remove-Variable -Name __generatedHelperPath -ErrorAction Ignore
+. $__validationGeneratedHelperPath
+Remove-Variable -Name __validationRepoRoot -ErrorAction Ignore
+Remove-Variable -Name __validationBuildRoot -ErrorAction Ignore
+Remove-Variable -Name __validationSharedImportPath -ErrorAction Ignore
+Remove-Variable -Name __validationManifestToolsPath -ErrorAction Ignore
+Remove-Variable -Name __validationGeneratedHelperPath -ErrorAction Ignore

--- a/build/Invoke-AzureDeploymentValidation.ps1
+++ b/build/Invoke-AzureDeploymentValidation.ps1
@@ -1117,6 +1117,79 @@ function Get-FunctionExecutionActivity {
     }
 }
 
+function Get-FunctionMetricSummary {
+    [CmdletBinding()]
+    [OutputType([object])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$ResourceId,
+
+        [Parameter(Mandatory = $true)]
+        [datetime]$StartTimeUtc,
+
+        [Parameter(Mandatory = $true)]
+        [datetime]$EndTimeUtc
+    )
+
+    $metrics = Invoke-AzCliJson -Arguments @(
+        'monitor', 'metrics', 'list',
+        '--resource', $ResourceId,
+        '--start-time', $StartTimeUtc.ToString('o'),
+        '--end-time', $EndTimeUtc.ToString('o'),
+        '--interval', 'PT1M',
+        '--aggregation', 'Average', 'Maximum', 'Total',
+        '--metrics', 'MemoryWorkingSet', 'AverageMemoryWorkingSet', 'CpuPercentage', 'OnDemandFunctionExecutionUnits',
+        '-o', 'json'
+    )
+
+    $peakWorkingSetMb = 0.0
+    $averageWorkingSetMb = 0.0
+    $peakCpuPercentage = 0.0
+    $executionUnits = 0.0
+
+    foreach ($metric in @($metrics.value)) {
+        $metricName = [string]$metric.name.value
+        $dataPoints = @($metric.timeseries | ForEach-Object { $_.data })
+        foreach ($dataPoint in $dataPoints) {
+            switch ($metricName) {
+                'MemoryWorkingSet' {
+                    if ($null -ne $dataPoint.maximum) {
+                        $peakWorkingSetMb = [math]::Max($peakWorkingSetMb, ([double]$dataPoint.maximum / 1MB))
+                    }
+                    elseif ($null -ne $dataPoint.average) {
+                        $peakWorkingSetMb = [math]::Max($peakWorkingSetMb, ([double]$dataPoint.average / 1MB))
+                    }
+                }
+                'AverageMemoryWorkingSet' {
+                    if ($null -ne $dataPoint.average) {
+                        $averageWorkingSetMb = [math]::Max($averageWorkingSetMb, ([double]$dataPoint.average / 1MB))
+                    }
+                }
+                'CpuPercentage' {
+                    if ($null -ne $dataPoint.maximum) {
+                        $peakCpuPercentage = [math]::Max($peakCpuPercentage, [double]$dataPoint.maximum)
+                    }
+                    elseif ($null -ne $dataPoint.average) {
+                        $peakCpuPercentage = [math]::Max($peakCpuPercentage, [double]$dataPoint.average)
+                    }
+                }
+                'OnDemandFunctionExecutionUnits' {
+                    if ($null -ne $dataPoint.total) {
+                        $executionUnits += [double]$dataPoint.total
+                    }
+                }
+            }
+        }
+    }
+
+    return [PSCustomObject]@{
+        peak_working_set_mb = [math]::Round($peakWorkingSetMb, 1)
+        average_working_set_mb = [math]::Round($averageWorkingSetMb, 1)
+        peak_cpu_percentage = [math]::Round($peakCpuPercentage, 1)
+        execution_units = [math]::Round($executionUnits, 2)
+    }
+}
+
 function Get-FunctionTraceAccessState {
     [CmdletBinding()]
     [OutputType([string])]
@@ -1270,6 +1343,7 @@ function Invoke-FunctionExecutionValidation {
         $waitStopwatch = [System.Diagnostics.Stopwatch]::StartNew()
         $lastHeartbeatSecond = -60
         $executionActivity = $null
+        $metricSummary = $null
         $lastExecutionMetricPollUtc = [datetime]::MinValue
         $latestPipelineStatus = $null
         $latestPipelineStatusBlobUtc = $null
@@ -1285,6 +1359,7 @@ function Invoke-FunctionExecutionValidation {
 
             if ($nowUtc -ge $lastExecutionMetricPollUtc.AddSeconds(60)) {
                 $executionActivity = Get-FunctionExecutionActivity -ResourceId $functionResourceId -StartTimeUtc $invokeStartedUtc.AddMinutes(-1) -EndTimeUtc $nowUtc
+                $metricSummary = Get-FunctionMetricSummary -ResourceId $functionResourceId -StartTimeUtc $invokeStartedUtc.AddMinutes(-1) -EndTimeUtc $nowUtc
                 $lastExecutionMetricPollUtc = $nowUtc
             }
 
@@ -1333,9 +1408,27 @@ function Invoke-FunctionExecutionValidation {
                 else {
                     'none'
                 }
+                $peakWorkingSetText = if ($null -ne $metricSummary -and $metricSummary.PSObject.Properties['peak_working_set_mb']) {
+                    [string]([double]$metricSummary.peak_working_set_mb)
+                }
+                else {
+                    'n/a'
+                }
+                $averageWorkingSetText = if ($null -ne $metricSummary -and $metricSummary.PSObject.Properties['average_working_set_mb']) {
+                    [string]([double]$metricSummary.average_working_set_mb)
+                }
+                else {
+                    'n/a'
+                }
+                $executionUnitsText = if ($null -ne $metricSummary -and $metricSummary.PSObject.Properties['execution_units']) {
+                    [string]([double]$metricSummary.execution_units)
+                }
+                else {
+                    'n/a'
+                }
                 $pipelineStatusText = Get-FunctionExecutionStatusSummaryText -StatusDocument $latestPipelineStatus
 
-                Write-ValidationLogLine -Message ("Function execution heartbeat: {0}s elapsed; terminalStatus={1}; dashboardBlob={2}; executionCount={3}; latestExecutionMetric={4}; traceAccess={5}; pipelineStatus={6}; lastTrace={7}" -f $elapsedWholeSeconds, $terminalText, $blobText, $executionCount, $executionTimestampText, $traceAccessState, $pipelineStatusText, $lastTraceMessage)
+                Write-ValidationLogLine -Message ("Function execution heartbeat: {0}s elapsed; terminalStatus={1}; dashboardBlob={2}; executionCount={3}; latestExecutionMetric={4}; peakWorkingSetMb={5}; averageWorkingSetMb={6}; executionUnits={7}; traceAccess={8}; pipelineStatus={9}; lastTrace={10}" -f $elapsedWholeSeconds, $terminalText, $blobText, $executionCount, $executionTimestampText, $peakWorkingSetText, $averageWorkingSetText, $executionUnitsText, $traceAccessState, $pipelineStatusText, $lastTraceMessage)
                 $lastHeartbeatSecond = $elapsedWholeSeconds
             }
 
@@ -1343,6 +1436,7 @@ function Invoke-FunctionExecutionValidation {
         }
 
         $executionActivity = Get-FunctionExecutionActivity -ResourceId $functionResourceId -StartTimeUtc $invokeStartedUtc.AddMinutes(-1) -EndTimeUtc ([datetime]::UtcNow)
+        $metricSummary = Get-FunctionMetricSummary -ResourceId $functionResourceId -StartTimeUtc $invokeStartedUtc.AddMinutes(-1) -EndTimeUtc ([datetime]::UtcNow)
 
         if ($terminalStatus -eq 'Failed') {
             throw 'Function App trace reported pipeline failure.'
@@ -1401,6 +1495,7 @@ function Invoke-FunctionExecutionValidation {
             traceAccessState = $traceAccessState
             executionCount = if ($null -ne $executionActivity -and $executionActivity.PSObject.Properties['total_count']) { [int]$executionActivity.total_count } else { 0 }
             latestExecutionMetricUtc = if ($null -ne $executionActivity -and $executionActivity.PSObject.Properties['latest_timestamp_utc'] -and $null -ne $executionActivity.latest_timestamp_utc) { ([datetime]$executionActivity.latest_timestamp_utc).ToString('o') } else { $null }
+            hostedMetrics = $metricSummary
             pipelineStatus = $latestPipelineStatus
             recentTraceEvents = @($events | Select-Object -Last 12)
         }

--- a/build/private/ArtifactManifestTools.ps1
+++ b/build/private/ArtifactManifestTools.ps1
@@ -127,6 +127,43 @@ function Test-PowerShellArtifactRequiresBuild {
     return $false
 }
 
+function Resolve-PowerShellArtifactOutputPath {
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$ManifestPath,
+
+        [Parameter(Mandatory = $true)]
+        [string]$RepoRoot,
+
+        [Parameter(Mandatory = $true)]
+        [string]$BuildScriptPath,
+
+        [Parameter(Mandatory = $false)]
+        [string]$BuildScriptNotFoundMessage = "Build script not found at '{0}'.",
+
+        [Parameter(Mandatory = $false)]
+        [string]$MissingOutputMessage = "Artifact output was not generated at '{0}'."
+    )
+
+    $artifactManifest = Read-PowerShellArtifactManifest -ManifestPath $ManifestPath -RepoRoot $RepoRoot
+    if (-not (Test-Path -LiteralPath $BuildScriptPath -PathType Leaf)) {
+        throw ($BuildScriptNotFoundMessage -f $BuildScriptPath)
+    }
+
+    $requiresBuild = Test-PowerShellArtifactRequiresBuild -ManifestPath $ManifestPath -RepoRoot $RepoRoot -BuildScriptPath $BuildScriptPath
+    if ($requiresBuild) {
+        & $BuildScriptPath
+    }
+
+    if (-not (Test-Path -LiteralPath $artifactManifest.OutputPath -PathType Leaf)) {
+        throw ($MissingOutputMessage -f $artifactManifest.OutputPath)
+    }
+
+    return $artifactManifest.OutputPath
+}
+
 function Build-PowerShellArtifactFromManifest {
     [CmdletBinding()]
     [OutputType([pscustomobject])]

--- a/src/powershell/Shared/Dashboard/DashboardGeneration.ps1
+++ b/src/powershell/Shared/Dashboard/DashboardGeneration.ps1
@@ -2273,6 +2273,49 @@ function Get-FileSha256Hex {
     }
 }
 
+function Get-FileSetFingerprint {
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Version,
+
+        [Parameter(Mandatory = $true)]
+        [System.IO.FileInfo[]]$Files,
+
+        [Parameter(Mandatory = $false)]
+        [string[]]$MetadataLines,
+
+        [Parameter(Mandatory = $false)]
+        [ValidateSet('FullName', 'Name')]
+        [string]$FileIdentityProperty = 'FullName'
+    )
+
+    $uniqueFiles = @($Files | Where-Object { $null -ne $_ } | Sort-Object FullName -Unique)
+    if ($uniqueFiles.Count -eq 0) {
+        return $null
+    }
+
+    $builder = [System.Text.StringBuilder]::new()
+    [void]$builder.AppendLine($Version)
+    foreach ($line in @($MetadataLines)) {
+        [void]$builder.AppendLine([string]$line)
+    }
+
+    foreach ($file in $uniqueFiles) {
+        $hash = Get-FileSha256Hex -Path $file.FullName
+        $fileIdentity = if ($FileIdentityProperty -eq 'Name') { $file.Name } else { $file.FullName }
+        [void]$builder.Append($fileIdentity).Append('|')
+        [void]$builder.Append($file.Length).Append('|')
+        [void]$builder.Append($file.LastWriteTimeUtc.Ticks).Append('|')
+        [void]$builder.AppendLine($hash)
+    }
+
+    $fingerprintBytes = [System.Text.Encoding]::UTF8.GetBytes($builder.ToString())
+    $fingerprintHash = [System.Security.Cryptography.SHA256]::HashData($fingerprintBytes)
+    return ([System.BitConverter]::ToString($fingerprintHash)).Replace('-', '').ToLowerInvariant()
+}
+
 function Sync-VulnContentStoreSidecar {
     [CmdletBinding()]
     [OutputType([bool])]
@@ -2349,21 +2392,10 @@ function Get-VulnObservedWindowCacheFingerprint {
         return $null
     }
 
-    $builder = [System.Text.StringBuilder]::new()
-    [void]$builder.AppendLine('observed-window-cache-v2')
-    [void]$builder.AppendLine(('AllowedGapDays=' + $AllowedGapDays))
-    [void]$builder.AppendLine(('CacheShape=' + $(if ($contentStoreExists) { 'compact-ref-array-v1' } else { 'row-object-v1' })))
-    foreach ($file in @($sourceFiles | Sort-Object FullName -Unique)) {
-        $hash = Get-FileSha256Hex -Path $file.FullName
-        [void]$builder.Append($file.Name).Append('|')
-        [void]$builder.Append($file.Length).Append('|')
-        [void]$builder.Append($file.LastWriteTimeUtc.Ticks).Append('|')
-        [void]$builder.AppendLine($hash)
-    }
-
-    $fingerprintBytes = [System.Text.Encoding]::UTF8.GetBytes($builder.ToString())
-    $fingerprintHash = [System.Security.Cryptography.SHA256]::HashData($fingerprintBytes)
-    return ([System.BitConverter]::ToString($fingerprintHash)).Replace('-', '').ToLowerInvariant()
+    return (Get-FileSetFingerprint -Version 'observed-window-cache-v2' -Files @($sourceFiles) -MetadataLines @(
+            ('AllowedGapDays=' + $AllowedGapDays)
+            ('CacheShape=' + $(if ($contentStoreExists) { 'compact-ref-array-v1' } else { 'row-object-v1' }))
+        ) -FileIdentityProperty Name)
 }
 
 function Get-VulnObservedWindowCachePath {
@@ -2835,20 +2867,9 @@ function Get-NormalizedVulnColumnCacheFingerprint {
             return $null
         }
 
-        $builder = [System.Text.StringBuilder]::new()
-        [void]$builder.AppendLine('dashboard-vuln-column-cache-v1')
-        [void]$builder.AppendLine(('SkipObservedWindowMerge=' + ($SkipObservedWindowMerge -eq $true)))
-        foreach ($file in @($files | Sort-Object FullName -Unique)) {
-            $hash = Get-FileSha256Hex -Path $file.FullName
-            [void]$builder.Append($file.FullName).Append('|')
-            [void]$builder.Append($file.Length).Append('|')
-            [void]$builder.Append($file.LastWriteTimeUtc.Ticks).Append('|')
-            [void]$builder.AppendLine($hash)
-        }
-
-    $fingerprintBytes = [System.Text.Encoding]::UTF8.GetBytes($builder.ToString())
-    $fingerprintHash = [System.Security.Cryptography.SHA256]::HashData($fingerprintBytes)
-    return ([System.BitConverter]::ToString($fingerprintHash)).Replace('-', '').ToLowerInvariant()
+        return (Get-FileSetFingerprint -Version 'dashboard-vuln-column-cache-v1' -Files @($files) -MetadataLines @(
+                ('SkipObservedWindowMerge=' + ($SkipObservedWindowMerge -eq $true))
+            ))
 }
 
 function Get-NormalizedVulnColumnCacheDirectoryPath {
@@ -3087,20 +3108,9 @@ function Get-DashboardPayloadCacheFingerprint {
         return $null
     }
 
-    $builder = [System.Text.StringBuilder]::new()
-    [void]$builder.AppendLine('dashboard-payload-cache-v5')
-    [void]$builder.AppendLine(('SkipObservedWindowMerge=' + ($SkipObservedWindowMerge -eq $true)))
-    foreach ($file in @($files | Sort-Object FullName -Unique)) {
-        $hash = Get-FileSha256Hex -Path $file.FullName
-        [void]$builder.Append($file.FullName).Append('|')
-        [void]$builder.Append($file.Length).Append('|')
-        [void]$builder.Append($file.LastWriteTimeUtc.Ticks).Append('|')
-        [void]$builder.AppendLine($hash)
-    }
-
-    $fingerprintBytes = [System.Text.Encoding]::UTF8.GetBytes($builder.ToString())
-    $fingerprintHash = [System.Security.Cryptography.SHA256]::HashData($fingerprintBytes)
-    return ([System.BitConverter]::ToString($fingerprintHash)).Replace('-', '').ToLowerInvariant()
+    return (Get-FileSetFingerprint -Version 'dashboard-payload-cache-v5' -Files @($files) -MetadataLines @(
+            ('SkipObservedWindowMerge=' + ($SkipObservedWindowMerge -eq $true))
+        ))
 }
 
 function Get-NormalizedPayloadCachePath {

--- a/src/powershell/Shared/Dashboard/DashboardGeneration.ps1
+++ b/src/powershell/Shared/Dashboard/DashboardGeneration.ps1
@@ -4507,6 +4507,11 @@ function Resolve-NormalizedInventoryLookup {
         [pscustomobject]$Context
     )
 
+    $inventoryData = $Context.AdvancedHuntingInventoryData
+    if ($null -eq $inventoryData -or $inventoryData.Count -eq 0) {
+        return -1
+    }
+
     $inventoryKey = Get-AdvancedHuntingInventoryMatchKey `
         -DeviceId ([string]$DeviceId) `
         -SoftwareVendor ([string]($SoftwareVendor ?? '')) `
@@ -4516,7 +4521,7 @@ function Resolve-NormalizedInventoryLookup {
         return -1
     }
 
-    $inventoryRecord = $Context.AdvancedHuntingInventoryData[$inventoryKey]
+    $inventoryRecord = $inventoryData[$inventoryKey]
     if ($null -eq $inventoryRecord) {
         return -1
     }

--- a/src/powershell/Shared/Dashboard/DashboardGeneration.ps1
+++ b/src/powershell/Shared/Dashboard/DashboardGeneration.ps1
@@ -5250,8 +5250,8 @@ function Invoke-ContentStoreNormalization {
             -RecommendedSecurityUpdateId ([string]$contentTemplate.rid) `
             -RecommendedSecurityUpdateUrl ([string]$contentTemplate.url) `
             -SoftwareVersion ([string]$contentTemplate.ver) `
-            -DiskPaths @($contentTemplate.dp) `
-            -RegistryPaths @($contentTemplate.rp) `
+            -DiskPaths $contentTemplate.dp `
+            -RegistryPaths $contentTemplate.rp `
             -SecurityUpdateAvailable ($contentTemplate.ua -eq $true) `
             -Context $Context
 

--- a/src/powershell/Shared/Dashboard/DashboardGeneration.ps1
+++ b/src/powershell/Shared/Dashboard/DashboardGeneration.ps1
@@ -4463,12 +4463,12 @@ function Resolve-NormalizedLookupIndexList {
         [hashtable]$IndexMap
     )
 
-    if ($null -eq $Values -or @($Values).Count -eq 0) {
+    if ($null -eq $Values -or $Values.Count -eq 0) {
         return $null
     }
 
     $indices = [System.Collections.Generic.List[int]]::new()
-    foreach ($value in @($Values)) {
+    foreach ($value in $Values) {
         if ($null -eq $value) { continue }
         $index = Get-OrCreateIndex -value $value -list $List -indexMap $IndexMap
         if ($index -ge 0) {

--- a/src/powershell/Shared/Dashboard/DashboardGeneration.ps1
+++ b/src/powershell/Shared/Dashboard/DashboardGeneration.ps1
@@ -4222,6 +4222,35 @@ function Add-NormalizedDevice {
     )
 
     $lookups = $Context.Lookups
+
+    function Get-NormalizationMachinePropertyValue {
+        [CmdletBinding()]
+        param(
+            [Parameter(Mandatory = $false)]
+            [AllowNull()]
+            [object]$Machine,
+
+            [Parameter(Mandatory = $false)]
+            [AllowNull()]
+            [object[]]$MachineTuple,
+
+            [Parameter(Mandatory = $true)]
+            [string]$PropertyName,
+
+            [Parameter(Mandatory = $false)]
+            [int]$TupleIndex = -1
+        )
+
+        if ($null -ne $MachineTuple -and $TupleIndex -ge 0) {
+            return $MachineTuple[$TupleIndex]
+        }
+
+        if ($null -eq $Machine -or $null -ne $MachineTuple) {
+            return $null
+        }
+
+        return $Machine.PSObject.Properties[$PropertyName]?.Value
+    }
     $deviceIndex = $Context.Indexes.devices
     $groupIndex = $Context.Indexes.groups
     $platformIndex = $Context.Indexes.platforms
@@ -4241,7 +4270,7 @@ function Add-NormalizedDevice {
 
     if (-not $deviceIndex.ContainsKey($deviceKey)) {
         $machine = if (-not [string]::IsNullOrWhiteSpace($DeviceId)) { $Context.Machines[$DeviceId] } else { $null }
-        $machineTuple = if ($machine -is [System.Array] -and $machine.Length -ge 10) { $machine } else { $null }
+        $machineTuple = if ($machine -is [System.Array] -and $machine.Length -ge 10) { [object[]]$machine } else { $null }
         $machineUsers = [string[]]@()
         if ($null -ne $Context.AdvancedHuntingDeviceUsers -and -not [string]::IsNullOrWhiteSpace($DeviceId)) {
             $rawMachineUsers = $Context.AdvancedHuntingDeviceUsers[[string]$DeviceId]
@@ -4275,18 +4304,18 @@ function Add-NormalizedDevice {
 
         $machineInfo = $null
         if ($machine -or $machineUsers.Count -gt 0) {
-            $machineLastSeen = if ($machineTuple) { $machineTuple[8] } elseif ($machine) { $machine.PSObject.Properties['lastSeen']?.Value } else { $null }
-            $machineFirstSeen = if ($machineTuple) { $machineTuple[9] } elseif ($machine) { $machine.PSObject.Properties['firstSeen']?.Value } else { $null }
+            $machineLastSeen = Get-NormalizationMachinePropertyValue -Machine $machine -MachineTuple $machineTuple -PropertyName 'lastSeen' -TupleIndex 8
+            $machineFirstSeen = Get-NormalizationMachinePropertyValue -Machine $machine -MachineTuple $machineTuple -PropertyName 'firstSeen' -TupleIndex 9
             $machineInfo = [PSCustomObject]@{
-                ip = if ($machineTuple) { $machineTuple[0] } elseif ($machine) { $machine.PSObject.Properties['lastIpAddress']?.Value } else { $null }
-                eip = if ($machineTuple) { $machineTuple[1] } elseif ($machine) { $machine.PSObject.Properties['lastExternalIpAddress']?.Value } else { $null }
+                ip = Get-NormalizationMachinePropertyValue -Machine $machine -MachineTuple $machineTuple -PropertyName 'lastIpAddress' -TupleIndex 0
+                eip = Get-NormalizationMachinePropertyValue -Machine $machine -MachineTuple $machineTuple -PropertyName 'lastExternalIpAddress' -TupleIndex 1
                 u = if ($machineUsers.Count -gt 0) { @($machineUsers) } else { $null }
-                hs = if ($machineTuple) { $machineTuple[2] } elseif ($machine) { $machine.PSObject.Properties['healthStatus']?.Value } else { $null }
-                rs = if ($machineTuple) { $machineTuple[3] } elseif ($machine) { $machine.PSObject.Properties['riskScore']?.Value } else { $null }
-                el = if ($machineTuple) { $machineTuple[4] } elseif ($machine) { $machine.PSObject.Properties['exposureLevel']?.Value } else { $null }
-                dv = if ($machineTuple) { $machineTuple[5] } elseif ($machine) { $machine.PSObject.Properties['deviceValue']?.Value } else { $null }
-                mb = if ($machineTuple) { $machineTuple[6] } elseif ($machine) { $machine.PSObject.Properties['managedBy']?.Value } else { $null }
-                aad = if ($machineTuple) { $machineTuple[7] } elseif ($machine) { $machine.PSObject.Properties['isAadJoined']?.Value } else { $null }
+                hs = Get-NormalizationMachinePropertyValue -Machine $machine -MachineTuple $machineTuple -PropertyName 'healthStatus' -TupleIndex 2
+                rs = Get-NormalizationMachinePropertyValue -Machine $machine -MachineTuple $machineTuple -PropertyName 'riskScore' -TupleIndex 3
+                el = Get-NormalizationMachinePropertyValue -Machine $machine -MachineTuple $machineTuple -PropertyName 'exposureLevel' -TupleIndex 4
+                dv = Get-NormalizationMachinePropertyValue -Machine $machine -MachineTuple $machineTuple -PropertyName 'deviceValue' -TupleIndex 5
+                mb = Get-NormalizationMachinePropertyValue -Machine $machine -MachineTuple $machineTuple -PropertyName 'managedBy' -TupleIndex 6
+                aad = Get-NormalizationMachinePropertyValue -Machine $machine -MachineTuple $machineTuple -PropertyName 'isAadJoined' -TupleIndex 7
                 ls = Get-NormalizationCachedYmdDate -Context $Context -DateValue $machineLastSeen
                 fs = Get-NormalizationCachedYmdDate -Context $Context -DateValue $machineFirstSeen
             }
@@ -4294,10 +4323,10 @@ function Add-NormalizedDevice {
 
         $lookups.devices.Add([PSCustomObject]@{
             id = $DeviceId
-            n = if ($DeviceName) { $DeviceName } elseif ($machine -and -not $machineTuple) { $machine.PSObject.Properties['computerDnsName']?.Value } else { '(no machine data)' }
+            n = if ($DeviceName) { $DeviceName } elseif ($machine -and -not $machineTuple) { Get-NormalizationMachinePropertyValue -Machine $machine -MachineTuple $machineTuple -PropertyName 'computerDnsName' } else { '(no machine data)' }
             g = $groupIdx
             o = $platIdx
-            ov = if ($OsVersion) { $OsVersion } elseif ($machine -and -not $machineTuple) { $machine.PSObject.Properties['osVersion']?.Value } else { $null }
+            ov = if ($OsVersion) { $OsVersion } elseif ($machine -and -not $machineTuple) { Get-NormalizationMachinePropertyValue -Machine $machine -MachineTuple $machineTuple -PropertyName 'osVersion' } else { $null }
             t = $tagIndices
             m = $machineInfo
         })

--- a/src/powershell/Shared/Dashboard/DashboardGeneration.ps1
+++ b/src/powershell/Shared/Dashboard/DashboardGeneration.ps1
@@ -3625,7 +3625,7 @@ function Get-GzipLine {
 function Get-OrCreateIndex {
     param($value, $list, $indexMap)
     if ($null -eq $value -or $value -eq '') { return -1 }
-    $key = $value.ToString()
+    $key = if ($value -is [string]) { $value } else { $value.ToString() }
     if (-not $indexMap.ContainsKey($key)) {
         $indexMap[$key] = $list.Count
         $list.Add($key)
@@ -4559,7 +4559,7 @@ function Resolve-NormalizedSeenWindowIndexSet {
     $firstSeen = Get-NormalizationCachedYmdDate -Context $Context -DateValue $FirstSeenValue
     $lastSeen = Get-NormalizationCachedYmdDate -Context $Context -DateValue $LastSeenValue
 
-    if ($firstSeen -and $lastSeen -and [datetime]$firstSeen -gt [datetime]$lastSeen) {
+    if ($firstSeen -and $lastSeen -and $firstSeen -gt $lastSeen) {
         $temp = $firstSeen
         $firstSeen = $lastSeen
         $lastSeen = $temp
@@ -4800,12 +4800,23 @@ function Get-NormalizedRecordLookup {
         -SecurityUpdateAvailable $SecurityUpdateAvailable `
         -Context $Context
 
-    Add-Member -InputObject $contentLookup -NotePropertyName inv -NotePropertyValue (Resolve-NormalizedInventoryLookup `
+    $inventoryLookup = Resolve-NormalizedInventoryLookup `
         -DeviceId $DeviceId `
         -SoftwareVendor $SoftwareVendor `
         -SoftwareName $SoftwareName `
         -SoftwareVersion $SoftwareVersion `
-        -Context $Context) -Force
+        -Context $Context
+
+    $contentLookup = [PSCustomObject]@{
+        sw = $contentLookup.sw
+        cve = $contentLookup.cve
+        ver = $contentLookup.ver
+        upd = $contentLookup.upd
+        ua = $contentLookup.ua
+        dp = $contentLookup.dp
+        rp = $contentLookup.rp
+        inv = $inventoryLookup
+    }
 
     return [PSCustomObject]@{
         DeviceIndex = Add-NormalizedDevice `

--- a/src/powershell/Shared/Dashboard/DashboardGeneration.ps1
+++ b/src/powershell/Shared/Dashboard/DashboardGeneration.ps1
@@ -4407,8 +4407,12 @@ function Add-NormalizedCve {
             if ($ahData.ContainsKey('IsExploitAvailable')) {
                 $isExploitAvailable = $ahData.IsExploitAvailable
             }
-            if ($ahData.AffectedSoftware) {
-                $affSoftwareIndices = Resolve-NormalizedLookupIndexList -Values $ahData.AffectedSoftware -List $lookups.affSoftware -IndexMap $affSoftwareIndex
+            if ($ahData.AffectedSoftware -and @($ahData.AffectedSoftware).Count -gt 0) {
+                $affSoftwareIndices = [System.Collections.Generic.List[int]]::new()
+                foreach ($sw in @($ahData.AffectedSoftware)) {
+                    $asIdx = Get-OrCreateIndex -value $sw -list $lookups.affSoftware -indexMap $affSoftwareIndex
+                    if ($asIdx -ge 0) { $affSoftwareIndices.Add($asIdx) }
+                }
             }
         }
 

--- a/src/powershell/Shared/Dashboard/DashboardGeneration.ps1
+++ b/src/powershell/Shared/Dashboard/DashboardGeneration.ps1
@@ -3656,6 +3656,14 @@ function Get-NormalizationContext {
     [OutputType([pscustomobject])]
     param()
 
+    $severityIndexByName = @{
+        Critical = 0
+        High = 1
+        Medium = 2
+        Low = 3
+        None = 4
+    }
+
     return [PSCustomObject]@{
         Lookups = @{
             vendors = [System.Collections.Generic.List[string]]::new()
@@ -3700,6 +3708,7 @@ function Get-NormalizationContext {
         AdvancedHuntingDeviceUsers = @{}
         AdvancedHuntingInventoryData = @{}
         NvdCveData = @{}
+        SeverityIndexByName = $severityIndexByName
         HasNoTags = $false
     }
 }
@@ -4361,6 +4370,7 @@ function Add-NormalizedCve {
     $cveIndex = $Context.Indexes.cves
     $affSoftwareIndex = $Context.Indexes.affSoftware
     $batchTitleIndex = $Context.Indexes.batchTitles
+    $severityIndexByName = $Context.SeverityIndexByName
 
     $cveIdText = [string]$CveId
     $severityLevelText = [string]$SeverityLevel
@@ -4376,13 +4386,10 @@ function Add-NormalizedCve {
     ) -join '|'
 
     if (-not $cveIndex.ContainsKey($cveKey)) {
-        $sevIdx = switch ($severityLevelText) {
-            'Critical' { 0 }
-            'High' { 1 }
-            'Medium' { 2 }
-            'Low' { 3 }
-            'None' { 4 }
-            default { -1 }
+        $sevIdx = if ($severityIndexByName.ContainsKey($severityLevelText)) {
+            [int]$severityIndexByName[$severityLevelText]
+        } else {
+            -1
         }
 
         $expIdx = Get-OrCreateIndex -value $ExploitabilityLevel -list $lookups.exploitLevels -indexMap $exploitIndex

--- a/src/powershell/Shared/Dashboard/DashboardGeneration.ps1
+++ b/src/powershell/Shared/Dashboard/DashboardGeneration.ps1
@@ -4232,35 +4232,6 @@ function Add-NormalizedDevice {
     )
 
     $lookups = $Context.Lookups
-
-    function Get-NormalizationMachinePropertyValue {
-        [CmdletBinding()]
-        param(
-            [Parameter(Mandatory = $false)]
-            [AllowNull()]
-            [object]$Machine,
-
-            [Parameter(Mandatory = $false)]
-            [AllowNull()]
-            [object[]]$MachineTuple,
-
-            [Parameter(Mandatory = $true)]
-            [string]$PropertyName,
-
-            [Parameter(Mandatory = $false)]
-            [int]$TupleIndex = -1
-        )
-
-        if ($null -ne $MachineTuple -and $TupleIndex -ge 0) {
-            return $MachineTuple[$TupleIndex]
-        }
-
-        if ($null -eq $Machine -or $null -ne $MachineTuple) {
-            return $null
-        }
-
-        return $Machine.PSObject.Properties[$PropertyName]?.Value
-    }
     $deviceIndex = $Context.Indexes.devices
     $groupIndex = $Context.Indexes.groups
     $platformIndex = $Context.Indexes.platforms
@@ -4280,7 +4251,7 @@ function Add-NormalizedDevice {
 
     if (-not $deviceIndex.ContainsKey($deviceKey)) {
         $machine = if (-not [string]::IsNullOrWhiteSpace($DeviceId)) { $Context.Machines[$DeviceId] } else { $null }
-        $machineTuple = if ($machine -is [System.Array] -and $machine.Length -ge 10) { [object[]]$machine } else { $null }
+        $machineTuple = if ($machine -is [System.Array] -and $machine.Length -ge 10) { $machine } else { $null }
         $machineUsers = [string[]]@()
         if ($null -ne $Context.AdvancedHuntingDeviceUsers -and -not [string]::IsNullOrWhiteSpace($DeviceId)) {
             $rawMachineUsers = $Context.AdvancedHuntingDeviceUsers[[string]$DeviceId]
@@ -4314,18 +4285,18 @@ function Add-NormalizedDevice {
 
         $machineInfo = $null
         if ($machine -or $machineUsers.Count -gt 0) {
-            $machineLastSeen = Get-NormalizationMachinePropertyValue -Machine $machine -MachineTuple $machineTuple -PropertyName 'lastSeen' -TupleIndex 8
-            $machineFirstSeen = Get-NormalizationMachinePropertyValue -Machine $machine -MachineTuple $machineTuple -PropertyName 'firstSeen' -TupleIndex 9
+            $machineLastSeen = if ($machineTuple) { $machineTuple[8] } elseif ($machine) { $machine.PSObject.Properties['lastSeen']?.Value } else { $null }
+            $machineFirstSeen = if ($machineTuple) { $machineTuple[9] } elseif ($machine) { $machine.PSObject.Properties['firstSeen']?.Value } else { $null }
             $machineInfo = [PSCustomObject]@{
-                ip = Get-NormalizationMachinePropertyValue -Machine $machine -MachineTuple $machineTuple -PropertyName 'lastIpAddress' -TupleIndex 0
-                eip = Get-NormalizationMachinePropertyValue -Machine $machine -MachineTuple $machineTuple -PropertyName 'lastExternalIpAddress' -TupleIndex 1
+                ip = if ($machineTuple) { $machineTuple[0] } elseif ($machine) { $machine.PSObject.Properties['lastIpAddress']?.Value } else { $null }
+                eip = if ($machineTuple) { $machineTuple[1] } elseif ($machine) { $machine.PSObject.Properties['lastExternalIpAddress']?.Value } else { $null }
                 u = if ($machineUsers.Count -gt 0) { @($machineUsers) } else { $null }
-                hs = Get-NormalizationMachinePropertyValue -Machine $machine -MachineTuple $machineTuple -PropertyName 'healthStatus' -TupleIndex 2
-                rs = Get-NormalizationMachinePropertyValue -Machine $machine -MachineTuple $machineTuple -PropertyName 'riskScore' -TupleIndex 3
-                el = Get-NormalizationMachinePropertyValue -Machine $machine -MachineTuple $machineTuple -PropertyName 'exposureLevel' -TupleIndex 4
-                dv = Get-NormalizationMachinePropertyValue -Machine $machine -MachineTuple $machineTuple -PropertyName 'deviceValue' -TupleIndex 5
-                mb = Get-NormalizationMachinePropertyValue -Machine $machine -MachineTuple $machineTuple -PropertyName 'managedBy' -TupleIndex 6
-                aad = Get-NormalizationMachinePropertyValue -Machine $machine -MachineTuple $machineTuple -PropertyName 'isAadJoined' -TupleIndex 7
+                hs = if ($machineTuple) { $machineTuple[2] } elseif ($machine) { $machine.PSObject.Properties['healthStatus']?.Value } else { $null }
+                rs = if ($machineTuple) { $machineTuple[3] } elseif ($machine) { $machine.PSObject.Properties['riskScore']?.Value } else { $null }
+                el = if ($machineTuple) { $machineTuple[4] } elseif ($machine) { $machine.PSObject.Properties['exposureLevel']?.Value } else { $null }
+                dv = if ($machineTuple) { $machineTuple[5] } elseif ($machine) { $machine.PSObject.Properties['deviceValue']?.Value } else { $null }
+                mb = if ($machineTuple) { $machineTuple[6] } elseif ($machine) { $machine.PSObject.Properties['managedBy']?.Value } else { $null }
+                aad = if ($machineTuple) { $machineTuple[7] } elseif ($machine) { $machine.PSObject.Properties['isAadJoined']?.Value } else { $null }
                 ls = Get-NormalizationCachedYmdDate -Context $Context -DateValue $machineLastSeen
                 fs = Get-NormalizationCachedYmdDate -Context $Context -DateValue $machineFirstSeen
             }
@@ -4333,10 +4304,10 @@ function Add-NormalizedDevice {
 
         $lookups.devices.Add([PSCustomObject]@{
             id = $DeviceId
-            n = if ($DeviceName) { $DeviceName } elseif ($machine -and -not $machineTuple) { Get-NormalizationMachinePropertyValue -Machine $machine -MachineTuple $machineTuple -PropertyName 'computerDnsName' } else { '(no machine data)' }
+            n = if ($DeviceName) { $DeviceName } elseif ($machine -and -not $machineTuple) { $machine.PSObject.Properties['computerDnsName']?.Value } else { '(no machine data)' }
             g = $groupIdx
             o = $platIdx
-            ov = if ($OsVersion) { $OsVersion } elseif ($machine -and -not $machineTuple) { Get-NormalizationMachinePropertyValue -Machine $machine -MachineTuple $machineTuple -PropertyName 'osVersion' } else { $null }
+            ov = if ($OsVersion) { $OsVersion } elseif ($machine -and -not $machineTuple) { $machine.PSObject.Properties['osVersion']?.Value } else { $null }
             t = $tagIndices
             m = $machineInfo
         })

--- a/src/powershell/Shared/Dashboard/DashboardGeneration.ps1
+++ b/src/powershell/Shared/Dashboard/DashboardGeneration.ps1
@@ -4362,29 +4362,32 @@ function Add-NormalizedCve {
     $affSoftwareIndex = $Context.Indexes.affSoftware
     $batchTitleIndex = $Context.Indexes.batchTitles
 
-    $sevIdx = switch ($SeverityLevel) {
-        'Critical' { 0 }
-        'High' { 1 }
-        'Medium' { 2 }
-        'Low' { 3 }
-        'None' { 4 }
-        default { -1 }
-    }
-
-    $expIdx = Get-OrCreateIndex -value $ExploitabilityLevel -list $lookups.exploitLevels -indexMap $exploitIndex
+    $cveIdText = [string]$CveId
+    $severityLevelText = [string]$SeverityLevel
+    $exploitabilityLevelText = [string]$ExploitabilityLevel
 
     $cveKey = @(
-        [string]$CveId
+        $cveIdText
         [string]$CvssScore
-        [string]$SeverityLevel
-        [string]$ExploitabilityLevel
+        $severityLevelText
+        $exploitabilityLevelText
         [string]$CveUrl
         [string]$CveBatchTitle
     ) -join '|'
 
     if (-not $cveIndex.ContainsKey($cveKey)) {
-        $ahData = $Context.AdvancedHuntingData[[string]$CveId]
-        $nvdData = $Context.NvdCveData[[string]$CveId]
+        $sevIdx = switch ($severityLevelText) {
+            'Critical' { 0 }
+            'High' { 1 }
+            'Medium' { 2 }
+            'Low' { 3 }
+            'None' { 4 }
+            default { -1 }
+        }
+
+        $expIdx = Get-OrCreateIndex -value $ExploitabilityLevel -list $lookups.exploitLevels -indexMap $exploitIndex
+        $ahData = $Context.AdvancedHuntingData[$cveIdText]
+        $nvdData = $Context.NvdCveData[$cveIdText]
         $publishedDate = $null
         $vulnDescription = $null
         $epssScore = $null

--- a/src/powershell/Shared/Dashboard/DashboardGeneration.ps1
+++ b/src/powershell/Shared/Dashboard/DashboardGeneration.ps1
@@ -5250,8 +5250,8 @@ function Invoke-ContentStoreNormalization {
             -RecommendedSecurityUpdateId ([string]$contentTemplate.rid) `
             -RecommendedSecurityUpdateUrl ([string]$contentTemplate.url) `
             -SoftwareVersion ([string]$contentTemplate.ver) `
-            -DiskPaths $contentTemplate.dp `
-            -RegistryPaths $contentTemplate.rp `
+            -DiskPaths @($contentTemplate.dp) `
+            -RegistryPaths @($contentTemplate.rp) `
             -SecurityUpdateAvailable ($contentTemplate.ua -eq $true) `
             -Context $Context
 

--- a/src/powershell/Shared/Dashboard/DashboardGeneration.ps1
+++ b/src/powershell/Shared/Dashboard/DashboardGeneration.ps1
@@ -4820,8 +4820,8 @@ function Get-NormalizedRecordLookup {
         -RecommendedSecurityUpdateId $RecommendedSecurityUpdateId `
         -RecommendedSecurityUpdateUrl $RecommendedSecurityUpdateUrl `
         -SoftwareVersion $SoftwareVersion `
-        -DiskPaths @($DiskPaths) `
-        -RegistryPaths @($RegistryPaths) `
+        -DiskPaths $DiskPaths `
+        -RegistryPaths $RegistryPaths `
         -SecurityUpdateAvailable $SecurityUpdateAvailable `
         -Context $Context
 
@@ -5038,8 +5038,8 @@ function Write-NormalizedSourceRow {
         -RecommendedSecurityUpdateId $RecommendedSecurityUpdateId `
         -RecommendedSecurityUpdateUrl $RecommendedSecurityUpdateUrl `
         -SoftwareVersion $SoftwareVersion `
-        -DiskPaths @($DiskPaths) `
-        -RegistryPaths @($RegistryPaths) `
+        -DiskPaths $DiskPaths `
+        -RegistryPaths $RegistryPaths `
         -SecurityUpdateAvailable $SecurityUpdateAvailable `
         -Context $Context
 

--- a/src/powershell/Shared/Dashboard/DashboardGeneration.ps1
+++ b/src/powershell/Shared/Dashboard/DashboardGeneration.ps1
@@ -4407,12 +4407,8 @@ function Add-NormalizedCve {
             if ($ahData.ContainsKey('IsExploitAvailable')) {
                 $isExploitAvailable = $ahData.IsExploitAvailable
             }
-            if ($ahData.AffectedSoftware -and @($ahData.AffectedSoftware).Count -gt 0) {
-                $affSoftwareIndices = [System.Collections.Generic.List[int]]::new()
-                foreach ($sw in @($ahData.AffectedSoftware)) {
-                    $asIdx = Get-OrCreateIndex -value $sw -list $lookups.affSoftware -indexMap $affSoftwareIndex
-                    if ($asIdx -ge 0) { $affSoftwareIndices.Add($asIdx) }
-                }
+            if ($ahData.AffectedSoftware) {
+                $affSoftwareIndices = Resolve-NormalizedLookupIndexList -Values $ahData.AffectedSoftware -List $lookups.affSoftware -IndexMap $affSoftwareIndex
             }
         }
 

--- a/src/powershell/Shared/Stores/MachineStore.ps1
+++ b/src/powershell/Shared/Stores/MachineStore.ps1
@@ -1013,6 +1013,42 @@ function Get-MachineHistoryRemovePaths {
     return [string[]]@($removePaths)
 }
 
+function Add-InitializedMachineRecordToCurrentMap {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [hashtable]$CurrentRecords,
+
+        [Parameter(Mandatory = $false)]
+        [AllowNull()]
+        [psobject]$Record,
+
+        [Parameter(Mandatory = $true)]
+        [string]$DefaultObservedOn
+    )
+
+    if ($null -eq $Record) { return }
+
+    $properties = $Record.PSObject.Properties
+    $machineId = [string]$properties['id']?.Value
+    if ([string]::IsNullOrWhiteSpace($machineId)) { return }
+
+    if ($properties['removed']?.Value -eq $true) {
+        $CurrentRecords.Remove($machineId)
+        return
+    }
+
+    if ($null -eq $properties['stateHash']) {
+        $properties.Add([System.Management.Automation.PSNoteProperty]::new('stateHash', (Get-MachineStateHash -Machine $Record)))
+    }
+
+    if ($null -eq $properties['observedOn']) {
+        $properties.Add([System.Management.Automation.PSNoteProperty]::new('observedOn', $DefaultObservedOn))
+    }
+
+    $CurrentRecords[$machineId] = $Record
+}
+
 function Initialize-MachineHistoryStore {
     [CmdletBinding()]
     [OutputType([hashtable])]
@@ -1033,6 +1069,7 @@ function Initialize-MachineHistoryStore {
     $migratedLegacy = $false
     $historyRecordsByPeriod = @{}
     $historyRecordKeys = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+    $defaultObservedOn = Get-Date -Format 'yyyy-MM-dd'
 
     foreach ($sourcePath in $historySourcePaths) {
         foreach ($record in Read-MachineRecordsFromFile -Path $sourcePath) {
@@ -1042,34 +1079,12 @@ function Initialize-MachineHistoryStore {
 
     if ($null -ne $currentReadPath) {
         foreach ($record in Read-MachineRecordsFromFile -Path $currentReadPath) {
-            if (-not $record.id) { continue }
-            if ($record.PSObject.Properties['removed']?.Value -eq $true) {
-                $currentRecords.Remove($record.id)
-                continue
-            }
-            if (-not $record.PSObject.Properties['stateHash']) {
-                Add-Member -InputObject $record -NotePropertyName stateHash -NotePropertyValue (Get-MachineStateHash -Machine $record)
-            }
-            if (-not $record.PSObject.Properties['observedOn']) {
-                Add-Member -InputObject $record -NotePropertyName observedOn -NotePropertyValue (Get-Date -Format 'yyyy-MM-dd')
-            }
-            $currentRecords[$record.id] = $record
+            Add-InitializedMachineRecordToCurrentMap -CurrentRecords $currentRecords -Record $record -DefaultObservedOn $defaultObservedOn
         }
     } elseif ($historySourcePaths.Count -gt 0) {
         foreach ($sourcePath in $historySourcePaths) {
             foreach ($record in Read-MachineRecordsFromFile -Path $sourcePath) {
-                if (-not $record.id) { continue }
-                if ($record.PSObject.Properties['removed']?.Value -eq $true) {
-                    $currentRecords.Remove($record.id)
-                    continue
-                }
-                if (-not $record.PSObject.Properties['stateHash']) {
-                    Add-Member -InputObject $record -NotePropertyName stateHash -NotePropertyValue (Get-MachineStateHash -Machine $record)
-                }
-                if (-not $record.PSObject.Properties['observedOn']) {
-                    Add-Member -InputObject $record -NotePropertyName observedOn -NotePropertyValue (Get-Date -Format 'yyyy-MM-dd')
-                }
-                $currentRecords[$record.id] = $record
+                Add-InitializedMachineRecordToCurrentMap -CurrentRecords $currentRecords -Record $record -DefaultObservedOn $defaultObservedOn
             }
         }
     }
@@ -1095,12 +1110,6 @@ function Initialize-MachineHistoryStore {
 
     if (($historyRecordsByPeriod.Count -eq 0) -and $currentRecords.Count -gt 0) {
         foreach ($record in $currentRecords.Values) {
-            if (-not $record.PSObject.Properties['stateHash']) {
-                Add-Member -InputObject $record -NotePropertyName stateHash -NotePropertyValue (Get-MachineStateHash -Machine $record)
-            }
-            if (-not $record.PSObject.Properties['observedOn']) {
-                Add-Member -InputObject $record -NotePropertyName observedOn -NotePropertyValue (Get-Date -Format 'yyyy-MM-dd')
-            }
             Add-MachineHistoryRecordToPeriodMap -HistoryRecordsByPeriod $historyRecordsByPeriod -RecordKeys $historyRecordKeys -Record $record
         }
     }

--- a/src/powershell/Shared/Stores/MachineStore.ps1
+++ b/src/powershell/Shared/Stores/MachineStore.ps1
@@ -123,6 +123,101 @@ function Get-MachineJsonElementScalarValue {
     }
 }
 
+function Get-MachineJsonElementStringArrayValue {
+    [CmdletBinding()]
+    [OutputType([string[]])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [System.Text.Json.JsonElement]$Element,
+
+        [Parameter(Mandatory = $true)]
+        [string]$Name
+    )
+
+    $property = [System.Text.Json.JsonElement]::new()
+    if (-not $Element.TryGetProperty($Name, [ref]$property)) {
+        return [string[]]@()
+    }
+
+    switch ($property.ValueKind) {
+        ([System.Text.Json.JsonValueKind]::Undefined) { return [string[]]@() }
+        ([System.Text.Json.JsonValueKind]::Null) { return [string[]]@() }
+        ([System.Text.Json.JsonValueKind]::String) { return (Get-NormalizedMachineTag -Tags $property.GetString()) }
+        ([System.Text.Json.JsonValueKind]::Array) {
+            $tagList = [System.Collections.Generic.List[string]]::new()
+            foreach ($item in $property.EnumerateArray()) {
+                $tagValue = switch ($item.ValueKind) {
+                    ([System.Text.Json.JsonValueKind]::String) { $item.GetString() }
+                    ([System.Text.Json.JsonValueKind]::Null) { $null }
+                    ([System.Text.Json.JsonValueKind]::Undefined) { $null }
+                    default { $item.GetRawText() }
+                }
+
+                if (-not [string]::IsNullOrWhiteSpace([string]$tagValue)) {
+                    $tagList.Add([string]$tagValue) | Out-Null
+                }
+            }
+
+            return (Get-NormalizedMachineTag -Tags @($tagList))
+        }
+        default { return (Get-NormalizedMachineTag -Tags (Get-MachineJsonElementScalarValue -Element $Element -Name $Name)) }
+    }
+}
+
+function ConvertFrom-MachineJsonElementToCompactMachineRecord {
+    [CmdletBinding()]
+    [OutputType([pscustomobject])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [System.Text.Json.JsonElement]$MachineElement
+    )
+
+    $machineId = [string](Get-MachineJsonElementScalarValue -Element $MachineElement -Name 'id')
+    if ([string]::IsNullOrWhiteSpace($machineId)) {
+        return $null
+    }
+
+    $observedOn = Get-MachineJsonElementScalarValue -Element $MachineElement -Name 'observedOn'
+    $stateHash = Get-MachineJsonElementScalarValue -Element $MachineElement -Name 'stateHash'
+    if ((Get-MachineJsonElementScalarValue -Element $MachineElement -Name 'removed') -eq $true) {
+        return [PSCustomObject]@{
+            id = $machineId
+            observedOn = $observedOn
+            removed = $true
+            stateHash = $stateHash
+        }
+    }
+
+    $record = [PSCustomObject]@{
+        id                    = $machineId
+        computerDnsName       = Get-MachineJsonElementScalarValue -Element $MachineElement -Name 'computerDnsName'
+        rbacGroupName         = Get-MachineJsonElementScalarValue -Element $MachineElement -Name 'rbacGroupName'
+        osPlatform            = Get-MachineJsonElementScalarValue -Element $MachineElement -Name 'osPlatform'
+        osVersion             = Get-MachineJsonElementScalarValue -Element $MachineElement -Name 'osVersion'
+        machineTags           = Get-MachineJsonElementStringArrayValue -Element $MachineElement -Name 'machineTags'
+        lastIpAddress         = Get-MachineJsonElementScalarValue -Element $MachineElement -Name 'lastIpAddress'
+        lastExternalIpAddress = Get-MachineJsonElementScalarValue -Element $MachineElement -Name 'lastExternalIpAddress'
+        healthStatus          = Get-MachineJsonElementScalarValue -Element $MachineElement -Name 'healthStatus'
+        riskScore             = Get-MachineJsonElementScalarValue -Element $MachineElement -Name 'riskScore'
+        exposureLevel         = Get-MachineJsonElementScalarValue -Element $MachineElement -Name 'exposureLevel'
+        deviceValue           = Get-MachineJsonElementScalarValue -Element $MachineElement -Name 'deviceValue'
+        managedBy             = Get-MachineJsonElementScalarValue -Element $MachineElement -Name 'managedBy'
+        isAadJoined           = Get-MachineJsonElementScalarValue -Element $MachineElement -Name 'isAadJoined'
+        lastSeen              = Get-MachineJsonElementScalarValue -Element $MachineElement -Name 'lastSeen'
+        firstSeen             = Get-MachineJsonElementScalarValue -Element $MachineElement -Name 'firstSeen'
+    }
+
+    if (-not [string]::IsNullOrWhiteSpace([string]$stateHash)) {
+        Add-Member -InputObject $record -NotePropertyName stateHash -NotePropertyValue $stateHash
+    }
+
+    if (-not [string]::IsNullOrWhiteSpace([string]$observedOn)) {
+        Add-Member -InputObject $record -NotePropertyName observedOn -NotePropertyValue $observedOn
+    }
+
+    return $record
+}
+
 function ConvertFrom-MachineJsonElementToNormalizationEntry {
     [CmdletBinding()]
     [OutputType([pscustomobject])]
@@ -178,75 +273,69 @@ function Read-MachineNormalizationEntriesFromFile {
         [string]$Path
     )
 
-    $fileMode = Get-JsonFileMode -Path $Path
-    if ($fileMode -eq 'Empty') {
-        return
-    }
-
-    if ($fileMode -eq 'Array') {
-        $rawContent = Read-TextFileContent -Path $Path
-        if ([string]::IsNullOrWhiteSpace($rawContent)) {
+    $readContext = Open-JsonFileReadContext -Path $Path
+    try {
+        if ($readContext.Mode -eq 'Empty') {
             return
         }
 
-        $jsonDocument = [System.Text.Json.JsonDocument]::Parse($rawContent)
-        $rawContent = $null
-        try {
-            if ($jsonDocument.RootElement.ValueKind -ne [System.Text.Json.JsonValueKind]::Array) {
+        if ($readContext.Mode -eq 'Array') {
+            $rawContent = Read-JsonFileRemainingContent -Context $readContext
+            if ([string]::IsNullOrWhiteSpace($rawContent)) {
                 return
             }
 
-            foreach ($machineElement in $jsonDocument.RootElement.EnumerateArray()) {
-                $entry = ConvertFrom-MachineJsonElementToNormalizationEntry -MachineElement $machineElement
+            $jsonDocument = [System.Text.Json.JsonDocument]::Parse($rawContent)
+            $rawContent = $null
+            try {
+                if ($jsonDocument.RootElement.ValueKind -ne [System.Text.Json.JsonValueKind]::Array) {
+                    return
+                }
+
+                foreach ($machineElement in $jsonDocument.RootElement.EnumerateArray()) {
+                    $entry = ConvertFrom-MachineJsonElementToNormalizationEntry -MachineElement $machineElement
+                    if ($null -ne $entry) {
+                        $entry
+                    }
+                }
+            }
+            finally {
+                $jsonDocument.Dispose()
+            }
+
+            return
+        }
+
+        $isFirstLine = [ref]$true
+        while (-not $readContext.Reader.EndOfStream) {
+            $line = Read-JsonFileLine -Context $readContext -IsFirstLine $isFirstLine
+            if ([string]::IsNullOrWhiteSpace($line)) { continue }
+
+            $jsonDocument = $null
+            try {
+                $jsonDocument = [System.Text.Json.JsonDocument]::Parse($line)
+            }
+            catch {
+                Write-Warning "Failed to parse machine line in $(Split-Path -Leaf $Path): $_"
+                continue
+            }
+
+            try {
+                $entry = ConvertFrom-MachineJsonElementToNormalizationEntry -MachineElement $jsonDocument.RootElement
                 if ($null -ne $entry) {
                     $entry
                 }
             }
-        }
-        finally {
-            $jsonDocument.Dispose()
-        }
-
-        return
-    }
-
-    $fileStream = [System.IO.File]::OpenRead($Path)
-    try {
-        $contentStream = if ($Path.EndsWith('.gz', [System.StringComparison]::OrdinalIgnoreCase)) {
-            [System.IO.Compression.GZipStream]::new($fileStream, [System.IO.Compression.CompressionMode]::Decompress)
-        } else { $fileStream }
-        try {
-            $reader = [System.IO.StreamReader]::new($contentStream, [System.Text.UTF8Encoding]::new($false))
-            try {
-                while (-not $reader.EndOfStream) {
-                    $line = $reader.ReadLine()
-                    if ([string]::IsNullOrWhiteSpace($line)) { continue }
-
-                    $jsonDocument = $null
-                    try {
-                        $jsonDocument = [System.Text.Json.JsonDocument]::Parse($line)
-                    }
-                    catch {
-                        Write-Warning "Failed to parse machine line in $(Split-Path -Leaf $Path): $_"
-                        continue
-                    }
-
-                    try {
-                        $entry = ConvertFrom-MachineJsonElementToNormalizationEntry -MachineElement $jsonDocument.RootElement
-                        if ($null -ne $entry) {
-                            $entry
-                        }
-                    }
-                    finally {
-                        $jsonDocument.Dispose()
-                    }
+            finally {
+                if ($null -ne $jsonDocument) {
+                    $jsonDocument.Dispose()
                 }
             }
-            finally { $reader.Dispose() }
         }
-        finally { if ($contentStream -ne $fileStream) { $contentStream.Dispose() } }
     }
-    finally { $fileStream.Dispose() }
+    finally {
+        Close-JsonFileReadContext -Context $readContext
+    }
 }
 
 function Get-NormalizedMachineTag {
@@ -507,38 +596,145 @@ function Read-TextFileContent {
     return (Get-Content -Path $Path -Raw)
 }
 
-function Get-JsonFileMode {
+function Open-JsonFileReadContext {
     [CmdletBinding()]
-    [OutputType([string])]
+    [OutputType([pscustomobject])]
     param(
         [Parameter(Mandatory = $true)]
         [string]$Path
     )
 
-    $fileStream = [System.IO.File]::OpenRead($Path)
+    $fileStream = $null
+    $contentStream = $null
+    $reader = $null
     try {
+        $fileStream = [System.IO.File]::OpenRead($Path)
         $contentStream = if ($Path.EndsWith('.gz', [System.StringComparison]::OrdinalIgnoreCase)) {
             [System.IO.Compression.GZipStream]::new($fileStream, [System.IO.Compression.CompressionMode]::Decompress)
-        } else { $fileStream }
-        try {
-            $reader = [System.IO.StreamReader]::new($contentStream, [System.Text.Encoding]::UTF8, $true)
-            try {
-                while (-not $reader.EndOfStream) {
-                    $charValue = $reader.Read()
-                    if ($charValue -lt 0) { break }
-                    $char = [char]$charValue
-                    if (-not [char]::IsWhiteSpace($char)) {
-                        if ($char -eq '[') { return 'Array' }
-                        return 'Ndjson'
-                    }
-                }
-                return 'Empty'
-            }
-            finally { $reader.Dispose() }
         }
-        finally { if ($contentStream -ne $fileStream) { $contentStream.Dispose() } }
+        else {
+            $fileStream
+        }
+
+        $reader = [System.IO.StreamReader]::new($contentStream, [System.Text.Encoding]::UTF8, $true)
+        $mode = 'Empty'
+        $firstContentText = $null
+        while (-not $reader.EndOfStream) {
+            $charValue = $reader.Read()
+            if ($charValue -lt 0) {
+                break
+            }
+
+            $char = [char]$charValue
+            if (-not [char]::IsWhiteSpace($char)) {
+                $mode = if ($char -eq '[') { 'Array' } else { 'Ndjson' }
+                $firstContentText = [string]$char
+                break
+            }
+        }
+
+        $context = [PSCustomObject]@{
+            Path = $Path
+            Mode = $mode
+            Reader = $reader
+            ContentStream = $contentStream
+            FileStream = $fileStream
+            FirstContentText = $firstContentText
+        }
+
+        $reader = $null
+        $contentStream = $null
+        $fileStream = $null
+        return $context
     }
-    finally { $fileStream.Dispose() }
+    finally {
+        if ($null -ne $reader) {
+            $reader.Dispose()
+        }
+        elseif ($null -ne $contentStream -and $contentStream -ne $fileStream) {
+            $contentStream.Dispose()
+        }
+
+        if ($null -ne $fileStream) {
+            $fileStream.Dispose()
+        }
+    }
+}
+
+function Close-JsonFileReadContext {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $false)]
+        [AllowNull()]
+        $Context
+    )
+
+    if ($null -eq $Context) {
+        return
+    }
+
+    $reader = $Context.PSObject.Properties['Reader']?.Value
+    if ($null -ne $reader) {
+        $reader.Dispose()
+        return
+    }
+
+    $contentStream = $Context.PSObject.Properties['ContentStream']?.Value
+    $fileStream = $Context.PSObject.Properties['FileStream']?.Value
+    if ($null -ne $contentStream -and $contentStream -ne $fileStream) {
+        $contentStream.Dispose()
+    }
+
+    if ($null -ne $fileStream) {
+        $fileStream.Dispose()
+    }
+}
+
+function Read-JsonFileRemainingContent {
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory = $true)]
+        $Context
+    )
+
+    if ($null -eq $Context -or $Context.Mode -eq 'Empty') {
+        return $null
+    }
+
+    $builder = [System.Text.StringBuilder]::new()
+    if (-not [string]::IsNullOrEmpty([string]$Context.FirstContentText)) {
+        [void]$builder.Append([string]$Context.FirstContentText)
+    }
+
+    [void]$builder.Append($Context.Reader.ReadToEnd())
+    return $builder.ToString()
+}
+
+function Read-JsonFileLine {
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory = $true)]
+        $Context,
+
+        [Parameter(Mandatory = $true)]
+        [ref]$IsFirstLine
+    )
+
+    $line = $Context.Reader.ReadLine()
+    if ($null -eq $line) {
+        return $null
+    }
+
+    if ($IsFirstLine.Value) {
+        $IsFirstLine.Value = $false
+        if (-not [string]::IsNullOrEmpty([string]$Context.FirstContentText)) {
+            return ([string]$Context.FirstContentText + $line)
+        }
+    }
+
+    return $line
 }
 
 function Read-MachineRecordsFromFile {
@@ -548,82 +744,69 @@ function Read-MachineRecordsFromFile {
         [string]$Path
     )
 
-    $fileMode = Get-JsonFileMode -Path $Path
-    if ($fileMode -eq 'Empty') {
-        return
-    }
-
-    if ($fileMode -eq 'Array') {
-        $rawContent = Read-TextFileContent -Path $Path
-        $machineList = $rawContent | ConvertFrom-Json
-        $rawContent = $null
-        if ($null -eq $machineList) { return }
-        if ($machineList -isnot [System.Array]) { $machineList = @($machineList) }
-
-        foreach ($machine in $machineList) {
-            if ($null -eq $machine) { continue }
-            if ($machine.PSObject.Properties['removed']?.Value -eq $true) {
-                ([PSCustomObject]@{
-                    id = $machine.PSObject.Properties['id']?.Value
-                    observedOn = $machine.PSObject.Properties['observedOn']?.Value
-                    removed = $true
-                    stateHash = $machine.PSObject.Properties['stateHash']?.Value
-                })
-                continue
-            }
-            $record = ConvertTo-CompactMachineRecord -Machine $machine
-            $stateHash = $machine.PSObject.Properties['stateHash']?.Value
-            $observedOn = $machine.PSObject.Properties['observedOn']?.Value
-            if ($stateHash) { Add-Member -InputObject $record -NotePropertyName stateHash -NotePropertyValue $stateHash }
-            if ($observedOn) { Add-Member -InputObject $record -NotePropertyName observedOn -NotePropertyValue $observedOn }
-            $record
+    $readContext = Open-JsonFileReadContext -Path $Path
+    try {
+        if ($readContext.Mode -eq 'Empty') {
+            return
         }
 
-        return
-    }
+        if ($readContext.Mode -eq 'Array') {
+            $rawContent = Read-JsonFileRemainingContent -Context $readContext
+            if ([string]::IsNullOrWhiteSpace($rawContent)) {
+                return
+            }
 
-    $fileStream = [System.IO.File]::OpenRead($Path)
-    try {
-        $contentStream = if ($Path.EndsWith('.gz', [System.StringComparison]::OrdinalIgnoreCase)) {
-            [System.IO.Compression.GZipStream]::new($fileStream, [System.IO.Compression.CompressionMode]::Decompress)
-        } else { $fileStream }
-        try {
-            $reader = [System.IO.StreamReader]::new($contentStream, [System.Text.UTF8Encoding]::new($false))
+            $jsonDocument = [System.Text.Json.JsonDocument]::Parse($rawContent)
+            $rawContent = $null
             try {
-                while (-not $reader.EndOfStream) {
-                    $line = $reader.ReadLine()
-                    if ([string]::IsNullOrWhiteSpace($line)) { continue }
-                    try {
-                        $machine = $line | ConvertFrom-Json
-                    }
-                    catch {
-                        Write-Warning "Failed to parse machine line in $(Split-Path -Leaf $Path): $_"
-                        continue
-                    }
+                if ($jsonDocument.RootElement.ValueKind -ne [System.Text.Json.JsonValueKind]::Array) {
+                    return
+                }
 
-                    if ($null -eq $machine) { continue }
-                    if ($machine.PSObject.Properties['removed']?.Value -eq $true) {
-                        ([PSCustomObject]@{
-                            id = $machine.PSObject.Properties['id']?.Value
-                            observedOn = $machine.PSObject.Properties['observedOn']?.Value
-                            removed = $true
-                            stateHash = $machine.PSObject.Properties['stateHash']?.Value
-                        })
-                        continue
+                foreach ($machineElement in $jsonDocument.RootElement.EnumerateArray()) {
+                    $record = ConvertFrom-MachineJsonElementToCompactMachineRecord -MachineElement $machineElement
+                    if ($null -ne $record) {
+                        $record
                     }
-                    $record = ConvertTo-CompactMachineRecord -Machine $machine
-                    $stateHash = $machine.PSObject.Properties['stateHash']?.Value
-                    $observedOn = $machine.PSObject.Properties['observedOn']?.Value
-                    if ($stateHash) { Add-Member -InputObject $record -NotePropertyName stateHash -NotePropertyValue $stateHash }
-                    if ($observedOn) { Add-Member -InputObject $record -NotePropertyName observedOn -NotePropertyValue $observedOn }
+                }
+            }
+            finally {
+                $jsonDocument.Dispose()
+            }
+
+            return
+        }
+
+        $isFirstLine = [ref]$true
+        while (-not $readContext.Reader.EndOfStream) {
+            $line = Read-JsonFileLine -Context $readContext -IsFirstLine $isFirstLine
+            if ([string]::IsNullOrWhiteSpace($line)) { continue }
+
+            $jsonDocument = $null
+            try {
+                $jsonDocument = [System.Text.Json.JsonDocument]::Parse($line)
+            }
+            catch {
+                Write-Warning "Failed to parse machine line in $(Split-Path -Leaf $Path): $_"
+                continue
+            }
+
+            try {
+                $record = ConvertFrom-MachineJsonElementToCompactMachineRecord -MachineElement $jsonDocument.RootElement
+                if ($null -ne $record) {
                     $record
                 }
             }
-            finally { $reader.Dispose() }
+            finally {
+                if ($null -ne $jsonDocument) {
+                    $jsonDocument.Dispose()
+                }
+            }
         }
-        finally { if ($contentStream -ne $fileStream) { $contentStream.Dispose() } }
     }
-    finally { $fileStream.Dispose() }
+    finally {
+        Close-JsonFileReadContext -Context $readContext
+    }
 }
 
 function Get-MachineStateHash {
@@ -1146,52 +1329,48 @@ function Read-AdvancedHuntingRecordsFromFile {
         [string]$Path
     )
 
-    $fileMode = Get-JsonFileMode -Path $Path
-    if ($fileMode -eq 'Empty') {
-        return
-    }
-
-    if ($fileMode -eq 'Array') {
-        $rawContent = Read-TextFileContent -Path $Path
-        $records = $rawContent | ConvertFrom-Json
-        $rawContent = $null
-        if ($null -eq $records) { return }
-        if ($records -isnot [System.Array]) { $records = @($records) }
-
-        foreach ($record in $records) {
-            if ($null -ne $record) {
-                $record
-            }
+    $readContext = Open-JsonFileReadContext -Path $Path
+    try {
+        if ($readContext.Mode -eq 'Empty') {
+            return
         }
 
-        return
-    }
+        if ($readContext.Mode -eq 'Array') {
+            $rawContent = Read-JsonFileRemainingContent -Context $readContext
+            if ([string]::IsNullOrWhiteSpace($rawContent)) {
+                return
+            }
 
-    $fileStream = [System.IO.File]::OpenRead($Path)
-    try {
-        $contentStream = if ($Path.EndsWith('.gz', [System.StringComparison]::OrdinalIgnoreCase)) {
-            [System.IO.Compression.GZipStream]::new($fileStream, [System.IO.Compression.CompressionMode]::Decompress)
-        } else { $fileStream }
-        try {
-            $reader = [System.IO.StreamReader]::new($contentStream, [System.Text.UTF8Encoding]::new($false))
-            try {
-                while (-not $reader.EndOfStream) {
-                    $line = $reader.ReadLine()
-                    if ([string]::IsNullOrWhiteSpace($line)) { continue }
-                    try {
-                        $record = $line | ConvertFrom-Json
-                        if ($null -ne $record) { $record }
-                    }
-                    catch {
-                        Write-Warning "Failed to parse Advanced Hunting line in $(Split-Path -Leaf $Path): $_"
-                    }
+            $records = $rawContent | ConvertFrom-Json
+            $rawContent = $null
+            if ($null -eq $records) { return }
+            if ($records -isnot [System.Array]) { $records = @($records) }
+
+            foreach ($record in $records) {
+                if ($null -ne $record) {
+                    $record
                 }
             }
-            finally { $reader.Dispose() }
+
+            return
         }
-        finally { if ($contentStream -ne $fileStream) { $contentStream.Dispose() } }
+
+        $isFirstLine = [ref]$true
+        while (-not $readContext.Reader.EndOfStream) {
+            $line = Read-JsonFileLine -Context $readContext -IsFirstLine $isFirstLine
+            if ([string]::IsNullOrWhiteSpace($line)) { continue }
+            try {
+                $record = $line | ConvertFrom-Json
+                if ($null -ne $record) { $record }
+            }
+            catch {
+                Write-Warning "Failed to parse Advanced Hunting line in $(Split-Path -Leaf $Path): $_"
+            }
+        }
     }
-    finally { $fileStream.Dispose() }
+    finally {
+        Close-JsonFileReadContext -Context $readContext
+    }
 }
 
 function Initialize-AdvancedHuntingStore {

--- a/tests/Invoke-BenchmarkSeries.ps1
+++ b/tests/Invoke-BenchmarkSeries.ps1
@@ -34,6 +34,39 @@ $ErrorActionPreference = 'Stop'
 
 . (Join-Path $PSScriptRoot 'Import-BenchmarkDatasetCatalog.ps1')
 
+function Get-PercentileValue {
+    [CmdletBinding()]
+    [OutputType([double])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [AllowEmptyCollection()]
+        [double[]]$SortedValues,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateRange(0.0, 100.0)]
+        [double]$Percentile
+    )
+
+    if ($SortedValues.Count -eq 0) {
+        return $null
+    }
+
+    if ($SortedValues.Count -eq 1) {
+        return [math]::Round($SortedValues[0], 2)
+    }
+
+    $rank = ($Percentile / 100.0) * ($SortedValues.Count - 1)
+    $lowerIndex = [int][math]::Floor($rank)
+    $upperIndex = [int][math]::Ceiling($rank)
+    if ($lowerIndex -eq $upperIndex) {
+        return [math]::Round($SortedValues[$lowerIndex], 2)
+    }
+
+    $weight = $rank - $lowerIndex
+    $interpolatedValue = $SortedValues[$lowerIndex] + (($SortedValues[$upperIndex] - $SortedValues[$lowerIndex]) * $weight)
+    return [math]::Round($interpolatedValue, 2)
+}
+
 function Get-NumericSeriesSummary {
     [CmdletBinding()]
     [OutputType([pscustomobject])]
@@ -57,12 +90,27 @@ function Get-NumericSeriesSummary {
         [math]::Round((($orderedValues[$middleIndex - 1] + $orderedValues[$middleIndex]) / 2.0), 2)
     }
 
+    $average = [double](($orderedValues | Measure-Object -Average).Average)
+    $variance = if ($orderedValues.Count -gt 1) {
+        (($orderedValues | ForEach-Object { [math]::Pow(([double]$_ - $average), 2) } | Measure-Object -Sum).Sum) / ($orderedValues.Count - 1)
+    }
+    else {
+        0.0
+    }
+
+    $percentile05 = Get-PercentileValue -SortedValues $orderedValues -Percentile 5
+    $percentile95 = Get-PercentileValue -SortedValues $orderedValues -Percentile 95
+
     return [PSCustomObject]@{
         count = $orderedValues.Count
         min = [math]::Round(($orderedValues | Measure-Object -Minimum).Minimum, 2)
         max = [math]::Round(($orderedValues | Measure-Object -Maximum).Maximum, 2)
-        average = [math]::Round(($orderedValues | Measure-Object -Average).Average, 2)
+        average = [math]::Round($average, 2)
         median = $median
+        standard_deviation = [math]::Round([math]::Sqrt($variance), 2)
+        percentile_05 = $percentile05
+        percentile_95 = $percentile95
+        spread_90 = if ($null -ne $percentile05 -and $null -ne $percentile95) { [math]::Round(($percentile95 - $percentile05), 2) } else { $null }
     }
 }
 
@@ -82,7 +130,7 @@ function Get-MarkdownStatisticLine {
         return ('- {0}: n/a' -f $Label)
     }
 
-    return ('- {0}: min `{1:N2}s`, median `{2:N2}s`, avg `{3:N2}s`, max `{4:N2}s`' -f $Label, [double]$Summary.min, [double]$Summary.median, [double]$Summary.average, [double]$Summary.max)
+    return ('- {0}: min `{1:N2}s`, p05-p95 `{2:N2}s`-`{3:N2}s`, median `{4:N2}s`, avg `{5:N2}s`, max `{6:N2}s`, stdev `{7:N2}s`' -f $Label, [double]$Summary.min, [double]$Summary.percentile_05, [double]$Summary.percentile_95, [double]$Summary.median, [double]$Summary.average, [double]$Summary.max, [double]$Summary.standard_deviation)
 }
 
 $repoRoot = Split-Path -Path $PSScriptRoot -Parent

--- a/tests/Invoke-BenchmarkSeries.ps1
+++ b/tests/Invoke-BenchmarkSeries.ps1
@@ -33,105 +33,7 @@ Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
 . (Join-Path $PSScriptRoot 'Import-BenchmarkDatasetCatalog.ps1')
-
-function Get-PercentileValue {
-    [CmdletBinding()]
-    [OutputType([double])]
-    param(
-        [Parameter(Mandatory = $true)]
-        [AllowEmptyCollection()]
-        [double[]]$SortedValues,
-
-        [Parameter(Mandatory = $true)]
-        [ValidateRange(0.0, 100.0)]
-        [double]$Percentile
-    )
-
-    if ($SortedValues.Count -eq 0) {
-        return $null
-    }
-
-    if ($SortedValues.Count -eq 1) {
-        return [math]::Round($SortedValues[0], 2)
-    }
-
-    $rank = ($Percentile / 100.0) * ($SortedValues.Count - 1)
-    $lowerIndex = [int][math]::Floor($rank)
-    $upperIndex = [int][math]::Ceiling($rank)
-    if ($lowerIndex -eq $upperIndex) {
-        return [math]::Round($SortedValues[$lowerIndex], 2)
-    }
-
-    $weight = $rank - $lowerIndex
-    $interpolatedValue = $SortedValues[$lowerIndex] + (($SortedValues[$upperIndex] - $SortedValues[$lowerIndex]) * $weight)
-    return [math]::Round($interpolatedValue, 2)
-}
-
-function Get-NumericSeriesSummary {
-    [CmdletBinding()]
-    [OutputType([pscustomobject])]
-    param(
-        [Parameter(Mandatory = $true)]
-        [AllowEmptyCollection()]
-        [double[]]$Values
-    )
-
-    $filteredValues = @($Values | Where-Object { $null -ne $_ })
-    if ($filteredValues.Count -eq 0) {
-        return $null
-    }
-
-    $orderedValues = @($filteredValues | Sort-Object)
-    $middleIndex = [math]::Floor($orderedValues.Count / 2)
-    $median = if (($orderedValues.Count % 2) -eq 1) {
-        $orderedValues[$middleIndex]
-    }
-    else {
-        [math]::Round((($orderedValues[$middleIndex - 1] + $orderedValues[$middleIndex]) / 2.0), 2)
-    }
-
-    $average = [double](($orderedValues | Measure-Object -Average).Average)
-    $variance = if ($orderedValues.Count -gt 1) {
-        (($orderedValues | ForEach-Object { [math]::Pow(([double]$_ - $average), 2) } | Measure-Object -Sum).Sum) / ($orderedValues.Count - 1)
-    }
-    else {
-        0.0
-    }
-
-    $percentile05 = Get-PercentileValue -SortedValues $orderedValues -Percentile 5
-    $percentile95 = Get-PercentileValue -SortedValues $orderedValues -Percentile 95
-
-    return [PSCustomObject]@{
-        count = $orderedValues.Count
-        min = [math]::Round(($orderedValues | Measure-Object -Minimum).Minimum, 2)
-        max = [math]::Round(($orderedValues | Measure-Object -Maximum).Maximum, 2)
-        average = [math]::Round($average, 2)
-        median = $median
-        standard_deviation = [math]::Round([math]::Sqrt($variance), 2)
-        percentile_05 = $percentile05
-        percentile_95 = $percentile95
-        spread_90 = if ($null -ne $percentile05 -and $null -ne $percentile95) { [math]::Round(($percentile95 - $percentile05), 2) } else { $null }
-    }
-}
-
-function Get-MarkdownStatisticLine {
-    [CmdletBinding()]
-    [OutputType([string])]
-    param(
-        [Parameter(Mandatory = $true)]
-        [string]$Label,
-
-        [Parameter(Mandatory = $false)]
-        [AllowNull()]
-        $Summary
-    )
-
-    if ($null -eq $Summary) {
-        return ('- {0}: n/a' -f $Label)
-    }
-
-    return ('- {0}: min `{1:N2}s`, p05-p95 `{2:N2}s`-`{3:N2}s`, median `{4:N2}s`, avg `{5:N2}s`, max `{6:N2}s`, stdev `{7:N2}s`' -f $Label, [double]$Summary.min, [double]$Summary.percentile_05, [double]$Summary.percentile_95, [double]$Summary.median, [double]$Summary.average, [double]$Summary.max, [double]$Summary.standard_deviation)
-}
+. (Join-Path $PSScriptRoot 'helpers\BenchmarkSeriesTools.ps1')
 
 $repoRoot = Split-Path -Path $PSScriptRoot -Parent
 $definition = Get-BenchmarkDatasetDefinition -DatasetId $BenchmarkDatasetId -RepoRoot $repoRoot
@@ -179,7 +81,7 @@ for ($iteration = 1; $iteration -le $Iterations; $iteration++) {
     $resultPaths.Add($resultPath) | Out-Null
 }
 
-$summary = [PSCustomObject]@{
+$summaryProperties = [ordered]@{
     generated_utc = [datetime]::UtcNow.ToString('o')
     benchmark_dataset_id = [string]$definition.id
     benchmark_dataset_path = $datasetPath
@@ -187,38 +89,15 @@ $summary = [PSCustomObject]@{
     local_only = ($LocalOnly -eq $true)
     persistent_local_workflow = ($IncludePersistentLocalWorkflow -eq $true)
     result_paths = @($resultPaths)
-    local_elapsed_seconds = Get-NumericSeriesSummary -Values @($runResults | ForEach-Object { [double]$_.current.local.elapsed_seconds })
-    runbook_elapsed_seconds = if ($LocalOnly) { $null } else { Get-NumericSeriesSummary -Values @($runResults | ForEach-Object { [double]$_.current.runbook.elapsed_seconds }) }
-    function_active_elapsed_seconds = if ($LocalOnly) { $null } else { Get-NumericSeriesSummary -Values @($runResults | ForEach-Object { if ($null -ne $_.current.function_app.active_elapsed_seconds) { [double]$_.current.function_app.active_elapsed_seconds } }) }
-    function_end_to_end_elapsed_seconds = if ($LocalOnly) { $null } else { Get-NumericSeriesSummary -Values @($runResults | ForEach-Object { [double]$_.current.function_app.end_to_end_elapsed_seconds }) }
-    function_pickup_delay_seconds = if ($LocalOnly) { $null } else { Get-NumericSeriesSummary -Values @($runResults | ForEach-Object { if ($null -ne $_.current.function_app.pickup_delay_seconds) { [double]$_.current.function_app.pickup_delay_seconds } }) }
-    persistent_reuse_elapsed_seconds = if ($IncludePersistentLocalWorkflow) { Get-NumericSeriesSummary -Values @($runResults | ForEach-Object { [double]$_.current.local_persistent_cache.reuse_after_payload_eviction.elapsed_seconds }) } else { $null }
 }
 
-$summaryPath = Join-Path $resolvedResultsRoot 'series-summary.json'
-$summary | ConvertTo-Json -Depth 20 | Set-Content -LiteralPath $summaryPath -Encoding utf8
-
-$summaryLines = [System.Collections.Generic.List[string]]::new()
-$summaryLines.Add('# Benchmark Series Summary') | Out-Null
-$summaryLines.Add('') | Out-Null
-$summaryLines.Add(('- Dataset: `{0}`' -f [string]$definition.id)) | Out-Null
-$summaryLines.Add(('- Dataset path: `{0}`' -f $datasetPath)) | Out-Null
-$summaryLines.Add(('- Iterations: `{0}`' -f $Iterations)) | Out-Null
-$summaryLines.Add(('- Results root: `{0}`' -f $resolvedResultsRoot)) | Out-Null
-$summaryLines.Add('') | Out-Null
-$summaryLines.Add((Get-MarkdownStatisticLine -Label 'Local elapsed' -Summary $summary.local_elapsed_seconds)) | Out-Null
-if (-not $LocalOnly) {
-    $summaryLines.Add((Get-MarkdownStatisticLine -Label 'Runbook elapsed' -Summary $summary.runbook_elapsed_seconds)) | Out-Null
-    $summaryLines.Add((Get-MarkdownStatisticLine -Label 'Function active elapsed' -Summary $summary.function_active_elapsed_seconds)) | Out-Null
-    $summaryLines.Add((Get-MarkdownStatisticLine -Label 'Function end-to-end elapsed' -Summary $summary.function_end_to_end_elapsed_seconds)) | Out-Null
-    $summaryLines.Add((Get-MarkdownStatisticLine -Label 'Function pickup delay' -Summary $summary.function_pickup_delay_seconds)) | Out-Null
-}
-if ($IncludePersistentLocalWorkflow) {
-    $summaryLines.Add((Get-MarkdownStatisticLine -Label 'Persistent local reuse elapsed' -Summary $summary.persistent_reuse_elapsed_seconds)) | Out-Null
+$metricSummary = Get-BenchmarkSeriesMetricSummary -RunResults @($runResults) -LocalOnly ($LocalOnly -eq $true) -IncludePersistentLocalWorkflow ($IncludePersistentLocalWorkflow -eq $true)
+foreach ($property in $metricSummary.PSObject.Properties) {
+    $summaryProperties[$property.Name] = $property.Value
 }
 
-$summaryMarkdownPath = Join-Path $resolvedResultsRoot 'series-summary.md'
-[System.IO.File]::WriteAllLines($summaryMarkdownPath, $summaryLines, [System.Text.UTF8Encoding]::new($false))
+$summary = [PSCustomObject]$summaryProperties
 
-Write-Host ('Benchmark series summary: {0}' -f $summaryPath) -ForegroundColor Green
-Write-Host ('Benchmark series markdown: {0}' -f $summaryMarkdownPath) -ForegroundColor Green
+$summaryArtifacts = Write-BenchmarkSeriesSummaryOutput -ResultsRoot $resolvedResultsRoot -Summary $summary
+Write-Host ('Benchmark series summary: {0}' -f $summaryArtifacts.SummaryPath) -ForegroundColor Green
+Write-Host ('Benchmark series markdown: {0}' -f $summaryArtifacts.SummaryMarkdownPath) -ForegroundColor Green

--- a/tests/Invoke-LargeDatasetValidation.ps1
+++ b/tests/Invoke-LargeDatasetValidation.ps1
@@ -60,6 +60,9 @@ param(
     [string]$DashboardOutputPath,
 
     [Parameter(Mandatory = $false)]
+    [string]$DiagnosticPhaseLogPath,
+
+    [Parameter(Mandatory = $false)]
     [string]$ValidationOutputPath,
 
     [Parameter(Mandatory = $false)]
@@ -129,6 +132,129 @@ function Get-ValidationAuditSummary {
     }
 }
 
+function ConvertTo-DiagnosticUtcDateTime {
+    [CmdletBinding()]
+    [OutputType([datetime])]
+    param(
+        [Parameter(Mandatory = $false)]
+        [AllowNull()]
+        $Value
+    )
+
+    if ($null -eq $Value) {
+        return $null
+    }
+
+    if ($Value -is [datetime]) {
+        return ([datetime]$Value).ToUniversalTime()
+    }
+
+    if ($Value -is [datetimeoffset]) {
+        return ([datetimeoffset]$Value).UtcDateTime
+    }
+
+    $text = [string]$Value
+    if ([string]::IsNullOrWhiteSpace($text)) {
+        return $null
+    }
+
+    $parsed = [datetimeoffset]::MinValue
+    if ([datetimeoffset]::TryParse($text, [ref]$parsed)) {
+        return $parsed.UtcDateTime
+    }
+
+    return $null
+}
+
+function Get-DiagnosticPhaseTimingSummary {
+    [CmdletBinding()]
+    [OutputType([pscustomobject])]
+    param(
+        [Parameter(Mandatory = $false)]
+        [AllowEmptyString()]
+        [string]$Path
+    )
+
+    if ([string]::IsNullOrWhiteSpace($Path) -or -not (Test-Path -LiteralPath $Path -PathType Leaf)) {
+        return $null
+    }
+
+    $phaseByName = [ordered]@{}
+    $pipelineStartUtc = $null
+    $pipelineEndUtc = $null
+
+    foreach ($line in Get-Content -LiteralPath $Path) {
+        if ([string]::IsNullOrWhiteSpace($line)) {
+            continue
+        }
+
+        $parts = @([string]$line -split "`t")
+        if ($parts.Count -lt 3) {
+            continue
+        }
+
+        $timestampUtc = ConvertTo-DiagnosticUtcDateTime -Value $parts[0]
+        if ($null -eq $timestampUtc) {
+            continue
+        }
+
+        $eventType = [string]$parts[1]
+        $name = [string]$parts[2]
+        switch ($eventType) {
+            'pipeline-start' {
+                if ($null -eq $pipelineStartUtc) {
+                    $pipelineStartUtc = $timestampUtc
+                }
+            }
+            'pipeline-end' {
+                $pipelineEndUtc = $timestampUtc
+            }
+            'phase-start' {
+                if (-not $phaseByName.Contains($name)) {
+                    $phaseByName[$name] = [ordered]@{ start_utc = $null; end_utc = $null }
+                }
+
+                if ($null -eq $phaseByName[$name].start_utc) {
+                    $phaseByName[$name].start_utc = $timestampUtc
+                }
+            }
+            'phase-end' {
+                if (-not $phaseByName.Contains($name)) {
+                    $phaseByName[$name] = [ordered]@{ start_utc = $null; end_utc = $null }
+                }
+
+                $phaseByName[$name].end_utc = $timestampUtc
+            }
+        }
+    }
+
+    $phaseTimings = [ordered]@{}
+    $phaseElapsedSeconds = 0.0
+    foreach ($phaseName in $phaseByName.Keys) {
+        $phaseEntry = $phaseByName[$phaseName]
+        if ($null -eq $phaseEntry.start_utc -or $null -eq $phaseEntry.end_utc) {
+            continue
+        }
+
+        $elapsedSeconds = [math]::Round((New-TimeSpan -Start $phaseEntry.start_utc -End $phaseEntry.end_utc).TotalSeconds, 2)
+        $phaseTimings[$phaseName] = $elapsedSeconds
+        $phaseElapsedSeconds += $elapsedSeconds
+    }
+
+    return [PSCustomObject]@{
+        source = 'diagnostic-phase-log'
+        generated_on_utc = [datetime]::UtcNow.ToString('o')
+        pipeline_elapsed_seconds = if ($null -ne $pipelineStartUtc -and $null -ne $pipelineEndUtc) {
+            [math]::Round((New-TimeSpan -Start $pipelineStartUtc -End $pipelineEndUtc).TotalSeconds, 2)
+        }
+        else {
+            $null
+        }
+        phase_elapsed_seconds = [math]::Round($phaseElapsedSeconds, 2)
+        phase_timings = [PSCustomObject]$phaseTimings
+    }
+}
+
 function Write-StressValidationReport {
     [CmdletBinding()]
     param(
@@ -146,6 +272,10 @@ function Write-StressValidationReport {
 
         [Parameter(Mandatory = $true)]
         [string]$DashboardOutputPath,
+
+        [Parameter(Mandatory = $false)]
+        [AllowEmptyString()]
+        [string]$ResolvedDiagnosticPhaseLogPath,
 
         [Parameter(Mandatory = $false)]
         [AllowEmptyString()]
@@ -184,7 +314,11 @@ function Write-StressValidationReport {
 
         [Parameter(Mandatory = $false)]
         [AllowNull()]
-        $Audit
+        $Audit,
+
+        [Parameter(Mandatory = $false)]
+        [AllowNull()]
+        $DiagnosticTimingSummary
     )
 
     $resolvedDashboardOutputPath = [System.IO.Path]::GetFullPath($DashboardOutputPath)
@@ -198,7 +332,22 @@ function Write-StressValidationReport {
         completedOn = (Get-Date).ToString('o')
         syntheticPath = $SyntheticPath
         dashboardOutputPath = $resolvedDashboardOutputPath
+        diagnosticPhaseLogPath = if ([string]::IsNullOrWhiteSpace($ResolvedDiagnosticPhaseLogPath)) { $null } else { [System.IO.Path]::GetFullPath($ResolvedDiagnosticPhaseLogPath) }
         elapsedSeconds = [math]::Round($ElapsedSeconds, 2)
+        generationTiming = if ($null -ne $DiagnosticTimingSummary) {
+            [PSCustomObject]@{
+                source = [string]$DiagnosticTimingSummary.source
+                generatedOnUtc = [string]$DiagnosticTimingSummary.generated_on_utc
+                pipelineElapsedSeconds = $DiagnosticTimingSummary.pipeline_elapsed_seconds
+                phaseElapsedSeconds = $DiagnosticTimingSummary.phase_elapsed_seconds
+                wrapperElapsedSeconds = [math]::Round($ElapsedSeconds, 2)
+                wrapperOverheadSeconds = [math]::Round(([math]::Round($ElapsedSeconds, 2) - [double]$DiagnosticTimingSummary.phase_elapsed_seconds), 2)
+                phaseTimings = $DiagnosticTimingSummary.phase_timings
+            }
+        }
+        else {
+            $null
+        }
         machineCount = $MachineCount
         currentRowCount = $CurrentRowCount
         historyRowCount = $HistoryRowCount
@@ -293,6 +442,13 @@ else {
     $null
 }
 
+$resolvedDiagnosticPhaseLogPath = if (-not [string]::IsNullOrWhiteSpace($DiagnosticPhaseLogPath)) {
+    [System.IO.Path]::GetFullPath($DiagnosticPhaseLogPath)
+}
+else {
+    $null
+}
+
 if ($null -ne $manifest) {
     $machineCount = [int]$manifest.actualDeviceCount
     $currentRowCount = [int]$manifest.actualCurrentRows
@@ -327,6 +483,9 @@ if ($Validate) {
         $generateArgs.ValidationOutputPath = $resolvedValidationOutputPath
     }
 }
+if (-not [string]::IsNullOrWhiteSpace($resolvedDiagnosticPhaseLogPath)) {
+    $generateArgs.DiagnosticPhaseLogPath = $resolvedDiagnosticPhaseLogPath
+}
 
 $reportPath = Join-Path $resolvedSyntheticPath 'stress-validation-report.json'
 if (Test-Path -LiteralPath $reportPath -PathType Leaf) {
@@ -335,6 +494,9 @@ if (Test-Path -LiteralPath $reportPath -PathType Leaf) {
 
 if (Test-Path -LiteralPath $dashboardOutput -PathType Leaf) {
     Remove-Item -LiteralPath $dashboardOutput -Force
+}
+if (-not [string]::IsNullOrWhiteSpace($resolvedDiagnosticPhaseLogPath) -and (Test-Path -LiteralPath $resolvedDiagnosticPhaseLogPath -PathType Leaf)) {
+    Remove-Item -LiteralPath $resolvedDiagnosticPhaseLogPath -Force
 }
 if (-not [string]::IsNullOrWhiteSpace($resolvedValidationOutputPath) -and (Test-Path -LiteralPath $resolvedValidationOutputPath -PathType Leaf)) {
     Remove-Item -LiteralPath $resolvedValidationOutputPath -Force
@@ -348,6 +510,7 @@ $status = 'success'
 $dashboardExitCode = $null
 $failureRecord = $null
 $audit = $null
+$diagnosticTimingSummary = $null
 try {
     $global:LASTEXITCODE = 0
     & $dashboardScript @generateArgs
@@ -375,6 +538,7 @@ catch {
     throw
 }
 finally {
+    $diagnosticTimingSummary = Get-DiagnosticPhaseTimingSummary -Path $resolvedDiagnosticPhaseLogPath
     $stopwatch.Stop()
     Write-StressValidationReport `
         -ReportPath $reportPath `
@@ -382,6 +546,7 @@ finally {
         -Preset $Preset `
         -SyntheticPath $resolvedSyntheticPath `
         -DashboardOutputPath $dashboardOutput `
+        -ResolvedDiagnosticPhaseLogPath $resolvedDiagnosticPhaseLogPath `
         -ResolvedValidationAuditPath $resolvedValidationOutputPath `
         -ElapsedSeconds $stopwatch.Elapsed.TotalSeconds `
         -MachineCount $machineCount `
@@ -392,7 +557,8 @@ finally {
         -Status $status `
         -DashboardExitCode $dashboardExitCode `
         -FailureRecord $failureRecord `
-        -Audit $audit
+        -Audit $audit `
+        -DiagnosticTimingSummary $diagnosticTimingSummary
 }
 
 $dashboardItem = Get-Item -LiteralPath $dashboardOutput
@@ -401,6 +567,9 @@ Write-Output ''
 Write-Output 'Stress validation completed.'
 Write-Output ("  Synthetic path: {0}" -f $resolvedSyntheticPath)
 Write-Output ("  Dashboard output: {0}" -f ([System.IO.Path]::GetFullPath($dashboardOutput)))
+if (-not [string]::IsNullOrWhiteSpace($resolvedDiagnosticPhaseLogPath)) {
+    Write-Output ("  Diagnostic phase log: {0}" -f $resolvedDiagnosticPhaseLogPath)
+}
 if (-not [string]::IsNullOrWhiteSpace($resolvedValidationOutputPath)) {
     Write-Output ("  Validation audit: {0}" -f $resolvedValidationOutputPath)
 }

--- a/tests/Invoke-LargeImportCoverage.ps1
+++ b/tests/Invoke-LargeImportCoverage.ps1
@@ -126,6 +126,7 @@ function Invoke-RepoScript {
 }
 
 function Reset-DirectoryPath {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '', Justification = 'Internal test helper recreates temporary directories in a controlled script flow.')]
     [CmdletBinding()]
     param(
         [Parameter(Mandatory = $true)]

--- a/tests/Measure-BranchVsMainBenchmark.ps1
+++ b/tests/Measure-BranchVsMainBenchmark.ps1
@@ -168,6 +168,351 @@ function Get-TextWithoutAnsiEscape {
     return ([regex]::Replace($Text, "`e\[[0-9;]*m", ''))
 }
 
+function Get-SeriesPercentileValue {
+    [CmdletBinding()]
+    [OutputType([double])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [AllowEmptyCollection()]
+        [double[]]$SortedValues,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateRange(0.0, 100.0)]
+        [double]$Percentile
+    )
+
+    if ($SortedValues.Count -eq 0) {
+        return $null
+    }
+
+    if ($SortedValues.Count -eq 1) {
+        return [math]::Round($SortedValues[0], 2)
+    }
+
+    $rank = ($Percentile / 100.0) * ($SortedValues.Count - 1)
+    $lowerIndex = [int][math]::Floor($rank)
+    $upperIndex = [int][math]::Ceiling($rank)
+    if ($lowerIndex -eq $upperIndex) {
+        return [math]::Round($SortedValues[$lowerIndex], 2)
+    }
+
+    $weight = $rank - $lowerIndex
+    $interpolatedValue = $SortedValues[$lowerIndex] + (($SortedValues[$upperIndex] - $SortedValues[$lowerIndex]) * $weight)
+    return [math]::Round($interpolatedValue, 2)
+}
+
+function Get-NumericSeriesSummary {
+    [CmdletBinding()]
+    [OutputType([pscustomobject])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [AllowEmptyCollection()]
+        [double[]]$Values
+    )
+
+    $filteredValues = @($Values | Where-Object { $null -ne $_ })
+    if ($filteredValues.Count -eq 0) {
+        return $null
+    }
+
+    $orderedValues = @($filteredValues | Sort-Object)
+    $middleIndex = [math]::Floor($orderedValues.Count / 2)
+    $median = if (($orderedValues.Count % 2) -eq 1) {
+        $orderedValues[$middleIndex]
+    }
+    else {
+        [math]::Round((($orderedValues[$middleIndex - 1] + $orderedValues[$middleIndex]) / 2.0), 2)
+    }
+
+    $average = [double](($orderedValues | Measure-Object -Average).Average)
+    $variance = if ($orderedValues.Count -gt 1) {
+        (($orderedValues | ForEach-Object { [math]::Pow(([double]$_ - $average), 2) } | Measure-Object -Sum).Sum) / ($orderedValues.Count - 1)
+    }
+    else {
+        0.0
+    }
+
+    $percentile05 = Get-SeriesPercentileValue -SortedValues $orderedValues -Percentile 5
+    $percentile95 = Get-SeriesPercentileValue -SortedValues $orderedValues -Percentile 95
+
+    return [PSCustomObject]@{
+        count = $orderedValues.Count
+        min = [math]::Round(($orderedValues | Measure-Object -Minimum).Minimum, 2)
+        max = [math]::Round(($orderedValues | Measure-Object -Maximum).Maximum, 2)
+        average = [math]::Round($average, 2)
+        median = $median
+        standard_deviation = [math]::Round([math]::Sqrt($variance), 2)
+        percentile_05 = $percentile05
+        percentile_95 = $percentile95
+        spread_90 = if ($null -ne $percentile05 -and $null -ne $percentile95) { [math]::Round(($percentile95 - $percentile05), 2) } else { $null }
+    }
+}
+
+function Get-MarkdownStatisticLine {
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Label,
+
+        [Parameter(Mandatory = $false)]
+        [AllowNull()]
+        $Summary
+    )
+
+    if ($null -eq $Summary) {
+        return ('- {0}: n/a' -f $Label)
+    }
+
+    return ('- {0}: min `{1:N2}s`, p05-p95 `{2:N2}s`-`{3:N2}s`, median `{4:N2}s`, avg `{5:N2}s`, max `{6:N2}s`, stdev `{7:N2}s`' -f $Label, [double]$Summary.min, [double]$Summary.percentile_05, [double]$Summary.percentile_95, [double]$Summary.median, [double]$Summary.average, [double]$Summary.max, [double]$Summary.standard_deviation)
+}
+
+function Get-BenchmarkMetricSeriesValues {
+    [CmdletBinding()]
+    [OutputType([double[]])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [AllowEmptyCollection()]
+        [object[]]$RunResults,
+
+        [Parameter(Mandatory = $true)]
+        [scriptblock]$Selector
+    )
+
+    $values = [System.Collections.Generic.List[double]]::new()
+    foreach ($runResult in $RunResults) {
+        $value = & $Selector $runResult
+        if ($null -eq $value) {
+            continue
+        }
+
+        $parsedValue = 0.0
+        if ([double]::TryParse([string]$value, [ref]$parsedValue)) {
+            $values.Add($parsedValue) | Out-Null
+        }
+    }
+
+    return @($values)
+}
+
+function Write-AdHocBenchmarkSeriesSummary {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$ResultPath
+    )
+
+    $resultLeaf = Split-Path -Path $ResultPath -Leaf
+    if ($resultLeaf -notlike 'run-*.json') {
+        return
+    }
+
+    $resultsDirectory = Split-Path -Path $ResultPath -Parent
+    $resultFiles = @(Get-ChildItem -LiteralPath $resultsDirectory -Filter 'run-*.json' -File | Sort-Object Name)
+    if ($resultFiles.Count -eq 0) {
+        return
+    }
+
+    $runResults = [System.Collections.Generic.List[object]]::new()
+    $resultPaths = [System.Collections.Generic.List[string]]::new()
+    foreach ($resultFile in $resultFiles) {
+        $runResults.Add((Get-Content -LiteralPath $resultFile.FullName -Raw | ConvertFrom-Json -Depth 50)) | Out-Null
+        $resultPaths.Add($resultFile.FullName) | Out-Null
+    }
+
+    $firstResult = $runResults[0]
+    $dataset = Get-ObjectPropertyValue -InputObject $firstResult -Name 'dataset'
+    $datasetDefinition = Get-ObjectPropertyValue -InputObject $dataset -Name 'definition'
+    $currentBaseline = Get-ObjectPropertyValue -InputObject (Get-ObjectPropertyValue -InputObject $firstResult -Name 'current') -Name 'baseline'
+    $localOnly = [bool](Get-ObjectPropertyValue -InputObject $firstResult -Name 'local_only')
+    $persistentLocalWorkflow = [bool](Get-ObjectPropertyValue -InputObject $firstResult -Name 'persistent_local_workflow')
+
+    $summary = [PSCustomObject]@{
+        generated_utc = [datetime]::UtcNow.ToString('o')
+        benchmark_mode = [string](Get-ObjectPropertyValue -InputObject $firstResult -Name 'benchmark_mode')
+        benchmark_dataset_id = [string](Get-ObjectPropertyValue -InputObject $datasetDefinition -Name 'id')
+        benchmark_dataset_path = [string](Get-ObjectPropertyValue -InputObject $dataset -Name 'path')
+        iteration_count = $runResults.Count
+        local_only = $localOnly
+        persistent_local_workflow = $persistentLocalWorkflow
+        current_baseline_name = [string]$currentBaseline
+        result_paths = @($resultPaths)
+        local_elapsed_seconds = Get-NumericSeriesSummary -Values (Get-BenchmarkMetricSeriesValues -RunResults $runResults -Selector {
+            param($result)
+            $current = Get-ObjectPropertyValue -InputObject $result -Name 'current'
+            $local = Get-ObjectPropertyValue -InputObject $current -Name 'local'
+            Get-ObjectPropertyValue -InputObject $local -Name 'elapsed_seconds'
+        })
+        runbook_elapsed_seconds = if ($localOnly) { $null } else { Get-NumericSeriesSummary -Values (Get-BenchmarkMetricSeriesValues -RunResults $runResults -Selector {
+            param($result)
+            $current = Get-ObjectPropertyValue -InputObject $result -Name 'current'
+            $runbook = Get-ObjectPropertyValue -InputObject $current -Name 'runbook'
+            Get-ObjectPropertyValue -InputObject $runbook -Name 'elapsed_seconds'
+        }) }
+        function_active_elapsed_seconds = if ($localOnly) { $null } else { Get-NumericSeriesSummary -Values (Get-BenchmarkMetricSeriesValues -RunResults $runResults -Selector {
+            param($result)
+            $current = Get-ObjectPropertyValue -InputObject $result -Name 'current'
+            $functionApp = Get-ObjectPropertyValue -InputObject $current -Name 'function_app'
+            Get-ObjectPropertyValue -InputObject $functionApp -Name 'active_elapsed_seconds'
+        }) }
+        function_end_to_end_elapsed_seconds = if ($localOnly) { $null } else { Get-NumericSeriesSummary -Values (Get-BenchmarkMetricSeriesValues -RunResults $runResults -Selector {
+            param($result)
+            $current = Get-ObjectPropertyValue -InputObject $result -Name 'current'
+            $functionApp = Get-ObjectPropertyValue -InputObject $current -Name 'function_app'
+            Get-ObjectPropertyValue -InputObject $functionApp -Name 'end_to_end_elapsed_seconds'
+        }) }
+        function_pickup_delay_seconds = if ($localOnly) { $null } else { Get-NumericSeriesSummary -Values (Get-BenchmarkMetricSeriesValues -RunResults $runResults -Selector {
+            param($result)
+            $current = Get-ObjectPropertyValue -InputObject $result -Name 'current'
+            $functionApp = Get-ObjectPropertyValue -InputObject $current -Name 'function_app'
+            Get-ObjectPropertyValue -InputObject $functionApp -Name 'pickup_delay_seconds'
+        }) }
+        persistent_reuse_elapsed_seconds = if ($persistentLocalWorkflow) { Get-NumericSeriesSummary -Values (Get-BenchmarkMetricSeriesValues -RunResults $runResults -Selector {
+            param($result)
+            $current = Get-ObjectPropertyValue -InputObject $result -Name 'current'
+            $localPersistentCache = Get-ObjectPropertyValue -InputObject $current -Name 'local_persistent_cache'
+            $reuse = Get-ObjectPropertyValue -InputObject $localPersistentCache -Name 'reuse_after_payload_eviction'
+            Get-ObjectPropertyValue -InputObject $reuse -Name 'elapsed_seconds'
+        }) } else { $null }
+    }
+
+    $summaryPath = Join-Path $resultsDirectory 'series-summary.json'
+    $summary | ConvertTo-Json -Depth 20 | Set-Content -LiteralPath $summaryPath -Encoding utf8
+
+    $summaryLines = [System.Collections.Generic.List[string]]::new()
+    $summaryLines.Add('# Benchmark Series Summary') | Out-Null
+    $summaryLines.Add('') | Out-Null
+    $summaryLines.Add(('- Benchmark mode: `{0}`' -f [string]$summary.benchmark_mode)) | Out-Null
+    if (-not [string]::IsNullOrWhiteSpace([string]$summary.current_baseline_name)) {
+        $summaryLines.Add(('- Baseline: `{0}`' -f [string]$summary.current_baseline_name)) | Out-Null
+    }
+    if (-not [string]::IsNullOrWhiteSpace([string]$summary.benchmark_dataset_id)) {
+        $summaryLines.Add(('- Dataset: `{0}`' -f [string]$summary.benchmark_dataset_id)) | Out-Null
+    }
+    if (-not [string]::IsNullOrWhiteSpace([string]$summary.benchmark_dataset_path)) {
+        $summaryLines.Add(('- Dataset path: `{0}`' -f [string]$summary.benchmark_dataset_path)) | Out-Null
+    }
+    $summaryLines.Add(('- Iterations: `{0}`' -f $summary.iteration_count)) | Out-Null
+    $summaryLines.Add(('- Results root: `{0}`' -f $resultsDirectory)) | Out-Null
+    $summaryLines.Add('') | Out-Null
+    $summaryLines.Add((Get-MarkdownStatisticLine -Label 'Local elapsed' -Summary $summary.local_elapsed_seconds)) | Out-Null
+    if (-not $localOnly) {
+        $summaryLines.Add((Get-MarkdownStatisticLine -Label 'Runbook elapsed' -Summary $summary.runbook_elapsed_seconds)) | Out-Null
+        $summaryLines.Add((Get-MarkdownStatisticLine -Label 'Function active elapsed' -Summary $summary.function_active_elapsed_seconds)) | Out-Null
+        $summaryLines.Add((Get-MarkdownStatisticLine -Label 'Function end-to-end elapsed' -Summary $summary.function_end_to_end_elapsed_seconds)) | Out-Null
+        $summaryLines.Add((Get-MarkdownStatisticLine -Label 'Function pickup delay' -Summary $summary.function_pickup_delay_seconds)) | Out-Null
+    }
+    if ($persistentLocalWorkflow) {
+        $summaryLines.Add((Get-MarkdownStatisticLine -Label 'Persistent local reuse elapsed' -Summary $summary.persistent_reuse_elapsed_seconds)) | Out-Null
+    }
+
+    $summaryMarkdownPath = Join-Path $resultsDirectory 'series-summary.md'
+    [System.IO.File]::WriteAllLines($summaryMarkdownPath, $summaryLines, [System.Text.UTF8Encoding]::new($false))
+}
+
+function Get-LocalDiagnosticTimingSummary {
+    [CmdletBinding()]
+    [OutputType([pscustomobject])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Path
+    )
+
+    if (-not (Test-Path -LiteralPath $Path -PathType Leaf)) {
+        return $null
+    }
+
+    $phaseByName = [ordered]@{}
+    $pipelineStartUtc = $null
+    $pipelineEndUtc = $null
+
+    foreach ($line in Get-Content -LiteralPath $Path) {
+        if ([string]::IsNullOrWhiteSpace($line)) {
+            continue
+        }
+
+        $parts = @([string]$line -split "`t")
+        if ($parts.Count -lt 3) {
+            continue
+        }
+
+        $timestampUtc = ConvertTo-UtcDateTime -Value $parts[0]
+        if ($null -eq $timestampUtc) {
+            continue
+        }
+
+        $eventType = [string]$parts[1]
+        $name = [string]$parts[2]
+        $status = if ($parts.Count -ge 4) { [string]$parts[3] } else { $null }
+
+        switch ($eventType) {
+            'pipeline-start' {
+                if ($null -eq $pipelineStartUtc) {
+                    $pipelineStartUtc = $timestampUtc
+                }
+            }
+            'pipeline-end' {
+                $pipelineEndUtc = $timestampUtc
+            }
+            'phase-start' {
+                if (-not $phaseByName.Contains($name)) {
+                    $phaseByName[$name] = [ordered]@{
+                        name = $name
+                        start_utc = $null
+                        end_utc = $null
+                        status = $null
+                    }
+                }
+
+                if ($null -eq $phaseByName[$name].start_utc) {
+                    $phaseByName[$name].start_utc = $timestampUtc
+                }
+            }
+            'phase-end' {
+                if (-not $phaseByName.Contains($name)) {
+                    $phaseByName[$name] = [ordered]@{
+                        name = $name
+                        start_utc = $null
+                        end_utc = $null
+                        status = $null
+                    }
+                }
+
+                $phaseByName[$name].end_utc = $timestampUtc
+                $phaseByName[$name].status = $status
+            }
+        }
+    }
+
+    $phaseSummaries = @(
+        foreach ($phaseEntry in $phaseByName.Values) {
+            $elapsedSeconds = if ($null -ne $phaseEntry.start_utc -and $null -ne $phaseEntry.end_utc) {
+                [math]::Round((New-TimeSpan -Start $phaseEntry.start_utc -End $phaseEntry.end_utc).TotalSeconds, 2)
+            }
+            else {
+                $null
+            }
+
+            [PSCustomObject]@{
+                name = [string]$phaseEntry.name
+                status = if ([string]::IsNullOrWhiteSpace([string]$phaseEntry.status)) { 'unknown' } else { [string]$phaseEntry.status }
+                elapsedSeconds = $elapsedSeconds
+            }
+        }
+    )
+
+    return [PSCustomObject]@{
+        path = $Path
+        phase_summaries = $phaseSummaries
+        pipeline_elapsed_seconds = if ($null -ne $pipelineStartUtc -and $null -ne $pipelineEndUtc) {
+            [math]::Round((New-TimeSpan -Start $pipelineStartUtc -End $pipelineEndUtc).TotalSeconds, 2)
+        }
+        else {
+            $null
+        }
+    }
+}
+
 function Get-LocalPhaseSummaryFromLog {
     [CmdletBinding()]
     [OutputType([object[]])]
@@ -224,11 +569,29 @@ function Get-LocalBenchmarkLogSummary {
     [OutputType([pscustomobject])]
     param(
         [Parameter(Mandatory = $true)]
-        [string]$StdoutPath
+        [string]$StdoutPath,
+
+        [Parameter(Mandatory = $false)]
+        [AllowEmptyString()]
+        [string]$DiagnosticLogPath
     )
 
     $phaseSummary = [ordered]@{}
-    foreach ($phase in @(Get-LocalPhaseSummaryFromLog -Path $StdoutPath)) {
+    $diagnosticTimingSummary = if ([string]::IsNullOrWhiteSpace($DiagnosticLogPath)) {
+        $null
+    }
+    else {
+        Get-LocalDiagnosticTimingSummary -Path $DiagnosticLogPath
+    }
+
+    $phaseEntries = if ($null -ne $diagnosticTimingSummary -and @($diagnosticTimingSummary.phase_summaries).Count -gt 0) {
+        @($diagnosticTimingSummary.phase_summaries)
+    }
+    else {
+        @(Get-LocalPhaseSummaryFromLog -Path $StdoutPath)
+    }
+
+    foreach ($phase in $phaseEntries) {
         if ($null -ne $phase.elapsedSeconds) {
             $phaseSummary[[string]$phase.name] = [double]$phase.elapsedSeconds
         }
@@ -243,9 +606,61 @@ function Get-LocalBenchmarkLogSummary {
 
     return [PSCustomObject]@{
         phase_elapsed_seconds = [PSCustomObject]$phaseSummary
+        phase_timing_source = if ($null -ne $diagnosticTimingSummary -and @($diagnosticTimingSummary.phase_summaries).Count -gt 0) { 'diagnostic-log' } else { 'stdout' }
+        pipeline_elapsed_seconds = if ($null -ne $diagnosticTimingSummary) { $diagnosticTimingSummary.pipeline_elapsed_seconds } else { $null }
         used_cached_payload = ($stdoutText -match 'Reusing cached normalized payload')
         used_cached_vuln_columns = ($stdoutText -match 'Reusing cached normalized vuln columns')
         published_cached_vuln_columns = ($stdoutText -match 'Cached normalized vuln columns as')
+    }
+}
+
+function Get-LocalBenchmarkProcessReport {
+    [CmdletBinding()]
+    [OutputType([pscustomobject])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$DatasetPath
+    )
+
+    $reportPath = Join-Path -Path $DatasetPath -ChildPath 'stress-validation-report.json'
+    if (-not (Test-Path -LiteralPath $reportPath -PathType Leaf)) {
+        return $null
+    }
+
+    return [PSCustomObject]@{
+        path = $reportPath
+        report = Get-Content -LiteralPath $reportPath -Raw | ConvertFrom-Json -Depth 50
+    }
+}
+
+function Get-LocalBenchmarkProcessTimingSummary {
+    [CmdletBinding()]
+    [OutputType([pscustomobject])]
+    param(
+        [Parameter(Mandatory = $false)]
+        [AllowNull()]
+        $ProcessReport
+    )
+
+    if ($null -eq $ProcessReport -or $null -eq $ProcessReport.report) {
+        return $null
+    }
+
+    $generationTiming = Get-ObjectPropertyValue -InputObject $ProcessReport.report -Name 'generationTiming'
+    if ($null -eq $generationTiming) {
+        return $null
+    }
+
+    $phaseTimings = Get-ObjectPropertyValue -InputObject $generationTiming -Name 'phaseTimings'
+    if ($null -eq $phaseTimings) {
+        return $null
+    }
+
+    return [PSCustomObject]@{
+        phase_elapsed_seconds = $phaseTimings
+        phase_timing_source = 'process-report'
+        pipeline_elapsed_seconds = Get-ObjectPropertyValue -InputObject $generationTiming -Name 'pipelineElapsedSeconds'
+        wrapper_overhead_seconds = Get-ObjectPropertyValue -InputObject $generationTiming -Name 'wrapperOverheadSeconds'
     }
 }
 
@@ -1513,8 +1928,10 @@ function Start-LocalBenchmark {
     $stdoutPath = Join-Path -Path $OutputDirectory -ChildPath ($Name + '.local.stdout.log')
     $stderrPath = Join-Path -Path $OutputDirectory -ChildPath ($Name + '.local.stderr.log')
     $dashboardPath = Join-Path -Path $OutputDirectory -ChildPath ($Name + '.local.html')
+    $phaseLogPath = Join-Path -Path $OutputDirectory -ChildPath ($Name + '.local.phase.log')
+    $processReportPath = Join-Path -Path $OutputDirectory -ChildPath ($Name + '.local.report.json')
 
-    foreach ($path in @($stdoutPath, $stderrPath, $dashboardPath)) {
+    foreach ($path in @($stdoutPath, $stderrPath, $dashboardPath, $phaseLogPath, $processReportPath)) {
         if (Test-Path -LiteralPath $path) {
             Remove-Item -LiteralPath $path -Recurse -Force -ErrorAction SilentlyContinue
         }
@@ -1526,7 +1943,8 @@ function Start-LocalBenchmark {
         '-File', $scriptPath,
         '-SkipSyntheticGeneration',
         '-SyntheticOutputPath', $localDatasetPath,
-        '-DashboardOutputPath', $dashboardPath
+        '-DashboardOutputPath', $dashboardPath,
+        '-DiagnosticPhaseLogPath', $phaseLogPath
     )
 
     $process = Start-Process -FilePath 'pwsh' -ArgumentList $argumentList -WorkingDirectory $RepoPath -RedirectStandardOutput $stdoutPath -RedirectStandardError $stderrPath -PassThru
@@ -1540,6 +1958,8 @@ function Start-LocalBenchmark {
         stdoutPath = $stdoutPath
         stderrPath = $stderrPath
         dashboardPath = $dashboardPath
+        phaseLogPath = $phaseLogPath
+        processReportPath = $processReportPath
         stopwatch = [System.Diagnostics.Stopwatch]::StartNew()
         samples = [System.Collections.Generic.List[object]]::new()
         peakRssBytes = [int64]0
@@ -1625,26 +2045,54 @@ function Get-LocalBenchmarkResult {
         [switch]$KeepDatasetPath
     )
 
-    $logSummary = Get-LocalBenchmarkLogSummary -StdoutPath $State.stdoutPath
+    $processReport = Get-LocalBenchmarkProcessReport -DatasetPath $State.datasetPath
+    if ($null -ne $processReport -and $State.Contains('processReportPath') -and -not [string]::IsNullOrWhiteSpace([string]$State.processReportPath)) {
+        Copy-Item -LiteralPath $processReport.path -Destination $State.processReportPath -Force
+    }
+    $processTimingSummary = Get-LocalBenchmarkProcessTimingSummary -ProcessReport $processReport
+    $logSummary = Get-LocalBenchmarkLogSummary -StdoutPath $State.stdoutPath -DiagnosticLogPath $State.phaseLogPath
+    $elapsedSeconds = if ($null -ne $processReport -and $processReport.report.PSObject.Properties['elapsedSeconds']) {
+        [math]::Round([double]$processReport.report.elapsedSeconds, 2)
+    }
+    elseif ($null -ne $logSummary.pipeline_elapsed_seconds) {
+        [math]::Round([double]$logSummary.pipeline_elapsed_seconds, 2)
+    }
+    else {
+        [math]::Round($State.stopwatch.Elapsed.TotalSeconds, 2)
+    }
+    $elapsedTimingSource = if ($null -ne $processReport -and $processReport.report.PSObject.Properties['elapsedSeconds']) {
+        'process-report'
+    }
+    elseif ($null -ne $logSummary.pipeline_elapsed_seconds) {
+        'diagnostic-log'
+    }
+    else {
+        'poll-stopwatch'
+    }
 
     $result = [PSCustomObject]@{
         status = if ($State.exitCode -eq 0) { 'Completed' } else { 'Failed' }
-        elapsed_seconds = [math]::Round($State.stopwatch.Elapsed.TotalSeconds, 2)
+        elapsed_seconds = $elapsedSeconds
+        elapsed_timing_source = $elapsedTimingSource
         peak_tree_rss_bytes = $State.peakRssBytes
         peak_tree_rss_gb = [math]::Round(($State.peakRssBytes / 1GB), 3)
         peak_tree_rss_at_seconds = $State.peakRssAtSeconds
         peak_tree_private_bytes = $State.peakPrivateBytes
         peak_tree_private_gb = [math]::Round(($State.peakPrivateBytes / 1GB), 3)
         peak_tree_private_at_seconds = $State.peakPrivateAtSeconds
-        rows_per_second = if ($State.stopwatch.Elapsed.TotalSeconds -gt 0) { [math]::Round(($TotalRows / $State.stopwatch.Elapsed.TotalSeconds), 0) } else { 0 }
+        rows_per_second = if ($elapsedSeconds -gt 0) { [math]::Round(($TotalRows / $elapsedSeconds), 0) } else { 0 }
         sample_count = $State.samples.Count
         dashboard_bytes = if (Test-Path -LiteralPath $State.dashboardPath -PathType Leaf) { (Get-Item -LiteralPath $State.dashboardPath).Length } else { 0 }
         dashboard_mb = if (Test-Path -LiteralPath $State.dashboardPath -PathType Leaf) { [math]::Round(((Get-Item -LiteralPath $State.dashboardPath).Length / 1MB), 2) } else { 0 }
-        phase_elapsed_seconds = $logSummary.phase_elapsed_seconds
+        phase_elapsed_seconds = if ($null -ne $processTimingSummary) { $processTimingSummary.phase_elapsed_seconds } else { $logSummary.phase_elapsed_seconds }
+        phase_timing_source = if ($null -ne $processTimingSummary) { $processTimingSummary.phase_timing_source } else { $logSummary.phase_timing_source }
+        wrapper_overhead_seconds = if ($null -ne $processTimingSummary) { $processTimingSummary.wrapper_overhead_seconds } else { $null }
         used_cached_payload = [bool]$logSummary.used_cached_payload
         used_cached_vuln_columns = [bool]$logSummary.used_cached_vuln_columns
         published_cached_vuln_columns = [bool]$logSummary.published_cached_vuln_columns
         environment_snapshot = $State.environmentSnapshot
+        process_report_path = if ($null -ne $processReport -and $State.Contains('processReportPath')) { $State.processReportPath } else { $null }
+        phase_log_path = if (Test-Path -LiteralPath $State.phaseLogPath -PathType Leaf) { $State.phaseLogPath } else { $null }
         stdout_path = $State.stdoutPath
         stderr_path = $State.stderrPath
         dashboard_path = $State.dashboardPath
@@ -2574,6 +3022,7 @@ $result = [PSCustomObject]@{
 }
 
 $result | ConvertTo-Json -Depth 10 | Set-Content -LiteralPath $resolvedResultsOutputPath -Encoding utf8
+Write-AdHocBenchmarkSeriesSummary -ResultPath $resolvedResultsOutputPath
 
 Write-Host ''
 Write-Host ('Benchmark report: {0}' -f $resolvedResultsOutputPath) -ForegroundColor Green

--- a/tests/Measure-BranchVsMainBenchmark.ps1
+++ b/tests/Measure-BranchVsMainBenchmark.ps1
@@ -90,6 +90,7 @@ $script:FunctionStorageAccountName = $FunctionStorageAccountName
 $script:PollIntervalSeconds = $PollIntervalSeconds
 
 . (Join-Path $PSScriptRoot 'Import-BenchmarkDatasetCatalog.ps1')
+. (Join-Path $PSScriptRoot 'helpers\BenchmarkSeriesTools.ps1')
 
 function Get-HeartbeatTimestampText {
     [CmdletBinding()]
@@ -168,133 +169,6 @@ function Get-TextWithoutAnsiEscape {
     return ([regex]::Replace($Text, "`e\[[0-9;]*m", ''))
 }
 
-function Get-SeriesPercentileValue {
-    [CmdletBinding()]
-    [OutputType([double])]
-    param(
-        [Parameter(Mandatory = $true)]
-        [AllowEmptyCollection()]
-        [double[]]$SortedValues,
-
-        [Parameter(Mandatory = $true)]
-        [ValidateRange(0.0, 100.0)]
-        [double]$Percentile
-    )
-
-    if ($SortedValues.Count -eq 0) {
-        return $null
-    }
-
-    if ($SortedValues.Count -eq 1) {
-        return [math]::Round($SortedValues[0], 2)
-    }
-
-    $rank = ($Percentile / 100.0) * ($SortedValues.Count - 1)
-    $lowerIndex = [int][math]::Floor($rank)
-    $upperIndex = [int][math]::Ceiling($rank)
-    if ($lowerIndex -eq $upperIndex) {
-        return [math]::Round($SortedValues[$lowerIndex], 2)
-    }
-
-    $weight = $rank - $lowerIndex
-    $interpolatedValue = $SortedValues[$lowerIndex] + (($SortedValues[$upperIndex] - $SortedValues[$lowerIndex]) * $weight)
-    return [math]::Round($interpolatedValue, 2)
-}
-
-function Get-NumericSeriesSummary {
-    [CmdletBinding()]
-    [OutputType([pscustomobject])]
-    param(
-        [Parameter(Mandatory = $true)]
-        [AllowEmptyCollection()]
-        [double[]]$Values
-    )
-
-    $filteredValues = @($Values | Where-Object { $null -ne $_ })
-    if ($filteredValues.Count -eq 0) {
-        return $null
-    }
-
-    $orderedValues = @($filteredValues | Sort-Object)
-    $middleIndex = [math]::Floor($orderedValues.Count / 2)
-    $median = if (($orderedValues.Count % 2) -eq 1) {
-        $orderedValues[$middleIndex]
-    }
-    else {
-        [math]::Round((($orderedValues[$middleIndex - 1] + $orderedValues[$middleIndex]) / 2.0), 2)
-    }
-
-    $average = [double](($orderedValues | Measure-Object -Average).Average)
-    $variance = if ($orderedValues.Count -gt 1) {
-        (($orderedValues | ForEach-Object { [math]::Pow(([double]$_ - $average), 2) } | Measure-Object -Sum).Sum) / ($orderedValues.Count - 1)
-    }
-    else {
-        0.0
-    }
-
-    $percentile05 = Get-SeriesPercentileValue -SortedValues $orderedValues -Percentile 5
-    $percentile95 = Get-SeriesPercentileValue -SortedValues $orderedValues -Percentile 95
-
-    return [PSCustomObject]@{
-        count = $orderedValues.Count
-        min = [math]::Round(($orderedValues | Measure-Object -Minimum).Minimum, 2)
-        max = [math]::Round(($orderedValues | Measure-Object -Maximum).Maximum, 2)
-        average = [math]::Round($average, 2)
-        median = $median
-        standard_deviation = [math]::Round([math]::Sqrt($variance), 2)
-        percentile_05 = $percentile05
-        percentile_95 = $percentile95
-        spread_90 = if ($null -ne $percentile05 -and $null -ne $percentile95) { [math]::Round(($percentile95 - $percentile05), 2) } else { $null }
-    }
-}
-
-function Get-MarkdownStatisticLine {
-    [CmdletBinding()]
-    [OutputType([string])]
-    param(
-        [Parameter(Mandatory = $true)]
-        [string]$Label,
-
-        [Parameter(Mandatory = $false)]
-        [AllowNull()]
-        $Summary
-    )
-
-    if ($null -eq $Summary) {
-        return ('- {0}: n/a' -f $Label)
-    }
-
-    return ('- {0}: min `{1:N2}s`, p05-p95 `{2:N2}s`-`{3:N2}s`, median `{4:N2}s`, avg `{5:N2}s`, max `{6:N2}s`, stdev `{7:N2}s`' -f $Label, [double]$Summary.min, [double]$Summary.percentile_05, [double]$Summary.percentile_95, [double]$Summary.median, [double]$Summary.average, [double]$Summary.max, [double]$Summary.standard_deviation)
-}
-
-function Get-BenchmarkMetricSeriesValues {
-    [CmdletBinding()]
-    [OutputType([double[]])]
-    param(
-        [Parameter(Mandatory = $true)]
-        [AllowEmptyCollection()]
-        [object[]]$RunResults,
-
-        [Parameter(Mandatory = $true)]
-        [scriptblock]$Selector
-    )
-
-    $values = [System.Collections.Generic.List[double]]::new()
-    foreach ($runResult in $RunResults) {
-        $value = & $Selector $runResult
-        if ($null -eq $value) {
-            continue
-        }
-
-        $parsedValue = 0.0
-        if ([double]::TryParse([string]$value, [ref]$parsedValue)) {
-            $values.Add($parsedValue) | Out-Null
-        }
-    }
-
-    return @($values)
-}
-
 function Write-AdHocBenchmarkSeriesSummary {
     [CmdletBinding()]
     param(
@@ -327,7 +201,7 @@ function Write-AdHocBenchmarkSeriesSummary {
     $localOnly = [bool](Get-ObjectPropertyValue -InputObject $firstResult -Name 'local_only')
     $persistentLocalWorkflow = [bool](Get-ObjectPropertyValue -InputObject $firstResult -Name 'persistent_local_workflow')
 
-    $summary = [PSCustomObject]@{
+    $summaryProperties = [ordered]@{
         generated_utc = [datetime]::UtcNow.ToString('o')
         benchmark_mode = [string](Get-ObjectPropertyValue -InputObject $firstResult -Name 'benchmark_mode')
         benchmark_dataset_id = [string](Get-ObjectPropertyValue -InputObject $datasetDefinition -Name 'id')
@@ -337,77 +211,15 @@ function Write-AdHocBenchmarkSeriesSummary {
         persistent_local_workflow = $persistentLocalWorkflow
         current_baseline_name = [string]$currentBaseline
         result_paths = @($resultPaths)
-        local_elapsed_seconds = Get-NumericSeriesSummary -Values (Get-BenchmarkMetricSeriesValues -RunResults $runResults -Selector {
-            param($result)
-            $current = Get-ObjectPropertyValue -InputObject $result -Name 'current'
-            $local = Get-ObjectPropertyValue -InputObject $current -Name 'local'
-            Get-ObjectPropertyValue -InputObject $local -Name 'elapsed_seconds'
-        })
-        runbook_elapsed_seconds = if ($localOnly) { $null } else { Get-NumericSeriesSummary -Values (Get-BenchmarkMetricSeriesValues -RunResults $runResults -Selector {
-            param($result)
-            $current = Get-ObjectPropertyValue -InputObject $result -Name 'current'
-            $runbook = Get-ObjectPropertyValue -InputObject $current -Name 'runbook'
-            Get-ObjectPropertyValue -InputObject $runbook -Name 'elapsed_seconds'
-        }) }
-        function_active_elapsed_seconds = if ($localOnly) { $null } else { Get-NumericSeriesSummary -Values (Get-BenchmarkMetricSeriesValues -RunResults $runResults -Selector {
-            param($result)
-            $current = Get-ObjectPropertyValue -InputObject $result -Name 'current'
-            $functionApp = Get-ObjectPropertyValue -InputObject $current -Name 'function_app'
-            Get-ObjectPropertyValue -InputObject $functionApp -Name 'active_elapsed_seconds'
-        }) }
-        function_end_to_end_elapsed_seconds = if ($localOnly) { $null } else { Get-NumericSeriesSummary -Values (Get-BenchmarkMetricSeriesValues -RunResults $runResults -Selector {
-            param($result)
-            $current = Get-ObjectPropertyValue -InputObject $result -Name 'current'
-            $functionApp = Get-ObjectPropertyValue -InputObject $current -Name 'function_app'
-            Get-ObjectPropertyValue -InputObject $functionApp -Name 'end_to_end_elapsed_seconds'
-        }) }
-        function_pickup_delay_seconds = if ($localOnly) { $null } else { Get-NumericSeriesSummary -Values (Get-BenchmarkMetricSeriesValues -RunResults $runResults -Selector {
-            param($result)
-            $current = Get-ObjectPropertyValue -InputObject $result -Name 'current'
-            $functionApp = Get-ObjectPropertyValue -InputObject $current -Name 'function_app'
-            Get-ObjectPropertyValue -InputObject $functionApp -Name 'pickup_delay_seconds'
-        }) }
-        persistent_reuse_elapsed_seconds = if ($persistentLocalWorkflow) { Get-NumericSeriesSummary -Values (Get-BenchmarkMetricSeriesValues -RunResults $runResults -Selector {
-            param($result)
-            $current = Get-ObjectPropertyValue -InputObject $result -Name 'current'
-            $localPersistentCache = Get-ObjectPropertyValue -InputObject $current -Name 'local_persistent_cache'
-            $reuse = Get-ObjectPropertyValue -InputObject $localPersistentCache -Name 'reuse_after_payload_eviction'
-            Get-ObjectPropertyValue -InputObject $reuse -Name 'elapsed_seconds'
-        }) } else { $null }
     }
 
-    $summaryPath = Join-Path $resultsDirectory 'series-summary.json'
-    $summary | ConvertTo-Json -Depth 20 | Set-Content -LiteralPath $summaryPath -Encoding utf8
-
-    $summaryLines = [System.Collections.Generic.List[string]]::new()
-    $summaryLines.Add('# Benchmark Series Summary') | Out-Null
-    $summaryLines.Add('') | Out-Null
-    $summaryLines.Add(('- Benchmark mode: `{0}`' -f [string]$summary.benchmark_mode)) | Out-Null
-    if (-not [string]::IsNullOrWhiteSpace([string]$summary.current_baseline_name)) {
-        $summaryLines.Add(('- Baseline: `{0}`' -f [string]$summary.current_baseline_name)) | Out-Null
-    }
-    if (-not [string]::IsNullOrWhiteSpace([string]$summary.benchmark_dataset_id)) {
-        $summaryLines.Add(('- Dataset: `{0}`' -f [string]$summary.benchmark_dataset_id)) | Out-Null
-    }
-    if (-not [string]::IsNullOrWhiteSpace([string]$summary.benchmark_dataset_path)) {
-        $summaryLines.Add(('- Dataset path: `{0}`' -f [string]$summary.benchmark_dataset_path)) | Out-Null
-    }
-    $summaryLines.Add(('- Iterations: `{0}`' -f $summary.iteration_count)) | Out-Null
-    $summaryLines.Add(('- Results root: `{0}`' -f $resultsDirectory)) | Out-Null
-    $summaryLines.Add('') | Out-Null
-    $summaryLines.Add((Get-MarkdownStatisticLine -Label 'Local elapsed' -Summary $summary.local_elapsed_seconds)) | Out-Null
-    if (-not $localOnly) {
-        $summaryLines.Add((Get-MarkdownStatisticLine -Label 'Runbook elapsed' -Summary $summary.runbook_elapsed_seconds)) | Out-Null
-        $summaryLines.Add((Get-MarkdownStatisticLine -Label 'Function active elapsed' -Summary $summary.function_active_elapsed_seconds)) | Out-Null
-        $summaryLines.Add((Get-MarkdownStatisticLine -Label 'Function end-to-end elapsed' -Summary $summary.function_end_to_end_elapsed_seconds)) | Out-Null
-        $summaryLines.Add((Get-MarkdownStatisticLine -Label 'Function pickup delay' -Summary $summary.function_pickup_delay_seconds)) | Out-Null
-    }
-    if ($persistentLocalWorkflow) {
-        $summaryLines.Add((Get-MarkdownStatisticLine -Label 'Persistent local reuse elapsed' -Summary $summary.persistent_reuse_elapsed_seconds)) | Out-Null
+    $metricSummary = Get-BenchmarkSeriesMetricSummary -RunResults @($runResults) -LocalOnly $localOnly -IncludePersistentLocalWorkflow $persistentLocalWorkflow
+    foreach ($property in $metricSummary.PSObject.Properties) {
+        $summaryProperties[$property.Name] = $property.Value
     }
 
-    $summaryMarkdownPath = Join-Path $resultsDirectory 'series-summary.md'
-    [System.IO.File]::WriteAllLines($summaryMarkdownPath, $summaryLines, [System.Text.UTF8Encoding]::new($false))
+    $summary = [PSCustomObject]$summaryProperties
+    [void](Write-BenchmarkSeriesSummaryOutput -ResultsRoot $resultsDirectory -Summary $summary)
 }
 
 function Get-LocalDiagnosticTimingSummary {

--- a/tests/Measure-BranchVsMainBenchmark.ps1
+++ b/tests/Measure-BranchVsMainBenchmark.ps1
@@ -1399,6 +1399,22 @@ function Get-AvailableMemoryGB {
     return [math]::Round(($os.FreePhysicalMemory / 1MB), 2)
 }
 
+function Get-PreBenchmarkEnvironmentSnapshot {
+    [CmdletBinding()]
+    [OutputType([pscustomobject])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Path
+    )
+
+    return [PSCustomObject]@{
+        captured_utc = [datetime]::UtcNow.ToString('o')
+        logical_cpu_count = [int][System.Environment]::ProcessorCount
+        available_memory_gb = Get-AvailableMemoryGB
+        free_disk_gb = [math]::Round(((Get-FreeDiskByteCount -Path $Path) / 1GB), 2)
+    }
+}
+
 function Get-ProcessTree {
     [CmdletBinding()]
     [OutputType([System.Diagnostics.Process[]])]
@@ -1519,6 +1535,7 @@ function Start-LocalBenchmark {
         repoPath = $RepoPath
         sourceDatasetPath = $BenchmarkDatasetPath
         datasetPath = $localDatasetPath
+        environmentSnapshot = Get-PreBenchmarkEnvironmentSnapshot -Path $OutputDirectory
         process = $process
         stdoutPath = $stdoutPath
         stderrPath = $stderrPath
@@ -1627,6 +1644,7 @@ function Get-LocalBenchmarkResult {
         used_cached_payload = [bool]$logSummary.used_cached_payload
         used_cached_vuln_columns = [bool]$logSummary.used_cached_vuln_columns
         published_cached_vuln_columns = [bool]$logSummary.published_cached_vuln_columns
+        environment_snapshot = $State.environmentSnapshot
         stdout_path = $State.stdoutPath
         stderr_path = $State.stderrPath
         dashboard_path = $State.dashboardPath
@@ -1691,6 +1709,95 @@ function Get-PhaseElapsedSecondsValue {
     }
 
     return [double]$phaseProperty.Value
+}
+
+function Get-PhaseElapsedSecondsDeltaSummary {
+    [CmdletBinding()]
+    [OutputType([pscustomobject])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [AllowNull()]
+        $CurrentResult,
+
+        [Parameter(Mandatory = $true)]
+        [AllowNull()]
+        $MainResult
+    )
+
+    $phaseNames = [System.Collections.Generic.List[string]]::new()
+    foreach ($phaseContainer in @(
+        (Get-ObjectPropertyValue -InputObject $CurrentResult -Name 'phase_elapsed_seconds'),
+        (Get-ObjectPropertyValue -InputObject $MainResult -Name 'phase_elapsed_seconds')
+    )) {
+        if ($null -eq $phaseContainer) {
+            continue
+        }
+
+        foreach ($phaseProperty in $phaseContainer.PSObject.Properties) {
+            $phaseName = [string]$phaseProperty.Name
+            if (-not $phaseNames.Contains($phaseName)) {
+                $phaseNames.Add($phaseName) | Out-Null
+            }
+        }
+    }
+
+    $deltaByName = [ordered]@{}
+    foreach ($phaseName in $phaseNames) {
+        $currentPhaseSeconds = Get-PhaseElapsedSecondsValue -Result $CurrentResult -PhaseName $phaseName
+        $mainPhaseSeconds = Get-PhaseElapsedSecondsValue -Result $MainResult -PhaseName $phaseName
+        if ($null -eq $currentPhaseSeconds -or $null -eq $mainPhaseSeconds) {
+            continue
+        }
+
+        $deltaByName[$phaseName] = [math]::Round(($currentPhaseSeconds - $mainPhaseSeconds), 2)
+    }
+
+    if ($deltaByName.Count -eq 0) {
+        return $null
+    }
+
+    return [PSCustomObject]$deltaByName
+}
+
+function Get-EnvironmentSnapshotDeltaSummary {
+    [CmdletBinding()]
+    [OutputType([pscustomobject])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [AllowNull()]
+        $CurrentResult,
+
+        [Parameter(Mandatory = $true)]
+        [AllowNull()]
+        $MainResult
+    )
+
+    $currentEnvironmentSnapshot = Get-ObjectPropertyValue -InputObject $CurrentResult -Name 'environment_snapshot'
+    $mainEnvironmentSnapshot = Get-ObjectPropertyValue -InputObject $MainResult -Name 'environment_snapshot'
+    if ($null -eq $currentEnvironmentSnapshot -or $null -eq $mainEnvironmentSnapshot) {
+        return $null
+    }
+
+    return [PSCustomObject]@{
+        available_memory_gb_delta = if ($null -ne $currentEnvironmentSnapshot.available_memory_gb -and $null -ne $mainEnvironmentSnapshot.available_memory_gb) {
+            [math]::Round(([double]$currentEnvironmentSnapshot.available_memory_gb - [double]$mainEnvironmentSnapshot.available_memory_gb), 2)
+        }
+        else {
+            $null
+        }
+        free_disk_gb_delta = if ($null -ne $currentEnvironmentSnapshot.free_disk_gb -and $null -ne $mainEnvironmentSnapshot.free_disk_gb) {
+            [math]::Round(([double]$currentEnvironmentSnapshot.free_disk_gb - [double]$mainEnvironmentSnapshot.free_disk_gb), 2)
+        }
+        else {
+            $null
+        }
+        logical_cpu_count_delta = if ($null -ne $currentEnvironmentSnapshot.logical_cpu_count -and $null -ne $mainEnvironmentSnapshot.logical_cpu_count) {
+            [int]$currentEnvironmentSnapshot.logical_cpu_count - [int]$mainEnvironmentSnapshot.logical_cpu_count
+        }
+        else {
+            $null
+        }
+    }
 }
 
 function Invoke-LocalPersistentCacheWorkflow {
@@ -2268,6 +2375,8 @@ function Get-ComparisonBlock {
             elapsed_seconds_delta = [math]::Round(($Current.local.elapsed_seconds - $Main.local.elapsed_seconds), 2)
             peak_rss_gb_delta = [math]::Round(($Current.local.peak_tree_rss_gb - $Main.local.peak_tree_rss_gb), 3)
             peak_private_gb_delta = [math]::Round(($Current.local.peak_tree_private_gb - $Main.local.peak_tree_private_gb), 3)
+            phase_elapsed_seconds_delta = Get-PhaseElapsedSecondsDeltaSummary -CurrentResult $Current.local -MainResult $Main.local
+            environment_snapshot_delta = Get-EnvironmentSnapshotDeltaSummary -CurrentResult $Current.local -MainResult $Main.local
         }
         local_persistent_cache = if ($Current.PSObject.Properties['local_persistent_cache'] -and $Main.PSObject.Properties['local_persistent_cache'] -and $null -ne $Current.local_persistent_cache -and $null -ne $Main.local_persistent_cache) {
             [PSCustomObject]@{

--- a/tests/Measure-BranchVsMainBenchmark.ps1
+++ b/tests/Measure-BranchVsMainBenchmark.ps1
@@ -169,6 +169,31 @@ function Get-TextWithoutAnsiEscape {
     return ([regex]::Replace($Text, "`e\[[0-9;]*m", ''))
 }
 
+function Test-ScriptParameterSupport {
+    [CmdletBinding()]
+    [OutputType([bool])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$ScriptPath,
+
+        [Parameter(Mandatory = $true)]
+        [string]$ParameterName
+    )
+
+    if (-not (Test-Path -LiteralPath $ScriptPath -PathType Leaf)) {
+        return $false
+    }
+
+    try {
+        $command = Get-Command -Name $ScriptPath -ErrorAction Stop
+        return $command.Parameters.ContainsKey($ParameterName)
+    }
+    catch {
+        Write-Verbose ("Unable to inspect parameters for {0}: {1}" -f $ScriptPath, $_.Exception.Message)
+        return $false
+    }
+}
+
 function Write-AdHocBenchmarkSeriesSummary {
     [CmdletBinding()]
     param(
@@ -1755,9 +1780,12 @@ function Start-LocalBenchmark {
         '-File', $scriptPath,
         '-SkipSyntheticGeneration',
         '-SyntheticOutputPath', $localDatasetPath,
-        '-DashboardOutputPath', $dashboardPath,
-        '-DiagnosticPhaseLogPath', $phaseLogPath
+        '-DashboardOutputPath', $dashboardPath
     )
+
+    if (Test-ScriptParameterSupport -ScriptPath $scriptPath -ParameterName 'DiagnosticPhaseLogPath') {
+        $argumentList += @('-DiagnosticPhaseLogPath', $phaseLogPath)
+    }
 
     $process = Start-Process -FilePath 'pwsh' -ArgumentList $argumentList -WorkingDirectory $RepoPath -RedirectStandardOutput $stdoutPath -RedirectStandardError $stderrPath -PassThru
     return [ordered]@{

--- a/tests/New-SyntheticLegacyVulnSnapshotSet.ps1
+++ b/tests/New-SyntheticLegacyVulnSnapshotSet.ps1
@@ -60,6 +60,7 @@ function Get-HistoryRowsReadPath {
 }
 
 function Invoke-SourceVulnRows {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '', Justification = 'Internal helper streams multiple vulnerability rows by design.')]
     [CmdletBinding()]
     param(
         [Parameter(Mandatory = $true)]
@@ -131,6 +132,8 @@ function Resolve-SnapshotDateList {
         $HistoryRowCount.Value = 0
         Invoke-SourceVulnRows -BasePath $BasePath -Process {
             param($Row, [string]$Kind)
+
+            [void]$Row
 
             if ($Kind -eq 'current') {
                 $CurrentRowCount.Value++
@@ -232,6 +235,7 @@ function Test-RowActiveOnSnapshotDate {
 }
 
 function New-GzipWriterState {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '', Justification = 'Internal helper stages gzip output writers for this synthetic data generator.')]
     [CmdletBinding()]
     param(
         [Parameter(Mandatory = $true)]
@@ -338,6 +342,8 @@ $resolvedSnapshotDates = Resolve-SnapshotDateList `
     -HistoryRowCount ([ref]$historyRowCount) `
     -DistinctLastSeenDateCount ([ref]$distinctLastSeenDateCount)
 
+$progressUpdateIntervalRows = $ProgressIntervalRows
+
 if ($resolvedSnapshotDates.Count -eq 0) {
     throw "No snapshot dates were selected from '$resolvedSourcePath'."
 }
@@ -359,6 +365,8 @@ try {
     Invoke-SourceVulnRows -BasePath $resolvedSourcePath -Process {
         param($Row, [string]$Kind)
 
+        [void]$Kind
+
         $sourceRowsProcessed++
         $groupId = Get-LegacySnapshotGroupId -Row $Row
         foreach ($snapshotDate in $resolvedSnapshotDates) {
@@ -373,7 +381,7 @@ try {
             [void]$groupsPerSnapshotDate[$snapshotDate].Add($groupId)
         }
 
-        if (($sourceRowsProcessed % $ProgressIntervalRows) -eq 0) {
+        if (($sourceRowsProcessed % $progressUpdateIntervalRows) -eq 0) {
             Write-Host ('[{0}] Processed {1} source rows in {2}' -f (Get-Date).ToString('yyyy-MM-dd HH:mm:ss'), $sourceRowsProcessed, $generationStopwatch.Elapsed.ToString('hh\:mm\:ss'))
         }
     }

--- a/tests/Record-BenchmarkHistory.ps1
+++ b/tests/Record-BenchmarkHistory.ps1
@@ -215,6 +215,8 @@ function Get-BaselineSummary {
         local_rows_per_second = Get-ObjectPropertyValue -InputObject $local -Name 'rows_per_second'
         local_peak_rss_gb = Get-ObjectPropertyValue -InputObject $local -Name 'peak_tree_rss_gb'
         local_peak_private_gb = Get-ObjectPropertyValue -InputObject $local -Name 'peak_tree_private_gb'
+        local_phase_elapsed_seconds = Get-ObjectPropertyValue -InputObject $local -Name 'phase_elapsed_seconds'
+        local_environment_snapshot = Get-ObjectPropertyValue -InputObject $local -Name 'environment_snapshot'
         runbook_elapsed_seconds = Get-ObjectPropertyValue -InputObject $runbook -Name 'elapsed_seconds'
         runbook_rows_per_second = Get-ObjectPropertyValue -InputObject $runbook -Name 'rows_per_second'
         runbook_peak_working_set_mb = Get-ObjectPropertyValue -InputObject $runbook -Name 'peak_working_set_mb'
@@ -389,6 +391,113 @@ function Format-DeltaValue {
     return ('{0}s ({1})' -f $deltaText, $trend)
 }
 
+function Format-SignedSecondsDeltaValue {
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory = $false)]
+        [AllowNull()]
+        $Value
+    )
+
+    if ($null -eq $Value) {
+        return 'n/a'
+    }
+
+    $delta = [math]::Round([double]$Value, 2)
+    $deltaText = if ($delta -gt 0) {
+        '+' + ('{0:N2}' -f $delta)
+    }
+    else {
+        ('{0:N2}' -f $delta)
+    }
+
+    $trend = if ($delta -lt 0) {
+        'faster'
+    }
+    elseif ($delta -gt 0) {
+        'slower'
+    }
+    else {
+        'unchanged'
+    }
+
+    return ('{0}s ({1})' -f $deltaText, $trend)
+}
+
+function Format-SignedNumberDeltaValue {
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory = $false)]
+        [AllowNull()]
+        $Value,
+
+        [Parameter(Mandatory = $false)]
+        [string]$Suffix = '',
+
+        [Parameter(Mandatory = $false)]
+        [ValidateRange(0, 6)]
+        [int]$Decimals = 3
+    )
+
+    if ($null -eq $Value) {
+        return 'n/a'
+    }
+
+    $delta = [math]::Round([double]$Value, $Decimals)
+    $format = '{0:N' + $Decimals + '}'
+    $deltaText = if ($delta -gt 0) {
+        '+' + ($format -f $delta)
+    }
+    else {
+        ($format -f $delta)
+    }
+
+    return ($deltaText + $Suffix)
+}
+
+function Format-EnvironmentSnapshotValue {
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory = $false)]
+        [AllowNull()]
+        $Snapshot
+    )
+
+    if ($null -eq $Snapshot) {
+        return 'n/a'
+    }
+
+    return ('{0} CPU | {1:N2} GB free memory | {2:N2} GB free disk' -f [int]$Snapshot.logical_cpu_count, [double]$Snapshot.available_memory_gb, [double]$Snapshot.free_disk_gb)
+}
+
+function Format-PhaseDeltaSummaryValue {
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory = $false)]
+        [AllowNull()]
+        $PhaseSummary
+    )
+
+    if ($null -eq $PhaseSummary) {
+        return 'n/a'
+    }
+
+    $phaseParts = [System.Collections.Generic.List[string]]::new()
+    foreach ($phaseProperty in $PhaseSummary.PSObject.Properties) {
+        $phaseParts.Add(('{0}: {1}' -f [string]$phaseProperty.Name, (Format-SignedSecondsDeltaValue -Value $phaseProperty.Value))) | Out-Null
+    }
+
+    if ($phaseParts.Count -eq 0) {
+        return 'n/a'
+    }
+
+    return ($phaseParts -join '; ')
+}
+
 function Write-BenchmarkHistorySummary {
     [CmdletBinding()]
     param(
@@ -427,6 +536,7 @@ function Write-BenchmarkHistorySummary {
         $lines.Add(('- Current git: `{0}` @ `{1}` ({2})' -f $Entry.current.repo.branch, $Entry.current.repo.commit_short, $(if ($Entry.current.repo.dirty) { 'dirty' } else { 'clean' }))) | Out-Null
     }
     $lines.Add(('- Local elapsed: {0}' -f (Format-SecondsValue -Value $Entry.current.local_elapsed_seconds))) | Out-Null
+        $lines.Add(('- Local pre-run environment: {0}' -f (Format-EnvironmentSnapshotValue -Snapshot $Entry.current.local_environment_snapshot))) | Out-Null
     $lines.Add(('- Runbook elapsed: {0}' -f (Format-SecondsValue -Value $Entry.current.runbook_elapsed_seconds))) | Out-Null
     $lines.Add(('- Function elapsed: {0} ({1})' -f (Format-SecondsValue -Value $Entry.current.function_elapsed_seconds), $(if ([string]::IsNullOrWhiteSpace([string]$Entry.current.function_timing_basis)) { 'legacy' } else { [string]$Entry.current.function_timing_basis }))) | Out-Null
     if ($null -ne $Entry.current.function_end_to_end_elapsed_seconds) {
@@ -440,6 +550,18 @@ function Write-BenchmarkHistorySummary {
         $lines.Add(('- Tags: `{0}`' -f (@($Entry.tags) -join '`, `'))) | Out-Null
     }
     $lines.Add(('- History file: `{0}`' -f $HistoryPath)) | Out-Null
+
+    if ($null -ne $Entry.comparison -and $null -ne $Entry.comparison.local) {
+        $lines.Add('') | Out-Null
+        $lines.Add('Current vs main baseline') | Out-Null
+        $lines.Add('') | Out-Null
+        $lines.Add(('- Local elapsed delta: {0}' -f (Format-SignedSecondsDeltaValue -Value $Entry.comparison.local.elapsed_seconds_delta))) | Out-Null
+        $lines.Add(('- Local peak RSS / private delta: {0} / {1}' -f (Format-SignedNumberDeltaValue -Value $Entry.comparison.local.peak_rss_gb_delta -Suffix 'GB' -Decimals 3), (Format-SignedNumberDeltaValue -Value $Entry.comparison.local.peak_private_gb_delta -Suffix 'GB' -Decimals 3))) | Out-Null
+        $lines.Add(('- Local phase deltas: {0}' -f (Format-PhaseDeltaSummaryValue -PhaseSummary $Entry.comparison.local.phase_elapsed_seconds_delta))) | Out-Null
+        if ($null -ne $Entry.comparison.local.environment_snapshot_delta) {
+            $lines.Add(('- Local pre-run environment delta: memory {0}, disk {1}, cpu {2}' -f (Format-SignedNumberDeltaValue -Value $Entry.comparison.local.environment_snapshot_delta.available_memory_gb_delta -Suffix 'GB' -Decimals 2), (Format-SignedNumberDeltaValue -Value $Entry.comparison.local.environment_snapshot_delta.free_disk_gb_delta -Suffix 'GB' -Decimals 2), (Format-SignedNumberDeltaValue -Value $Entry.comparison.local.environment_snapshot_delta.logical_cpu_count_delta -Decimals 0))) | Out-Null
+        }
+    }
 
     if ($null -ne $PreviousEntry) {
         $lines.Add('') | Out-Null

--- a/tests/Run-SharedHelperRegression.ps1
+++ b/tests/Run-SharedHelperRegression.ps1
@@ -724,6 +724,40 @@ function Test-ResolveNormalizedLookupIndexListHandlesScalarAndCollectionValues {
     Assert-True ($null -eq $emptyValueIndices) 'Expected empty lookup input to return no indices.'
 }
 
+function Test-ResolveNormalizedInventoryLookupSkipsEmptyInventoryData {
+    [CmdletBinding()]
+    param()
+
+    $context = Get-NormalizationContext
+    $emptyInventoryIndex = Resolve-NormalizedInventoryLookup `
+        -DeviceId 'device-001' `
+        -SoftwareVendor 'contoso' `
+        -SoftwareName 'legacy_agent' `
+        -SoftwareVersion '6.0.0' `
+        -Context $context
+
+    $inventoryKey = Get-AdvancedHuntingInventoryMatchKey -DeviceId 'device-001' -SoftwareVendor 'contoso' -SoftwareName 'legacy_agent' -SoftwareVersion '6.0.0'
+    $context.AdvancedHuntingInventoryData = @{
+        $inventoryKey = [PSCustomObject]@{
+            ProductCodeCpe = 'cpe:/a:contoso:legacy_agent:6.0.0'
+            EndOfSupportStatus = 'supported'
+            EndOfSupportDate = '2027-10-01'
+        }
+    }
+
+    $populatedInventoryIndex = Resolve-NormalizedInventoryLookup `
+        -DeviceId 'device-001' `
+        -SoftwareVendor 'contoso' `
+        -SoftwareName 'legacy_agent' `
+        -SoftwareVersion '6.0.0' `
+        -Context $context
+
+    Assert-True ($emptyInventoryIndex -eq -1) 'Expected empty inventory data to skip normalized inventory lookup creation.'
+    Assert-True ($context.Lookups.inventory.Count -eq 1) 'Expected only the populated inventory lookup to materialize in the lookup table.'
+    Assert-True ($populatedInventoryIndex -eq 0) 'Expected populated inventory data to create the first normalized inventory lookup.'
+    Assert-True ([string]$context.Lookups.inventory[0].cpe -eq 'cpe:/a:contoso:legacy_agent:6.0.0') 'Expected populated inventory lookup to preserve ProductCodeCpe.'
+}
+
 function Test-ConvertToNormalizedDataUsesStableDeviceIdFallback {
     [CmdletBinding()]
     param()
@@ -2352,6 +2386,8 @@ Test-ReadNormalizedVulnStoreRow
 Write-Output '  Normalized vulnerability store reader checks passed.'
 Test-ResolveNormalizedLookupIndexListHandlesScalarAndCollectionValues
 Write-Output '  Lookup index list normalization checks passed.'
+Test-ResolveNormalizedInventoryLookupSkipsEmptyInventoryData
+Write-Output '  Inventory lookup normalization checks passed.'
 Test-ConvertToNormalizedDataUsesStableDeviceIdFallback
 Write-Output '  Stable device fallback identity checks passed.'
 Test-ConvertToNormalizedDataWritesExpectedRowCount

--- a/tests/Run-SharedHelperRegression.ps1
+++ b/tests/Run-SharedHelperRegression.ps1
@@ -773,6 +773,45 @@ function Test-AddNormalizedCveUsesStableSeverityIndexLookup {
     Assert-True ($context.Lookups.cves[$unknownCveIndex].sv -eq -1) 'Expected unknown severity CVEs to preserve the fallback lookup index.'
 }
 
+function Test-GetNormalizedRecordLookupHandlesScalarPathInputs {
+    [CmdletBinding()]
+    param()
+
+    $context = Get-NormalizationContext
+
+    $recordLookup = Get-NormalizedRecordLookup `
+        -DeviceId 'device-001' `
+        -DeviceName 'device-001.contoso.com' `
+        -GroupName 'Pilot' `
+        -OsPlatform 'Windows10' `
+        -OsVersion '10.0.26100' `
+        -MachineTags @('Pilot') `
+        -SoftwareVendor 'contoso' `
+        -SoftwareName 'legacy_agent' `
+        -RecommendationReference '' `
+        -CveId 'CVE-2026-1004' `
+        -CvssScore '6.5' `
+        -SeverityLevel 'Medium' `
+        -ExploitabilityLevel 'High' `
+        -CveUrl 'https://example.test/CVE-2026-1004' `
+        -CveBatchTitle 'baseline' `
+        -RecommendedSecurityUpdate '' `
+        -RecommendedSecurityUpdateId '' `
+        -RecommendedSecurityUpdateUrl '' `
+        -SoftwareVersion '6.0.0' `
+        -DiskPaths 'C:\Windows\System32\kernel32.dll' `
+        -RegistryPaths 'HKLM\Software\Microsoft\Windows' `
+        -SecurityUpdateAvailable $false `
+        -Context $context
+
+    Assert-True ($recordLookup.ContentLookup.dp.Count -eq 1) 'Expected scalar disk path input to resolve to a single normalized lookup index.'
+    Assert-True ($recordLookup.ContentLookup.dp[0] -eq 0) 'Expected scalar disk path input to create lookup index 0.'
+    Assert-True ($recordLookup.ContentLookup.rp.Count -eq 1) 'Expected scalar registry path input to resolve to a single normalized lookup index.'
+    Assert-True ($recordLookup.ContentLookup.rp[0] -eq 0) 'Expected scalar registry path input to create lookup index 0.'
+    Assert-True ($context.Lookups.diskPaths.Count -eq 1) 'Expected scalar disk path input to materialize one disk path lookup.'
+    Assert-True ($context.Lookups.regPaths.Count -eq 1) 'Expected scalar registry path input to materialize one registry path lookup.'
+}
+
 function Test-ConvertToNormalizedDataUsesStableDeviceIdFallback {
     [CmdletBinding()]
     param()
@@ -2405,6 +2444,8 @@ Test-ResolveNormalizedInventoryLookupSkipsEmptyInventoryData
 Write-Output '  Inventory lookup normalization checks passed.'
 Test-AddNormalizedCveUsesStableSeverityIndexLookup
 Write-Output '  CVE severity lookup checks passed.'
+Test-GetNormalizedRecordLookupHandlesScalarPathInputs
+Write-Output '  Scalar path lookup checks passed.'
 Test-ConvertToNormalizedDataUsesStableDeviceIdFallback
 Write-Output '  Stable device fallback identity checks passed.'
 Test-ConvertToNormalizedDataWritesExpectedRowCount

--- a/tests/Run-SharedHelperRegression.ps1
+++ b/tests/Run-SharedHelperRegression.ps1
@@ -127,6 +127,7 @@ function Get-TestQuarterlyHistoryDocument {
 }
 
 function Test-VulnPropertyHelpersSupportSupportedRowShapes {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '', Justification = 'Regression test name intentionally refers to multiple supported row shapes.')]
     [CmdletBinding()]
     param()
 
@@ -278,6 +279,7 @@ function Test-LocalExportArtifactCleanup {
 }
 
 function Test-InitializeMachineHistoryStoreBackfillsCurrentRecordMetadata {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '', Justification = 'Regression test name intentionally refers to current records and metadata fields as a set.')]
     [CmdletBinding()]
     param()
 
@@ -705,6 +707,7 @@ function Test-ReadNormalizedVulnStoreRow {
 }
 
 function Test-ResolveNormalizedLookupIndexListHandlesScalarAndCollectionValues {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '', Justification = 'Regression test name intentionally covers both scalar and collection values.')]
     [CmdletBinding()]
     param()
 
@@ -774,6 +777,7 @@ function Test-AddNormalizedCveUsesStableSeverityIndexLookup {
 }
 
 function Test-GetNormalizedRecordLookupHandlesScalarPathInputs {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '', Justification = 'Regression test name intentionally refers to multiple path inputs.')]
     [CmdletBinding()]
     param()
 
@@ -1449,6 +1453,7 @@ function Test-AdvancedHuntingBundleMatchesDedicatedReaderData {
 }
 
 function Test-AdvancedHuntingBundleStringArrayFiltersSparseInputs {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '', Justification = 'Regression test name intentionally refers to multiple sparse inputs.')]
     [CmdletBinding()]
     param()
 

--- a/tests/Run-SharedHelperRegression.ps1
+++ b/tests/Run-SharedHelperRegression.ps1
@@ -704,6 +704,26 @@ function Test-ReadNormalizedVulnStoreRow {
     }
 }
 
+function Test-ResolveNormalizedLookupIndexListHandlesScalarAndCollectionValues {
+    [CmdletBinding()]
+    param()
+
+    $lookupList = [System.Collections.Generic.List[string]]::new()
+    $indexMap = @{}
+
+    $singleValueIndices = Resolve-NormalizedLookupIndexList -Values 'C:\Windows\System32\kernel32.dll' -List $lookupList -IndexMap $indexMap
+    $mixedValueIndices = Resolve-NormalizedLookupIndexList -Values @('C:\Windows\System32\kernel32.dll', $null, 'HKLM\Software\Microsoft\Windows') -List $lookupList -IndexMap $indexMap
+    $emptyValueIndices = Resolve-NormalizedLookupIndexList -Values @() -List $lookupList -IndexMap $indexMap
+
+    Assert-True ($singleValueIndices.Count -eq 1) 'Expected scalar lookup input to resolve to a single lookup index.'
+    Assert-True ($singleValueIndices[0] -eq 0) 'Expected the first scalar lookup input to create lookup index 0.'
+    Assert-True ($mixedValueIndices.Count -eq 2) 'Expected mixed lookup input to skip nulls and keep two resolved values.'
+    Assert-True ($mixedValueIndices[0] -eq 0) 'Expected repeated lookup values to reuse the existing lookup index.'
+    Assert-True ($mixedValueIndices[1] -eq 1) 'Expected a new lookup value to receive the next lookup index.'
+    Assert-True ($lookupList.Count -eq 2) 'Expected lookup storage to contain only the two unique non-null values.'
+    Assert-True ($null -eq $emptyValueIndices) 'Expected empty lookup input to return no indices.'
+}
+
 function Test-ConvertToNormalizedDataUsesStableDeviceIdFallback {
     [CmdletBinding()]
     param()
@@ -2330,6 +2350,8 @@ Test-MergeVulnObservedWindowRows
 Write-Output '  Vulnerability observation merge checks passed.'
 Test-ReadNormalizedVulnStoreRow
 Write-Output '  Normalized vulnerability store reader checks passed.'
+Test-ResolveNormalizedLookupIndexListHandlesScalarAndCollectionValues
+Write-Output '  Lookup index list normalization checks passed.'
 Test-ConvertToNormalizedDataUsesStableDeviceIdFallback
 Write-Output '  Stable device fallback identity checks passed.'
 Test-ConvertToNormalizedDataWritesExpectedRowCount

--- a/tests/Run-SharedHelperRegression.ps1
+++ b/tests/Run-SharedHelperRegression.ps1
@@ -758,6 +758,21 @@ function Test-ResolveNormalizedInventoryLookupSkipsEmptyInventoryData {
     Assert-True ([string]$context.Lookups.inventory[0].cpe -eq 'cpe:/a:contoso:legacy_agent:6.0.0') 'Expected populated inventory lookup to preserve ProductCodeCpe.'
 }
 
+function Test-AddNormalizedCveUsesStableSeverityIndexLookup {
+    [CmdletBinding()]
+    param()
+
+    $context = Get-NormalizationContext
+
+    $highCveIndex = Add-NormalizedCve -CveId 'CVE-2026-1001' -CvssScore '9.0' -SeverityLevel 'High' -ExploitabilityLevel 'High' -CveUrl 'https://example.test/CVE-2026-1001' -CveBatchTitle 'baseline' -Context $context
+    $noneCveIndex = Add-NormalizedCve -CveId 'CVE-2026-1002' -CvssScore '0.0' -SeverityLevel 'None' -ExploitabilityLevel 'Unproven' -CveUrl 'https://example.test/CVE-2026-1002' -CveBatchTitle 'baseline' -Context $context
+    $unknownCveIndex = Add-NormalizedCve -CveId 'CVE-2026-1003' -CvssScore '5.0' -SeverityLevel 'Unexpected' -ExploitabilityLevel 'ProofOfConcept' -CveUrl 'https://example.test/CVE-2026-1003' -CveBatchTitle 'baseline' -Context $context
+
+    Assert-True ($context.Lookups.cves[$highCveIndex].sv -eq 1) 'Expected High severity CVEs to serialize severity lookup index 1.'
+    Assert-True ($context.Lookups.cves[$noneCveIndex].sv -eq 4) 'Expected None severity CVEs to serialize severity lookup index 4.'
+    Assert-True ($context.Lookups.cves[$unknownCveIndex].sv -eq -1) 'Expected unknown severity CVEs to preserve the fallback lookup index.'
+}
+
 function Test-ConvertToNormalizedDataUsesStableDeviceIdFallback {
     [CmdletBinding()]
     param()
@@ -2388,6 +2403,8 @@ Test-ResolveNormalizedLookupIndexListHandlesScalarAndCollectionValues
 Write-Output '  Lookup index list normalization checks passed.'
 Test-ResolveNormalizedInventoryLookupSkipsEmptyInventoryData
 Write-Output '  Inventory lookup normalization checks passed.'
+Test-AddNormalizedCveUsesStableSeverityIndexLookup
+Write-Output '  CVE severity lookup checks passed.'
 Test-ConvertToNormalizedDataUsesStableDeviceIdFallback
 Write-Output '  Stable device fallback identity checks passed.'
 Test-ConvertToNormalizedDataWritesExpectedRowCount

--- a/tests/Run-SharedHelperRegression.ps1
+++ b/tests/Run-SharedHelperRegression.ps1
@@ -952,6 +952,35 @@ function Test-ConvertToNormalizedDataCanConsumeLookupsOnPayloadClose {
     }
 }
 
+function Test-ConvertToNormalizedDataDeduplicatesRepeatedCveLookup {
+    [CmdletBinding()]
+    param()
+
+    $tempRoot = Join-Path ([System.IO.Path]::GetTempPath()) ('normalized-repeat-cve-' + [guid]::NewGuid().ToString('N'))
+    [void](New-Item -Path $tempRoot -ItemType Directory -Force)
+    $outputPath = Join-Path $tempRoot 'normalized-vulns.json'
+    $payloadPath = Join-Path $tempRoot 'payload.json.gz'
+
+    try {
+        $firstRow = Get-TestVulnRow -Id 'repeat-cve-001' -CveId 'CVE-2026-0155' -SnapshotDate '2026-03-20' -Version '1.0.0'
+        $secondRow = Get-TestVulnRow -Id 'repeat-cve-002' -CveId 'CVE-2026-0155' -SnapshotDate '2026-03-21' -Version '1.0.1'
+
+        Write-NdjsonRecordsFile -Path (Get-VulnCurrentPath -BasePath $tempRoot) -Records @($firstRow, $secondRow)
+
+        $result = ConvertTo-NormalizedData -DataPath $tempRoot -VulnOutputPath $outputPath -PayloadOutputPath $payloadPath -Machines @{} -AdvancedHuntingData @{}
+        $payload = Read-GzipTextFile -Path $payloadPath | ConvertFrom-Json -Depth 100
+
+        Assert-True ($result.VulnCount -eq 2) 'Expected repeated-CVE regression test to preserve both vulnerability rows.'
+        Assert-True ($result.CveCount -eq 1) 'Expected repeated rows sharing the same CVE definition to reuse a single CVE lookup.'
+        Assert-True ($payload.lookups.cves.Count -eq 1) 'Expected the payload to materialize only one CVE lookup for repeated CVE rows.'
+    }
+    finally {
+        if (Test-Path -LiteralPath $tempRoot) {
+            Remove-Item -LiteralPath $tempRoot -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+}
+
 function Test-ConvertToNormalizedDataIncludesAdvancedHuntingDeviceUserMap {
     [CmdletBinding()]
     param()
@@ -2311,6 +2340,8 @@ Test-ConvertToNormalizedDataPreservesOptionalNvdFallback
 Write-Output '  Optional NVD fallback normalization checks passed.'
 Test-ConvertToNormalizedDataCanConsumeLookupsOnPayloadClose
 Write-Output '  Consuming payload-close lookup checks passed.'
+Test-ConvertToNormalizedDataDeduplicatesRepeatedCveLookup
+Write-Output '  Repeated CVE lookup deduplication checks passed.'
 Test-ConvertToNormalizedDataIncludesAdvancedHuntingDeviceUserMap
 Write-Output '  Advanced Hunting device-user normalization checks passed.'
 Test-WriteCombinedPayloadGzipPreservesColumnPayload

--- a/tests/Run-SharedHelperRegression.ps1
+++ b/tests/Run-SharedHelperRegression.ps1
@@ -69,6 +69,33 @@ function Get-TestVulnRow {
     }
 }
 
+function Get-TestMachineRecord {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Id
+    )
+
+    return [PSCustomObject]@{
+        id                    = $Id
+        computerDnsName       = ($Id + '.contoso.com')
+        rbacGroupName         = 'Servers'
+        osPlatform            = 'Windows'
+        osVersion             = '10.0.22631'
+        machineTags           = @('Prod')
+        lastIpAddress         = '10.0.0.10'
+        lastExternalIpAddress = '52.0.0.10'
+        healthStatus          = 'Active'
+        riskScore             = 'Medium'
+        exposureLevel         = 'High'
+        deviceValue           = 'Normal'
+        managedBy             = 'Intune'
+        isAadJoined           = $true
+        lastSeen              = '2026-04-22T00:00:00Z'
+        firstSeen             = '2026-04-01T00:00:00Z'
+    }
+}
+
 function Get-TestQuarterlyHistoryDocument {
     [CmdletBinding()]
     param(
@@ -242,6 +269,43 @@ function Test-LocalExportArtifactCleanup {
         Assert-True (-not (Test-Path -LiteralPath (Join-Path $tempRoot '.dashboard-cache'))) 'Expected transient dashboard cache directory to be removed.'
         Assert-True (-not (Test-Path -LiteralPath (Join-Path $tempRoot '.vuln-content-store-staging-123'))) 'Expected transient content-store staging directory to be removed.'
         Assert-True (-not (Test-Path -LiteralPath (Join-Path $tempRoot '.synthetic-progress.json'))) 'Expected transient synthetic progress file to be removed.'
+    }
+    finally {
+        if (Test-Path -LiteralPath $tempRoot) {
+            Remove-Item -LiteralPath $tempRoot -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+}
+
+function Test-InitializeMachineHistoryStoreBackfillsCurrentRecordMetadata {
+    [CmdletBinding()]
+    param()
+
+    $tempRoot = Join-Path ([System.IO.Path]::GetTempPath()) ('machine-store-init-' + [guid]::NewGuid().ToString('N'))
+    [void](New-Item -Path $tempRoot -ItemType Directory -Force)
+
+    try {
+        $expectedObservedOn = Get-Date -Format 'yyyy-MM-dd'
+        Write-NdjsonRecordsFile -Path (Get-MachineCurrentPath -BasePath $tempRoot) -Records @(
+            (Get-TestMachineRecord -Id 'machine-001'),
+            [PSCustomObject]@{
+                id = 'machine-002'
+                removed = $true
+            }
+        )
+
+        $store = Initialize-MachineHistoryStore -Path $tempRoot
+        $currentRecord = $store.CurrentRecords['machine-001']
+        $periodKey = Get-QuarterPeriodKeyFromDate -Date $expectedObservedOn
+        $historyRecords = @($store.HistoryRecordsByPeriod[$periodKey])
+
+        Assert-True ($store.CurrentRecords.Count -eq 1) 'Expected removal records to be excluded from the current machine map.'
+        Assert-True ($null -ne $currentRecord) 'Expected the surviving machine record to remain in the current machine map.'
+        Assert-True ([string]$currentRecord.observedOn -eq $expectedObservedOn) 'Expected current machine records without observedOn to be backfilled once during initialization.'
+        Assert-True ([string]$currentRecord.stateHash -eq [string](Get-MachineStateHash -Machine $currentRecord)) 'Expected current machine records without stateHash to be backfilled during initialization.'
+        Assert-True ($historyRecords.Count -eq 1) 'Expected current machine records to seed history when no history store exists yet.'
+        Assert-True ([string]$historyRecords[0].id -eq 'machine-001') 'Expected seeded history to include the surviving machine record.'
+        Assert-True ([string]$historyRecords[0].observedOn -eq $expectedObservedOn) 'Expected seeded history rows to preserve the backfilled observedOn value.'
     }
     finally {
         if (Test-Path -LiteralPath $tempRoot) {
@@ -2213,6 +2277,8 @@ Test-VulnContentStoreExistenceNeedsRef
 Write-Output '  Content-store existence checks passed.'
 Test-LocalExportArtifactCleanup
 Write-Output '  Local export artifact cleanup checks passed.'
+Test-InitializeMachineHistoryStoreBackfillsCurrentRecordMetadata
+Write-Output '  Machine store initialization checks passed.'
 Test-BulkSnapshotImportSmoke
 Write-Output '  Bulk snapshot import smoke checks passed.'
 Test-BulkSnapshotImportSingleSnapshot

--- a/tests/helpers/BenchmarkSeriesTools.ps1
+++ b/tests/helpers/BenchmarkSeriesTools.ps1
@@ -1,0 +1,244 @@
+﻿function Get-SeriesPercentileValue {
+    [CmdletBinding()]
+    [OutputType([double])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [AllowEmptyCollection()]
+        [double[]]$SortedValues,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateRange(0.0, 100.0)]
+        [double]$Percentile
+    )
+
+    if ($SortedValues.Count -eq 0) {
+        return $null
+    }
+
+    if ($SortedValues.Count -eq 1) {
+        return [math]::Round($SortedValues[0], 2)
+    }
+
+    $rank = ($Percentile / 100.0) * ($SortedValues.Count - 1)
+    $lowerIndex = [int][math]::Floor($rank)
+    $upperIndex = [int][math]::Ceiling($rank)
+    if ($lowerIndex -eq $upperIndex) {
+        return [math]::Round($SortedValues[$lowerIndex], 2)
+    }
+
+    $weight = $rank - $lowerIndex
+    $interpolatedValue = $SortedValues[$lowerIndex] + (($SortedValues[$upperIndex] - $SortedValues[$lowerIndex]) * $weight)
+    return [math]::Round($interpolatedValue, 2)
+}
+
+function Get-NumericSeriesSummary {
+    [CmdletBinding()]
+    [OutputType([pscustomobject])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [AllowEmptyCollection()]
+        [double[]]$Values
+    )
+
+    $filteredValues = @($Values | Where-Object { $null -ne $_ })
+    if ($filteredValues.Count -eq 0) {
+        return $null
+    }
+
+    $orderedValues = @($filteredValues | Sort-Object)
+    $middleIndex = [math]::Floor($orderedValues.Count / 2)
+    $median = if (($orderedValues.Count % 2) -eq 1) {
+        $orderedValues[$middleIndex]
+    }
+    else {
+        [math]::Round((($orderedValues[$middleIndex - 1] + $orderedValues[$middleIndex]) / 2.0), 2)
+    }
+
+    $average = [double](($orderedValues | Measure-Object -Average).Average)
+    $variance = if ($orderedValues.Count -gt 1) {
+        (($orderedValues | ForEach-Object { [math]::Pow(([double]$_ - $average), 2) } | Measure-Object -Sum).Sum) / ($orderedValues.Count - 1)
+    }
+    else {
+        0.0
+    }
+
+    $percentile05 = Get-SeriesPercentileValue -SortedValues $orderedValues -Percentile 5
+    $percentile95 = Get-SeriesPercentileValue -SortedValues $orderedValues -Percentile 95
+
+    return [PSCustomObject]@{
+        count = $orderedValues.Count
+        min = [math]::Round(($orderedValues | Measure-Object -Minimum).Minimum, 2)
+        max = [math]::Round(($orderedValues | Measure-Object -Maximum).Maximum, 2)
+        average = [math]::Round($average, 2)
+        median = $median
+        standard_deviation = [math]::Round([math]::Sqrt($variance), 2)
+        percentile_05 = $percentile05
+        percentile_95 = $percentile95
+        spread_90 = if ($null -ne $percentile05 -and $null -ne $percentile95) { [math]::Round(($percentile95 - $percentile05), 2) } else { $null }
+    }
+}
+
+function Get-MarkdownStatisticLine {
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Label,
+
+        [Parameter(Mandatory = $false)]
+        [AllowNull()]
+        $Summary
+    )
+
+    if ($null -eq $Summary) {
+        return ('- {0}: n/a' -f $Label)
+    }
+
+    return ('- {0}: min `{1:N2}s`, p05-p95 `{2:N2}s`-`{3:N2}s`, median `{4:N2}s`, avg `{5:N2}s`, max `{6:N2}s`, stdev `{7:N2}s`' -f $Label, [double]$Summary.min, [double]$Summary.percentile_05, [double]$Summary.percentile_95, [double]$Summary.median, [double]$Summary.average, [double]$Summary.max, [double]$Summary.standard_deviation)
+}
+
+function Get-BenchmarkMetricSeriesValueList {
+    [CmdletBinding()]
+    [OutputType([double[]])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [AllowEmptyCollection()]
+        [object[]]$RunResults,
+
+        [Parameter(Mandatory = $true)]
+        [scriptblock]$Selector
+    )
+
+    $values = [System.Collections.Generic.List[double]]::new()
+    foreach ($runResult in $RunResults) {
+        $value = & $Selector $runResult
+        if ($null -eq $value) {
+            continue
+        }
+
+        $parsedValue = 0.0
+        if ([double]::TryParse([string]$value, [ref]$parsedValue)) {
+            $values.Add($parsedValue) | Out-Null
+        }
+    }
+
+    return @($values)
+}
+
+function Get-BenchmarkSeriesMetricSummary {
+    [CmdletBinding()]
+    [OutputType([pscustomobject])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [AllowEmptyCollection()]
+        [object[]]$RunResults,
+
+        [Parameter(Mandatory = $true)]
+        [bool]$LocalOnly,
+
+        [Parameter(Mandatory = $true)]
+        [bool]$IncludePersistentLocalWorkflow
+    )
+
+    return [PSCustomObject]@{
+        local_elapsed_seconds = Get-NumericSeriesSummary -Values (Get-BenchmarkMetricSeriesValueList -RunResults $RunResults -Selector {
+            param($result)
+            [double]$result.current.local.elapsed_seconds
+        })
+        runbook_elapsed_seconds = if ($LocalOnly) { $null } else { Get-NumericSeriesSummary -Values (Get-BenchmarkMetricSeriesValueList -RunResults $RunResults -Selector {
+            param($result)
+            if ($null -ne $result.current.runbook) {
+                [double]$result.current.runbook.elapsed_seconds
+            }
+        }) }
+        function_active_elapsed_seconds = if ($LocalOnly) { $null } else { Get-NumericSeriesSummary -Values (Get-BenchmarkMetricSeriesValueList -RunResults $RunResults -Selector {
+            param($result)
+            if ($null -ne $result.current.function_app -and $null -ne $result.current.function_app.active_elapsed_seconds) {
+                [double]$result.current.function_app.active_elapsed_seconds
+            }
+        }) }
+        function_end_to_end_elapsed_seconds = if ($LocalOnly) { $null } else { Get-NumericSeriesSummary -Values (Get-BenchmarkMetricSeriesValueList -RunResults $RunResults -Selector {
+            param($result)
+            if ($null -ne $result.current.function_app) {
+                [double]$result.current.function_app.end_to_end_elapsed_seconds
+            }
+        }) }
+        function_pickup_delay_seconds = if ($LocalOnly) { $null } else { Get-NumericSeriesSummary -Values (Get-BenchmarkMetricSeriesValueList -RunResults $RunResults -Selector {
+            param($result)
+            if ($null -ne $result.current.function_app -and $null -ne $result.current.function_app.pickup_delay_seconds) {
+                [double]$result.current.function_app.pickup_delay_seconds
+            }
+        }) }
+        persistent_reuse_elapsed_seconds = if ($IncludePersistentLocalWorkflow) { Get-NumericSeriesSummary -Values (Get-BenchmarkMetricSeriesValueList -RunResults $RunResults -Selector {
+            param($result)
+            if ($null -ne $result.current.local_persistent_cache -and $null -ne $result.current.local_persistent_cache.reuse_after_payload_eviction) {
+                [double]$result.current.local_persistent_cache.reuse_after_payload_eviction.elapsed_seconds
+            }
+        }) } else { $null }
+    }
+}
+
+function Write-BenchmarkSeriesSummaryOutput {
+    [CmdletBinding()]
+    [OutputType([pscustomobject])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$ResultsRoot,
+
+        [Parameter(Mandatory = $true)]
+        $Summary
+    )
+
+    $resolvedResultsRoot = [System.IO.Path]::GetFullPath($ResultsRoot)
+    $summaryPath = Join-Path $resolvedResultsRoot 'series-summary.json'
+    $summary | ConvertTo-Json -Depth 20 | Set-Content -LiteralPath $summaryPath -Encoding utf8
+
+    $summaryLines = [System.Collections.Generic.List[string]]::new()
+    $summaryLines.Add('# Benchmark Series Summary') | Out-Null
+    $summaryLines.Add('') | Out-Null
+
+    $benchmarkModeProperty = $Summary.PSObject.Properties['benchmark_mode']
+    if ($null -ne $benchmarkModeProperty -and -not [string]::IsNullOrWhiteSpace([string]$benchmarkModeProperty.Value)) {
+        $summaryLines.Add(('- Benchmark mode: `{0}`' -f [string]$benchmarkModeProperty.Value)) | Out-Null
+    }
+
+    $baselineProperty = $Summary.PSObject.Properties['current_baseline_name']
+    if ($null -ne $baselineProperty -and -not [string]::IsNullOrWhiteSpace([string]$baselineProperty.Value)) {
+        $summaryLines.Add(('- Baseline: `{0}`' -f [string]$baselineProperty.Value)) | Out-Null
+    }
+
+    $datasetIdProperty = $Summary.PSObject.Properties['benchmark_dataset_id']
+    if ($null -ne $datasetIdProperty -and -not [string]::IsNullOrWhiteSpace([string]$datasetIdProperty.Value)) {
+        $summaryLines.Add(('- Dataset: `{0}`' -f [string]$datasetIdProperty.Value)) | Out-Null
+    }
+
+    $datasetPathProperty = $Summary.PSObject.Properties['benchmark_dataset_path']
+    if ($null -ne $datasetPathProperty -and -not [string]::IsNullOrWhiteSpace([string]$datasetPathProperty.Value)) {
+        $summaryLines.Add(('- Dataset path: `{0}`' -f [string]$datasetPathProperty.Value)) | Out-Null
+    }
+
+    $summaryLines.Add(('- Iterations: `{0}`' -f [int]$Summary.iteration_count)) | Out-Null
+    $summaryLines.Add(('- Results root: `{0}`' -f $resolvedResultsRoot)) | Out-Null
+    $summaryLines.Add('') | Out-Null
+    $summaryLines.Add((Get-MarkdownStatisticLine -Label 'Local elapsed' -Summary $Summary.local_elapsed_seconds)) | Out-Null
+
+    $localOnly = [bool]$Summary.local_only
+    if (-not $localOnly) {
+        $summaryLines.Add((Get-MarkdownStatisticLine -Label 'Runbook elapsed' -Summary $Summary.runbook_elapsed_seconds)) | Out-Null
+        $summaryLines.Add((Get-MarkdownStatisticLine -Label 'Function active elapsed' -Summary $Summary.function_active_elapsed_seconds)) | Out-Null
+        $summaryLines.Add((Get-MarkdownStatisticLine -Label 'Function end-to-end elapsed' -Summary $Summary.function_end_to_end_elapsed_seconds)) | Out-Null
+        $summaryLines.Add((Get-MarkdownStatisticLine -Label 'Function pickup delay' -Summary $Summary.function_pickup_delay_seconds)) | Out-Null
+    }
+
+    if ([bool]$Summary.persistent_local_workflow) {
+        $summaryLines.Add((Get-MarkdownStatisticLine -Label 'Persistent local reuse elapsed' -Summary $Summary.persistent_reuse_elapsed_seconds)) | Out-Null
+    }
+
+    $summaryMarkdownPath = Join-Path $resolvedResultsRoot 'series-summary.md'
+    [System.IO.File]::WriteAllLines($summaryMarkdownPath, $summaryLines, [System.Text.UTF8Encoding]::new($false))
+
+    return [PSCustomObject]@{
+        SummaryPath = $summaryPath
+        SummaryMarkdownPath = $summaryMarkdownPath
+    }
+}


### PR DESCRIPTION
## Summary
- optimize machine history initialization and dashboard normalization hot paths
- add regression coverage for machine-store initialization, CVE lookup reuse, inventory lookup short-circuiting, and scalar path lookup inputs
- fix PowerShell ScriptAnalyzer warnings in test helpers so the validation workflow stays green
- leave `azure/Invoke-DashboardPipeline.ps1` out of the branch because CI rebuilds it for validation and the `Sync Azure Runbook` workflow regenerates it on `main`

## Validation
- ran `pwsh -NoProfile -File .\build\Invoke-RegressionValidation.ps1`
- reran the repo ScriptAnalyzer scope with `build\PSScriptAnalyzerSettings.psd1`
- completed Azure runbook-only comparison against `main` on the benchmark-medium-v1 dataset with no repeatable memory regression signal
