### PR TITLE
Harden MDE vulnerability export retry and staging

### DIFF
--- a/azure/Invoke-DashboardPipeline.ps1
+++ b/azure/Invoke-DashboardPipeline.ps1
@@ -6880,7 +6880,7 @@ function Invoke-MdeBulkVulnerabilitySnapshotDownload {
         try {
             Invoke-WebRequestWithRetry -Uri $fileUrl -OutFile $stagingOutputFile -MaxRetries 6 -InitialDelayMs 2000 -TimeoutSec 1800 -RetryTransientTransportFailures
 
-            $stagingFile = Get-Item -LiteralPath $stagingOutputFile -ErrorAction Stop
+            $stagingFile = Get-Item -LiteralPath $stagingOutputFile -Force -ErrorAction Stop
             if ($stagingFile.Length -le 0) {
                 throw "Downloaded file is empty: $(Get-SanitizedUriForLog -Uri $fileUrl)"
             }

--- a/azure/Invoke-DashboardPipeline.ps1
+++ b/azure/Invoke-DashboardPipeline.ps1
@@ -563,6 +563,17 @@ function Get-HttpHeaderStringValue {
     return ''
 }
 
+function ConvertTo-BoundedRetryDelayMillisecondsValue {
+    [CmdletBinding()]
+    [OutputType([int])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [long]$DelayMilliseconds
+    )
+
+    return [int][Math]::Min([long][int]::MaxValue, [Math]::Max(0L, $DelayMilliseconds))
+}
+
 function Get-HttpRetryDelayOverride {
     [CmdletBinding()]
     [OutputType([Nullable[int]])]
@@ -576,9 +587,9 @@ function Get-HttpRetryDelayOverride {
 
     $retryAfterSecondsText = Get-HttpHeaderStringValue -Headers $Headers -Names @('Retry-After')
     if (-not [string]::IsNullOrWhiteSpace($retryAfterSecondsText)) {
-        $retryAfterSeconds = 0
-        if ([int]::TryParse($retryAfterSecondsText, [ref]$retryAfterSeconds) -and $retryAfterSeconds -ge 0) {
-            return [Math]::Max(0, $retryAfterSeconds * 1000)
+        $retryAfterSeconds = 0L
+        if ([long]::TryParse($retryAfterSecondsText, [ref]$retryAfterSeconds) -and $retryAfterSeconds -ge 0) {
+            return (ConvertTo-BoundedRetryDelayMillisecondsValue -DelayMilliseconds ($retryAfterSeconds * 1000L))
         }
 
         $retryAfterTimestamp = [datetimeoffset]::MinValue
@@ -591,16 +602,16 @@ function Get-HttpRetryDelayOverride {
                 [ref]$retryAfterTimestamp
             )
         ) {
-            $delayMilliseconds = [int][Math]::Ceiling(($retryAfterTimestamp.ToUniversalTime() - $ReferenceTime.ToUniversalTime()).TotalMilliseconds)
-            return [Math]::Max(0, $delayMilliseconds)
+            $delayMilliseconds = [long][Math]::Ceiling(($retryAfterTimestamp.ToUniversalTime() - $ReferenceTime.ToUniversalTime()).TotalMilliseconds)
+            return (ConvertTo-BoundedRetryDelayMillisecondsValue -DelayMilliseconds $delayMilliseconds)
         }
     }
 
     $retryAfterMillisecondsText = Get-HttpHeaderStringValue -Headers $Headers -Names @('retry-after-ms', 'x-ms-retry-after-ms')
     if (-not [string]::IsNullOrWhiteSpace($retryAfterMillisecondsText)) {
-        $retryAfterMilliseconds = 0
-        if ([int]::TryParse($retryAfterMillisecondsText, [ref]$retryAfterMilliseconds) -and $retryAfterMilliseconds -ge 0) {
-            return $retryAfterMilliseconds
+        $retryAfterMilliseconds = 0L
+        if ([long]::TryParse($retryAfterMillisecondsText, [ref]$retryAfterMilliseconds) -and $retryAfterMilliseconds -ge 0) {
+            return (ConvertTo-BoundedRetryDelayMillisecondsValue -DelayMilliseconds $retryAfterMilliseconds)
         }
     }
 

--- a/azure/Invoke-DashboardPipeline.ps1
+++ b/azure/Invoke-DashboardPipeline.ps1
@@ -487,7 +487,6 @@ function Invoke-BoundedRunspacePool {
                     AsyncResult = $powershell.BeginInvoke()
                 })
         }
-
         $parallelResults = [System.Collections.Generic.List[object]]::new()
         foreach ($pendingInvocation in $pendingInvocations) {
             try {
@@ -509,6 +508,157 @@ function Invoke-BoundedRunspacePool {
         $runspacePool.Close()
         $runspacePool.Dispose()
     }
+}
+
+function Get-HttpHeaderStringValue {
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory = $false)]
+        $Headers,
+
+        [Parameter(Mandatory = $true)]
+        [string[]]$Names
+    )
+
+    if ($null -eq $Headers) {
+        return ''
+    }
+
+    $headerEntries = @()
+    try {
+        $headerEntries = @($Headers.GetEnumerator())
+    }
+    catch {
+        $headerEntries = @()
+    }
+
+    foreach ($name in $Names) {
+        foreach ($entry in $headerEntries) {
+            if (-not [string]::Equals([string]$entry.Key, $name, [System.StringComparison]::OrdinalIgnoreCase)) {
+                continue
+            }
+
+            foreach ($value in @($entry.Value)) {
+                $text = [string]$value
+                if (-not [string]::IsNullOrWhiteSpace($text)) {
+                    return $text
+                }
+            }
+        }
+
+        try {
+            foreach ($value in @($Headers[$name])) {
+                $text = [string]$value
+                if (-not [string]::IsNullOrWhiteSpace($text)) {
+                    return $text
+                }
+            }
+        }
+        catch {
+            Write-Verbose "Could not read HTTP header '$name': $_"
+        }
+    }
+
+    return ''
+}
+
+function Get-HttpRetryDelayOverride {
+    [CmdletBinding()]
+    [OutputType([Nullable[int]])]
+    param(
+        [Parameter(Mandatory = $false)]
+        $Headers,
+
+        [Parameter(Mandatory = $false)]
+        [datetimeoffset]$ReferenceTime = [datetimeoffset]::UtcNow
+    )
+
+    $retryAfterSecondsText = Get-HttpHeaderStringValue -Headers $Headers -Names @('Retry-After')
+    if (-not [string]::IsNullOrWhiteSpace($retryAfterSecondsText)) {
+        $retryAfterSeconds = 0
+        if ([int]::TryParse($retryAfterSecondsText, [ref]$retryAfterSeconds) -and $retryAfterSeconds -ge 0) {
+            return [Math]::Max(0, $retryAfterSeconds * 1000)
+        }
+
+        $retryAfterTimestamp = [datetimeoffset]::MinValue
+        if (
+            [datetimeoffset]::TryParseExact(
+                $retryAfterSecondsText,
+                'r',
+                [System.Globalization.CultureInfo]::InvariantCulture,
+                [System.Globalization.DateTimeStyles]::AssumeUniversal,
+                [ref]$retryAfterTimestamp
+            )
+        ) {
+            $delayMilliseconds = [int][Math]::Ceiling(($retryAfterTimestamp.ToUniversalTime() - $ReferenceTime.ToUniversalTime()).TotalMilliseconds)
+            return [Math]::Max(0, $delayMilliseconds)
+        }
+    }
+
+    $retryAfterMillisecondsText = Get-HttpHeaderStringValue -Headers $Headers -Names @('retry-after-ms', 'x-ms-retry-after-ms')
+    if (-not [string]::IsNullOrWhiteSpace($retryAfterMillisecondsText)) {
+        $retryAfterMilliseconds = 0
+        if ([int]::TryParse($retryAfterMillisecondsText, [ref]$retryAfterMilliseconds) -and $retryAfterMilliseconds -ge 0) {
+            return $retryAfterMilliseconds
+        }
+    }
+
+    return $null
+}
+
+function Get-SanitizedUriForLog {
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory = $false)]
+        [AllowEmptyString()]
+        [string]$Uri
+    )
+
+    if ([string]::IsNullOrWhiteSpace($Uri)) {
+        return ''
+    }
+
+    $absoluteUri = $null
+    if ([System.Uri]::TryCreate($Uri, [System.UriKind]::Absolute, [ref]$absoluteUri)) {
+        if ($absoluteUri.IsFile) {
+            return $absoluteUri.LocalPath
+        }
+
+        return $absoluteUri.GetLeftPart([System.UriPartial]::Path)
+    }
+
+    return $Uri
+}
+
+function Test-IsTransientTransportException {
+    [CmdletBinding()]
+    [OutputType([bool])]
+    param(
+        [Parameter(Mandatory = $false)]
+        [System.Exception]$Exception
+    )
+
+    if ($null -eq $Exception) {
+        return $false
+    }
+
+    if ($Exception -is [System.TimeoutException] -or $Exception.InnerException -is [System.TimeoutException]) {
+        return $true
+    }
+
+    $messageText = @(
+        [string]$Exception.Message
+        [string]$Exception.InnerException?.Message
+    ) -join "`n"
+
+    $transientPattern = 'ResponseEnded|response ended prematurely|An error occurred while sending the request|The underlying connection was closed|The request was canceled|timed out|A connection attempt failed|An existing connection was forcibly closed|connection reset|temporarily unavailable'
+    if ($Exception -is [System.Net.Http.HttpRequestException]) {
+        return ($messageText -match $transientPattern)
+    }
+
+    return ($messageText -match $transientPattern)
 }
 
 function Invoke-RestMethodWithRetry {
@@ -540,11 +690,15 @@ function Invoke-RestMethodWithRetry {
 
         [Parameter(Mandatory = $false)]
         [ValidateRange(1, 3600)]
-        [int]$TimeoutSec
+        [int]$TimeoutSec,
+
+        [Parameter(Mandatory = $false)]
+        [switch]$RetryTransientTransportFailures
     )
 
     $attempt = 0
     $delay = $InitialDelayMs
+    $requestUriForLog = Get-SanitizedUriForLog -Uri $Uri
 
     while ($true) {
         try {
@@ -566,30 +720,36 @@ function Invoke-RestMethodWithRetry {
                 $statusCode = [int]$_.Exception.Response.StatusCode
             }
 
-            $retryable = $statusCode -in @(429, 500, 502, 503, 504)
+            $retryable = $statusCode -in @(408, 429, 500, 502, 503, 504)
+            if (-not $retryable -and $RetryTransientTransportFailures) {
+                $retryable = Test-IsTransientTransportException -Exception $_.Exception
+            }
+
             if (-not $retryable -or $attempt -ge $MaxRetries) {
                 throw
             }
 
-            # Respect Retry-After header for 429 responses
-            $retryAfter = $null
+            $waitMs = $delay
             try {
                 if ($_.Exception.Response -and $_.Exception.Response.Headers) {
-                    $retryAfter = $_.Exception.Response.Headers['Retry-After']
+                    $retryDelayMilliseconds = Get-HttpRetryDelayOverride -Headers $_.Exception.Response.Headers
+                    if ($null -ne $retryDelayMilliseconds) {
+                        $waitMs = $retryDelayMilliseconds
+                    }
                 }
             }
             catch {
-                Write-Verbose "Could not read Retry-After header: $_"
+                Write-Verbose "Could not read retry delay headers: $_"
             }
 
-            $waitMs = if ($retryAfter -and [int]::TryParse($retryAfter, [ref]$null)) {
-                [int]$retryAfter * 1000
+            $failureLabel = if ($null -ne $statusCode) {
+                "HTTP $statusCode"
             }
             else {
-                $delay
+                $_.Exception.GetType().Name
             }
 
-            Write-Warning "API call failed (attempt $attempt/$MaxRetries, HTTP $statusCode): $($_.Exception.Message). Retrying in $([math]::Round($waitMs / 1000, 1))s..."
+            Write-Warning ("API call failed for {0} (attempt {1}/{2}, {3}). Retrying in {4}s..." -f $requestUriForLog, $attempt, $MaxRetries, $failureLabel, [math]::Round($waitMs / 1000, 1))
             Start-Sleep -Milliseconds $waitMs
             $delay = [int]($delay * $BackoffMultiplier)
         }
@@ -628,7 +788,10 @@ function Invoke-WebRequestWithRetry {
 
         [Parameter(Mandatory = $false)]
         [ValidateRange(1, 3600)]
-        [int]$TimeoutSec
+        [int]$TimeoutSec,
+
+        [Parameter(Mandatory = $false)]
+        [switch]$RetryTransientTransportFailures
     )
 
     $attempt = 0
@@ -639,6 +802,7 @@ function Invoke-WebRequestWithRetry {
     else {
         'HTTP request'
     }
+    $requestUriForLog = Get-SanitizedUriForLog -Uri $Uri
 
     while ($true) {
         try {
@@ -661,29 +825,36 @@ function Invoke-WebRequestWithRetry {
                 $statusCode = [int]$_.Exception.Response.StatusCode
             }
 
-            $retryable = $statusCode -in @(429, 500, 502, 503, 504)
+            $retryable = $statusCode -in @(408, 429, 500, 502, 503, 504)
+            if (-not $retryable -and $RetryTransientTransportFailures) {
+                $retryable = Test-IsTransientTransportException -Exception $_.Exception
+            }
+
             if (-not $retryable -or $attempt -ge $MaxRetries) {
                 throw
             }
 
-            $retryAfter = $null
+            $waitMs = $delay
             try {
                 if ($_.Exception.Response -and $_.Exception.Response.Headers) {
-                    $retryAfter = $_.Exception.Response.Headers['Retry-After']
+                    $retryDelayMilliseconds = Get-HttpRetryDelayOverride -Headers $_.Exception.Response.Headers
+                    if ($null -ne $retryDelayMilliseconds) {
+                        $waitMs = $retryDelayMilliseconds
+                    }
                 }
             }
             catch {
-                Write-Verbose "Could not read Retry-After header: $_"
+                Write-Verbose "Could not read retry delay headers: $_"
             }
 
-            $waitMs = if ($retryAfter -and [int]::TryParse($retryAfter, [ref]$null)) {
-                [int]$retryAfter * 1000
+            $failureLabel = if ($null -ne $statusCode) {
+                "HTTP $statusCode"
             }
             else {
-                $delay
+                $_.Exception.GetType().Name
             }
 
-            Write-Warning "$requestLabel failed (attempt $attempt/$MaxRetries, HTTP $statusCode): $($_.Exception.Message). Retrying in $([math]::Round($waitMs / 1000, 1))s..."
+            Write-Warning ("{0} failed for {1} (attempt {2}/{3}, {4}). Retrying in {5}s..." -f $requestLabel, $requestUriForLog, $attempt, $MaxRetries, $failureLabel, [math]::Round($waitMs / 1000, 1))
             Start-Sleep -Milliseconds $waitMs
             $delay = [int]($delay * $BackoffMultiplier)
         }
@@ -1572,6 +1743,7 @@ function Test-IsTransientExportArtifactName {
     return (
         ($normalizedName -like '.dashboard-cache/*') -or
         ($normalizedName -match '(^|/)\.vuln-content-store-staging-[^/]+(?:/|$)') -or
+        ($normalizedName -match '(^|/)\.VulnExport_\d+_\d{4}-\d{2}-\d{2}(?:_part_\d+)?\.json(?:\.gz)?\.partial$') -or
         ($normalizedName -in @(
             '.synthetic-progress.json',
             '.synthetic-progress.json.gz',
@@ -1722,7 +1894,7 @@ function Test-IsLegacyVulnSnapshotFileName {
         [string]$Name
     )
 
-    return ($Name -match '^VulnExport_\d+_\d{4}-\d{2}-\d{2}\.json(?:\.gz)?$')
+    return ($Name -match '^VulnExport_\d+_\d{4}-\d{2}-\d{2}(?:_part_\d+)?\.json(?:\.gz)?$')
 }
 
 function Get-VulnSnapshotDateFromName {
@@ -6594,6 +6766,67 @@ function Get-MdeHeaderCollection {
     }
 }
 
+function Resolve-UriQueryParameterValue {
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Uri,
+
+        [Parameter(Mandatory = $true)]
+        [string]$Name,
+
+        [Parameter(Mandatory = $true)]
+        [string]$Value
+    )
+
+    $absoluteUri = $null
+    if (-not [System.Uri]::TryCreate($Uri, [System.UriKind]::Absolute, [ref]$absoluteUri)) {
+        return $Uri
+    }
+
+    $uriBuilder = [System.UriBuilder]::new($absoluteUri)
+    $queryEntries = [System.Collections.Generic.List[string]]::new()
+    foreach ($queryEntry in @($uriBuilder.Query.TrimStart('?').Split('&', [System.StringSplitOptions]::RemoveEmptyEntries))) {
+        $key = [System.Uri]::UnescapeDataString(($queryEntry.Split('=', 2))[0])
+        if ($key -ieq $Name) {
+            continue
+        }
+
+        $queryEntries.Add($queryEntry)
+    }
+
+    $queryEntries.Add(("{0}={1}" -f [System.Uri]::EscapeDataString($Name), [System.Uri]::EscapeDataString($Value)))
+    $uriBuilder.Query = [string]::Join('&', $queryEntries)
+    return $uriBuilder.Uri.AbsoluteUri
+}
+
+function Get-MdeBulkVulnerabilityExportRequestUri {
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$ExportUrl,
+
+        [Parameter(Mandatory = $false)]
+        [ValidateRange(1, 6)]
+        [int]$SasValidHours = 6
+    )
+
+    return (Resolve-UriQueryParameterValue -Uri $ExportUrl -Name 'sasValidHours' -Value ([string]$SasValidHours))
+}
+
+function Get-VulnSnapshotStagingPath {
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$OutputFile
+    )
+
+    return (Join-Path -Path (Split-Path -Path $OutputFile -Parent) -ChildPath ('.' + (Split-Path -Path $OutputFile -Leaf) + '.partial'))
+}
+
 function Invoke-MdeBulkVulnerabilitySnapshotDownload {
     [CmdletBinding()]
     param(
@@ -6607,13 +6840,15 @@ function Invoke-MdeBulkVulnerabilitySnapshotDownload {
         [string]$ExportUrl
     )
 
-    $response = Invoke-RestMethodWithRetry -Uri $ExportUrl -Headers $Headers -Method Get
+    $resolvedExportUrl = Get-MdeBulkVulnerabilityExportRequestUri -ExportUrl $ExportUrl
+    $response = Invoke-RestMethodWithRetry -Uri $resolvedExportUrl -Headers $Headers -Method Get -MaxRetries 4 -InitialDelayMs 5000 -TimeoutSec 600 -RetryTransientTransportFailures
     $exportFiles = @($response.exportFiles)
     if ($exportFiles.Count -eq 0) {
         throw 'Bulk vulnerability export returned no files.'
     }
 
     $downloadedFiles = [System.Collections.Generic.List[string]]::new()
+    $partIndexBySnapshotKey = @{}
     foreach ($fileUrl in $exportFiles) {
         if ($fileUrl -match '/collection/([^/?]+)/.*%3DgroupId%3D([^&%? ]+)') {
             $date = $Matches[1]
@@ -6624,11 +6859,46 @@ function Invoke-MdeBulkVulnerabilitySnapshotDownload {
             $groupId = [System.Uri]::UnescapeDataString($Matches[2])
         }
         else {
-            throw "Unexpected export URL format. Cannot extract date and groupId from: $fileUrl"
+            throw "Unexpected export URL format. Cannot extract date and groupId from: $(Get-SanitizedUriForLog -Uri $fileUrl)"
         }
 
-        $outputFile = Join-Path $OutputPath "VulnExport_${groupId}_${date}.json.gz"
-        Invoke-WebRequestWithRetry -Uri $fileUrl -OutFile $outputFile
+        $snapshotKey = "${groupId}|${date}"
+        $partIndex = if ($partIndexBySnapshotKey.ContainsKey($snapshotKey)) {
+            [int]$partIndexBySnapshotKey[$snapshotKey]
+        }
+        else {
+            0
+        }
+        $partIndexBySnapshotKey[$snapshotKey] = ($partIndex + 1)
+
+        $outputFile = Join-Path $OutputPath ("VulnExport_{0}_{1}_part_{2}.json.gz" -f $groupId, $date, $partIndex)
+        $stagingOutputFile = Get-VulnSnapshotStagingPath -OutputFile $outputFile
+        if (Test-Path -LiteralPath $stagingOutputFile -PathType Leaf) {
+            Remove-Item -LiteralPath $stagingOutputFile -Force -ErrorAction SilentlyContinue
+        }
+
+        try {
+            Invoke-WebRequestWithRetry -Uri $fileUrl -OutFile $stagingOutputFile -MaxRetries 6 -InitialDelayMs 2000 -TimeoutSec 1800 -RetryTransientTransportFailures
+
+            $stagingFile = Get-Item -LiteralPath $stagingOutputFile -ErrorAction Stop
+            if ($stagingFile.Length -le 0) {
+                throw "Downloaded file is empty: $(Get-SanitizedUriForLog -Uri $fileUrl)"
+            }
+
+            if (Test-Path -LiteralPath $outputFile -PathType Leaf) {
+                Remove-Item -LiteralPath $outputFile -Force -ErrorAction SilentlyContinue
+            }
+
+            [System.IO.File]::Move($stagingOutputFile, $outputFile)
+        }
+        catch {
+            if (Test-Path -LiteralPath $stagingOutputFile -PathType Leaf) {
+                Remove-Item -LiteralPath $stagingOutputFile -Force -ErrorAction SilentlyContinue
+            }
+
+            throw
+        }
+
         $downloadedFiles.Add($outputFile)
     }
 

--- a/src/powershell/Shared/Core/Core.ps1
+++ b/src/powershell/Shared/Core/Core.ps1
@@ -292,7 +292,6 @@ function Invoke-BoundedRunspacePool {
                     AsyncResult = $powershell.BeginInvoke()
                 })
         }
-
         $parallelResults = [System.Collections.Generic.List[object]]::new()
         foreach ($pendingInvocation in $pendingInvocations) {
             try {
@@ -314,6 +313,157 @@ function Invoke-BoundedRunspacePool {
         $runspacePool.Close()
         $runspacePool.Dispose()
     }
+}
+
+function Get-HttpHeaderStringValue {
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory = $false)]
+        $Headers,
+
+        [Parameter(Mandatory = $true)]
+        [string[]]$Names
+    )
+
+    if ($null -eq $Headers) {
+        return ''
+    }
+
+    $headerEntries = @()
+    try {
+        $headerEntries = @($Headers.GetEnumerator())
+    }
+    catch {
+        $headerEntries = @()
+    }
+
+    foreach ($name in $Names) {
+        foreach ($entry in $headerEntries) {
+            if (-not [string]::Equals([string]$entry.Key, $name, [System.StringComparison]::OrdinalIgnoreCase)) {
+                continue
+            }
+
+            foreach ($value in @($entry.Value)) {
+                $text = [string]$value
+                if (-not [string]::IsNullOrWhiteSpace($text)) {
+                    return $text
+                }
+            }
+        }
+
+        try {
+            foreach ($value in @($Headers[$name])) {
+                $text = [string]$value
+                if (-not [string]::IsNullOrWhiteSpace($text)) {
+                    return $text
+                }
+            }
+        }
+        catch {
+            Write-Verbose "Could not read HTTP header '$name': $_"
+        }
+    }
+
+    return ''
+}
+
+function Get-HttpRetryDelayOverride {
+    [CmdletBinding()]
+    [OutputType([Nullable[int]])]
+    param(
+        [Parameter(Mandatory = $false)]
+        $Headers,
+
+        [Parameter(Mandatory = $false)]
+        [datetimeoffset]$ReferenceTime = [datetimeoffset]::UtcNow
+    )
+
+    $retryAfterSecondsText = Get-HttpHeaderStringValue -Headers $Headers -Names @('Retry-After')
+    if (-not [string]::IsNullOrWhiteSpace($retryAfterSecondsText)) {
+        $retryAfterSeconds = 0
+        if ([int]::TryParse($retryAfterSecondsText, [ref]$retryAfterSeconds) -and $retryAfterSeconds -ge 0) {
+            return [Math]::Max(0, $retryAfterSeconds * 1000)
+        }
+
+        $retryAfterTimestamp = [datetimeoffset]::MinValue
+        if (
+            [datetimeoffset]::TryParseExact(
+                $retryAfterSecondsText,
+                'r',
+                [System.Globalization.CultureInfo]::InvariantCulture,
+                [System.Globalization.DateTimeStyles]::AssumeUniversal,
+                [ref]$retryAfterTimestamp
+            )
+        ) {
+            $delayMilliseconds = [int][Math]::Ceiling(($retryAfterTimestamp.ToUniversalTime() - $ReferenceTime.ToUniversalTime()).TotalMilliseconds)
+            return [Math]::Max(0, $delayMilliseconds)
+        }
+    }
+
+    $retryAfterMillisecondsText = Get-HttpHeaderStringValue -Headers $Headers -Names @('retry-after-ms', 'x-ms-retry-after-ms')
+    if (-not [string]::IsNullOrWhiteSpace($retryAfterMillisecondsText)) {
+        $retryAfterMilliseconds = 0
+        if ([int]::TryParse($retryAfterMillisecondsText, [ref]$retryAfterMilliseconds) -and $retryAfterMilliseconds -ge 0) {
+            return $retryAfterMilliseconds
+        }
+    }
+
+    return $null
+}
+
+function Get-SanitizedUriForLog {
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory = $false)]
+        [AllowEmptyString()]
+        [string]$Uri
+    )
+
+    if ([string]::IsNullOrWhiteSpace($Uri)) {
+        return ''
+    }
+
+    $absoluteUri = $null
+    if ([System.Uri]::TryCreate($Uri, [System.UriKind]::Absolute, [ref]$absoluteUri)) {
+        if ($absoluteUri.IsFile) {
+            return $absoluteUri.LocalPath
+        }
+
+        return $absoluteUri.GetLeftPart([System.UriPartial]::Path)
+    }
+
+    return $Uri
+}
+
+function Test-IsTransientTransportException {
+    [CmdletBinding()]
+    [OutputType([bool])]
+    param(
+        [Parameter(Mandatory = $false)]
+        [System.Exception]$Exception
+    )
+
+    if ($null -eq $Exception) {
+        return $false
+    }
+
+    if ($Exception -is [System.TimeoutException] -or $Exception.InnerException -is [System.TimeoutException]) {
+        return $true
+    }
+
+    $messageText = @(
+        [string]$Exception.Message
+        [string]$Exception.InnerException?.Message
+    ) -join "`n"
+
+    $transientPattern = 'ResponseEnded|response ended prematurely|An error occurred while sending the request|The underlying connection was closed|The request was canceled|timed out|A connection attempt failed|An existing connection was forcibly closed|connection reset|temporarily unavailable'
+    if ($Exception -is [System.Net.Http.HttpRequestException]) {
+        return ($messageText -match $transientPattern)
+    }
+
+    return ($messageText -match $transientPattern)
 }
 
 function Invoke-RestMethodWithRetry {
@@ -345,11 +495,15 @@ function Invoke-RestMethodWithRetry {
 
         [Parameter(Mandatory = $false)]
         [ValidateRange(1, 3600)]
-        [int]$TimeoutSec
+        [int]$TimeoutSec,
+
+        [Parameter(Mandatory = $false)]
+        [switch]$RetryTransientTransportFailures
     )
 
     $attempt = 0
     $delay = $InitialDelayMs
+    $requestUriForLog = Get-SanitizedUriForLog -Uri $Uri
 
     while ($true) {
         try {
@@ -371,30 +525,36 @@ function Invoke-RestMethodWithRetry {
                 $statusCode = [int]$_.Exception.Response.StatusCode
             }
 
-            $retryable = $statusCode -in @(429, 500, 502, 503, 504)
+            $retryable = $statusCode -in @(408, 429, 500, 502, 503, 504)
+            if (-not $retryable -and $RetryTransientTransportFailures) {
+                $retryable = Test-IsTransientTransportException -Exception $_.Exception
+            }
+
             if (-not $retryable -or $attempt -ge $MaxRetries) {
                 throw
             }
 
-            # Respect Retry-After header for 429 responses
-            $retryAfter = $null
+            $waitMs = $delay
             try {
                 if ($_.Exception.Response -and $_.Exception.Response.Headers) {
-                    $retryAfter = $_.Exception.Response.Headers['Retry-After']
+                    $retryDelayMilliseconds = Get-HttpRetryDelayOverride -Headers $_.Exception.Response.Headers
+                    if ($null -ne $retryDelayMilliseconds) {
+                        $waitMs = $retryDelayMilliseconds
+                    }
                 }
             }
             catch {
-                Write-Verbose "Could not read Retry-After header: $_"
+                Write-Verbose "Could not read retry delay headers: $_"
             }
 
-            $waitMs = if ($retryAfter -and [int]::TryParse($retryAfter, [ref]$null)) {
-                [int]$retryAfter * 1000
+            $failureLabel = if ($null -ne $statusCode) {
+                "HTTP $statusCode"
             }
             else {
-                $delay
+                $_.Exception.GetType().Name
             }
 
-            Write-Warning "API call failed (attempt $attempt/$MaxRetries, HTTP $statusCode): $($_.Exception.Message). Retrying in $([math]::Round($waitMs / 1000, 1))s..."
+            Write-Warning ("API call failed for {0} (attempt {1}/{2}, {3}). Retrying in {4}s..." -f $requestUriForLog, $attempt, $MaxRetries, $failureLabel, [math]::Round($waitMs / 1000, 1))
             Start-Sleep -Milliseconds $waitMs
             $delay = [int]($delay * $BackoffMultiplier)
         }
@@ -433,7 +593,10 @@ function Invoke-WebRequestWithRetry {
 
         [Parameter(Mandatory = $false)]
         [ValidateRange(1, 3600)]
-        [int]$TimeoutSec
+        [int]$TimeoutSec,
+
+        [Parameter(Mandatory = $false)]
+        [switch]$RetryTransientTransportFailures
     )
 
     $attempt = 0
@@ -444,6 +607,7 @@ function Invoke-WebRequestWithRetry {
     else {
         'HTTP request'
     }
+    $requestUriForLog = Get-SanitizedUriForLog -Uri $Uri
 
     while ($true) {
         try {
@@ -466,29 +630,36 @@ function Invoke-WebRequestWithRetry {
                 $statusCode = [int]$_.Exception.Response.StatusCode
             }
 
-            $retryable = $statusCode -in @(429, 500, 502, 503, 504)
+            $retryable = $statusCode -in @(408, 429, 500, 502, 503, 504)
+            if (-not $retryable -and $RetryTransientTransportFailures) {
+                $retryable = Test-IsTransientTransportException -Exception $_.Exception
+            }
+
             if (-not $retryable -or $attempt -ge $MaxRetries) {
                 throw
             }
 
-            $retryAfter = $null
+            $waitMs = $delay
             try {
                 if ($_.Exception.Response -and $_.Exception.Response.Headers) {
-                    $retryAfter = $_.Exception.Response.Headers['Retry-After']
+                    $retryDelayMilliseconds = Get-HttpRetryDelayOverride -Headers $_.Exception.Response.Headers
+                    if ($null -ne $retryDelayMilliseconds) {
+                        $waitMs = $retryDelayMilliseconds
+                    }
                 }
             }
             catch {
-                Write-Verbose "Could not read Retry-After header: $_"
+                Write-Verbose "Could not read retry delay headers: $_"
             }
 
-            $waitMs = if ($retryAfter -and [int]::TryParse($retryAfter, [ref]$null)) {
-                [int]$retryAfter * 1000
+            $failureLabel = if ($null -ne $statusCode) {
+                "HTTP $statusCode"
             }
             else {
-                $delay
+                $_.Exception.GetType().Name
             }
 
-            Write-Warning "$requestLabel failed (attempt $attempt/$MaxRetries, HTTP $statusCode): $($_.Exception.Message). Retrying in $([math]::Round($waitMs / 1000, 1))s..."
+            Write-Warning ("{0} failed for {1} (attempt {2}/{3}, {4}). Retrying in {5}s..." -f $requestLabel, $requestUriForLog, $attempt, $MaxRetries, $failureLabel, [math]::Round($waitMs / 1000, 1))
             Start-Sleep -Milliseconds $waitMs
             $delay = [int]($delay * $BackoffMultiplier)
         }
@@ -1377,6 +1548,7 @@ function Test-IsTransientExportArtifactName {
     return (
         ($normalizedName -like '.dashboard-cache/*') -or
         ($normalizedName -match '(^|/)\.vuln-content-store-staging-[^/]+(?:/|$)') -or
+        ($normalizedName -match '(^|/)\.VulnExport_\d+_\d{4}-\d{2}-\d{2}(?:_part_\d+)?\.json(?:\.gz)?\.partial$') -or
         ($normalizedName -in @(
             '.synthetic-progress.json',
             '.synthetic-progress.json.gz',
@@ -1527,7 +1699,7 @@ function Test-IsLegacyVulnSnapshotFileName {
         [string]$Name
     )
 
-    return ($Name -match '^VulnExport_\d+_\d{4}-\d{2}-\d{2}\.json(?:\.gz)?$')
+    return ($Name -match '^VulnExport_\d+_\d{4}-\d{2}-\d{2}(?:_part_\d+)?\.json(?:\.gz)?$')
 }
 
 function Get-VulnSnapshotDateFromName {

--- a/src/powershell/Shared/Core/Core.ps1
+++ b/src/powershell/Shared/Core/Core.ps1
@@ -368,6 +368,17 @@ function Get-HttpHeaderStringValue {
     return ''
 }
 
+function ConvertTo-BoundedRetryDelayMillisecondsValue {
+    [CmdletBinding()]
+    [OutputType([int])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [long]$DelayMilliseconds
+    )
+
+    return [int][Math]::Min([long][int]::MaxValue, [Math]::Max(0L, $DelayMilliseconds))
+}
+
 function Get-HttpRetryDelayOverride {
     [CmdletBinding()]
     [OutputType([Nullable[int]])]
@@ -381,9 +392,9 @@ function Get-HttpRetryDelayOverride {
 
     $retryAfterSecondsText = Get-HttpHeaderStringValue -Headers $Headers -Names @('Retry-After')
     if (-not [string]::IsNullOrWhiteSpace($retryAfterSecondsText)) {
-        $retryAfterSeconds = 0
-        if ([int]::TryParse($retryAfterSecondsText, [ref]$retryAfterSeconds) -and $retryAfterSeconds -ge 0) {
-            return [Math]::Max(0, $retryAfterSeconds * 1000)
+        $retryAfterSeconds = 0L
+        if ([long]::TryParse($retryAfterSecondsText, [ref]$retryAfterSeconds) -and $retryAfterSeconds -ge 0) {
+            return (ConvertTo-BoundedRetryDelayMillisecondsValue -DelayMilliseconds ($retryAfterSeconds * 1000L))
         }
 
         $retryAfterTimestamp = [datetimeoffset]::MinValue
@@ -396,16 +407,16 @@ function Get-HttpRetryDelayOverride {
                 [ref]$retryAfterTimestamp
             )
         ) {
-            $delayMilliseconds = [int][Math]::Ceiling(($retryAfterTimestamp.ToUniversalTime() - $ReferenceTime.ToUniversalTime()).TotalMilliseconds)
-            return [Math]::Max(0, $delayMilliseconds)
+            $delayMilliseconds = [long][Math]::Ceiling(($retryAfterTimestamp.ToUniversalTime() - $ReferenceTime.ToUniversalTime()).TotalMilliseconds)
+            return (ConvertTo-BoundedRetryDelayMillisecondsValue -DelayMilliseconds $delayMilliseconds)
         }
     }
 
     $retryAfterMillisecondsText = Get-HttpHeaderStringValue -Headers $Headers -Names @('retry-after-ms', 'x-ms-retry-after-ms')
     if (-not [string]::IsNullOrWhiteSpace($retryAfterMillisecondsText)) {
-        $retryAfterMilliseconds = 0
-        if ([int]::TryParse($retryAfterMillisecondsText, [ref]$retryAfterMilliseconds) -and $retryAfterMilliseconds -ge 0) {
-            return $retryAfterMilliseconds
+        $retryAfterMilliseconds = 0L
+        if ([long]::TryParse($retryAfterMillisecondsText, [ref]$retryAfterMilliseconds) -and $retryAfterMilliseconds -ge 0) {
+            return (ConvertTo-BoundedRetryDelayMillisecondsValue -DelayMilliseconds $retryAfterMilliseconds)
         }
     }
 

--- a/src/powershell/Shared/DefenderApi/MdeExport.ps1
+++ b/src/powershell/Shared/DefenderApi/MdeExport.ps1
@@ -138,6 +138,67 @@ function Get-MdeHeaderCollection {
     }
 }
 
+function Resolve-UriQueryParameterValue {
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Uri,
+
+        [Parameter(Mandatory = $true)]
+        [string]$Name,
+
+        [Parameter(Mandatory = $true)]
+        [string]$Value
+    )
+
+    $absoluteUri = $null
+    if (-not [System.Uri]::TryCreate($Uri, [System.UriKind]::Absolute, [ref]$absoluteUri)) {
+        return $Uri
+    }
+
+    $uriBuilder = [System.UriBuilder]::new($absoluteUri)
+    $queryEntries = [System.Collections.Generic.List[string]]::new()
+    foreach ($queryEntry in @($uriBuilder.Query.TrimStart('?').Split('&', [System.StringSplitOptions]::RemoveEmptyEntries))) {
+        $key = [System.Uri]::UnescapeDataString(($queryEntry.Split('=', 2))[0])
+        if ($key -ieq $Name) {
+            continue
+        }
+
+        $queryEntries.Add($queryEntry)
+    }
+
+    $queryEntries.Add(("{0}={1}" -f [System.Uri]::EscapeDataString($Name), [System.Uri]::EscapeDataString($Value)))
+    $uriBuilder.Query = [string]::Join('&', $queryEntries)
+    return $uriBuilder.Uri.AbsoluteUri
+}
+
+function Get-MdeBulkVulnerabilityExportRequestUri {
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$ExportUrl,
+
+        [Parameter(Mandatory = $false)]
+        [ValidateRange(1, 6)]
+        [int]$SasValidHours = 6
+    )
+
+    return (Resolve-UriQueryParameterValue -Uri $ExportUrl -Name 'sasValidHours' -Value ([string]$SasValidHours))
+}
+
+function Get-VulnSnapshotStagingPath {
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$OutputFile
+    )
+
+    return (Join-Path -Path (Split-Path -Path $OutputFile -Parent) -ChildPath ('.' + (Split-Path -Path $OutputFile -Leaf) + '.partial'))
+}
+
 function Invoke-MdeBulkVulnerabilitySnapshotDownload {
     [CmdletBinding()]
     param(
@@ -151,13 +212,15 @@ function Invoke-MdeBulkVulnerabilitySnapshotDownload {
         [string]$ExportUrl
     )
 
-    $response = Invoke-RestMethodWithRetry -Uri $ExportUrl -Headers $Headers -Method Get
+    $resolvedExportUrl = Get-MdeBulkVulnerabilityExportRequestUri -ExportUrl $ExportUrl
+    $response = Invoke-RestMethodWithRetry -Uri $resolvedExportUrl -Headers $Headers -Method Get -MaxRetries 4 -InitialDelayMs 5000 -TimeoutSec 600 -RetryTransientTransportFailures
     $exportFiles = @($response.exportFiles)
     if ($exportFiles.Count -eq 0) {
         throw 'Bulk vulnerability export returned no files.'
     }
 
     $downloadedFiles = [System.Collections.Generic.List[string]]::new()
+    $partIndexBySnapshotKey = @{}
     foreach ($fileUrl in $exportFiles) {
         if ($fileUrl -match '/collection/([^/?]+)/.*%3DgroupId%3D([^&%? ]+)') {
             $date = $Matches[1]
@@ -168,11 +231,46 @@ function Invoke-MdeBulkVulnerabilitySnapshotDownload {
             $groupId = [System.Uri]::UnescapeDataString($Matches[2])
         }
         else {
-            throw "Unexpected export URL format. Cannot extract date and groupId from: $fileUrl"
+            throw "Unexpected export URL format. Cannot extract date and groupId from: $(Get-SanitizedUriForLog -Uri $fileUrl)"
         }
 
-        $outputFile = Join-Path $OutputPath "VulnExport_${groupId}_${date}.json.gz"
-        Invoke-WebRequestWithRetry -Uri $fileUrl -OutFile $outputFile
+        $snapshotKey = "${groupId}|${date}"
+        $partIndex = if ($partIndexBySnapshotKey.ContainsKey($snapshotKey)) {
+            [int]$partIndexBySnapshotKey[$snapshotKey]
+        }
+        else {
+            0
+        }
+        $partIndexBySnapshotKey[$snapshotKey] = ($partIndex + 1)
+
+        $outputFile = Join-Path $OutputPath ("VulnExport_{0}_{1}_part_{2}.json.gz" -f $groupId, $date, $partIndex)
+        $stagingOutputFile = Get-VulnSnapshotStagingPath -OutputFile $outputFile
+        if (Test-Path -LiteralPath $stagingOutputFile -PathType Leaf) {
+            Remove-Item -LiteralPath $stagingOutputFile -Force -ErrorAction SilentlyContinue
+        }
+
+        try {
+            Invoke-WebRequestWithRetry -Uri $fileUrl -OutFile $stagingOutputFile -MaxRetries 6 -InitialDelayMs 2000 -TimeoutSec 1800 -RetryTransientTransportFailures
+
+            $stagingFile = Get-Item -LiteralPath $stagingOutputFile -ErrorAction Stop
+            if ($stagingFile.Length -le 0) {
+                throw "Downloaded file is empty: $(Get-SanitizedUriForLog -Uri $fileUrl)"
+            }
+
+            if (Test-Path -LiteralPath $outputFile -PathType Leaf) {
+                Remove-Item -LiteralPath $outputFile -Force -ErrorAction SilentlyContinue
+            }
+
+            [System.IO.File]::Move($stagingOutputFile, $outputFile)
+        }
+        catch {
+            if (Test-Path -LiteralPath $stagingOutputFile -PathType Leaf) {
+                Remove-Item -LiteralPath $stagingOutputFile -Force -ErrorAction SilentlyContinue
+            }
+
+            throw
+        }
+
         $downloadedFiles.Add($outputFile)
     }
 

--- a/src/powershell/Shared/DefenderApi/MdeExport.ps1
+++ b/src/powershell/Shared/DefenderApi/MdeExport.ps1
@@ -252,7 +252,7 @@ function Invoke-MdeBulkVulnerabilitySnapshotDownload {
         try {
             Invoke-WebRequestWithRetry -Uri $fileUrl -OutFile $stagingOutputFile -MaxRetries 6 -InitialDelayMs 2000 -TimeoutSec 1800 -RetryTransientTransportFailures
 
-            $stagingFile = Get-Item -LiteralPath $stagingOutputFile -ErrorAction Stop
+            $stagingFile = Get-Item -LiteralPath $stagingOutputFile -Force -ErrorAction Stop
             if ($stagingFile.Length -le 0) {
                 throw "Downloaded file is empty: $(Get-SanitizedUriForLog -Uri $fileUrl)"
             }

--- a/tests/Run-SharedHelperRegression.ps1
+++ b/tests/Run-SharedHelperRegression.ps1
@@ -447,6 +447,8 @@ function Test-HttpRetryDelayHelperBehavior {
     Assert-True ((Get-HttpRetryDelayOverride -Headers @{ 'Retry-After' = '7' } -ReferenceTime $fixedNow) -eq 7000) 'Expected Retry-After integer seconds to convert to milliseconds.'
     Assert-True ((Get-HttpRetryDelayOverride -Headers @{ 'Retry-After' = $retryAfterDate } -ReferenceTime $fixedNow) -eq 9000) 'Expected Retry-After HTTP-date values to convert to milliseconds.'
     Assert-True ((Get-HttpRetryDelayOverride -Headers @{ 'x-ms-retry-after-ms' = '250' }) -eq 250) 'Expected retry-after-ms headers to convert directly to milliseconds.'
+    Assert-True ((Get-HttpRetryDelayOverride -Headers @{ 'Retry-After' = '2147484' } -ReferenceTime $fixedNow) -eq [int]::MaxValue) 'Expected oversized Retry-After second values to clamp to the maximum supported sleep interval.'
+    Assert-True ((Get-HttpRetryDelayOverride -Headers @{ 'x-ms-retry-after-ms' = '21474836470' }) -eq [int]::MaxValue) 'Expected oversized retry-after-ms header values to clamp to the maximum supported sleep interval.'
     Assert-True ($null -eq (Get-HttpRetryDelayOverride -Headers @{} -ReferenceTime $fixedNow)) 'Expected the retry delay helper to return no override when no retry headers are present.'
 }
 

--- a/tests/Run-SharedHelperRegression.ps1
+++ b/tests/Run-SharedHelperRegression.ps1
@@ -379,6 +379,388 @@ function Test-BulkSnapshotImportSingleSnapshot {
     }
 }
 
+function Test-BulkSnapshotImportMultipartSnapshot {
+    [CmdletBinding()]
+    param()
+
+    $tempRoot = Join-Path ([System.IO.Path]::GetTempPath()) ('bulk-snapshot-import-multipart-' + [guid]::NewGuid().ToString('N'))
+    [void](New-Item -Path $tempRoot -ItemType Directory -Force)
+
+    try {
+        @(
+            @{
+                Name = 'VulnExport_1_2026-01-01_part_0.json'
+                Rows = @(
+                    (Get-TestVulnRow -Id 'multipart-001' -CveId 'CVE-2026-1001' -SnapshotDate '2026-01-01' -Version '1.0.0')
+                )
+            }
+            @{
+                Name = 'VulnExport_1_2026-01-01_part_1.json'
+                Rows = @(
+                    (Get-TestVulnRow -Id 'multipart-002' -CveId 'CVE-2026-1002' -SnapshotDate '2026-01-01' -Version '1.0.0')
+                )
+            }
+            @{
+                Name = 'VulnExport_1_2026-01-02.json'
+                Rows = @(
+                    (Get-TestVulnRow -Id 'multipart-003' -CveId 'CVE-2026-1003' -SnapshotDate '2026-01-02' -Version '1.0.1')
+                )
+            }
+        ) | ForEach-Object {
+            $path = Join-Path $tempRoot $_.Name
+            $lines = @($_.Rows | ForEach-Object { $_ | ConvertTo-Json -Compress -Depth 8 })
+            [System.IO.File]::WriteAllLines($path, $lines, [System.Text.UTF8Encoding]::new($false))
+        }
+
+        Assert-True (Test-IsLegacyVulnSnapshotFileName -Name 'VulnExport_1_2026-01-01_part_0.json.gz') 'Expected multipart legacy snapshot names to be recognized.'
+        Assert-True (Test-IsLegacyVulnSnapshotFileName -Name 'VulnExport_1_2026-01-02.json.gz') 'Expected legacy single-part snapshot names to remain recognized.'
+
+        $publishResult = Publish-VulnStoreFromBulkSnapshot -BasePath $tempRoot -RemoveSnapshotFiles
+        $storeRows = @(Read-VulnStoreRow -BasePath $tempRoot)
+        $currentRows = @($storeRows | Where-Object { (Get-VulnPropertyValue -InputObject $_ -Name 'Id') -eq 'multipart-003' })
+        $historyRows = @($storeRows | Where-Object { (Get-VulnPropertyValue -InputObject $_ -Name 'Id') -in @('multipart-001', 'multipart-002') })
+
+        Assert-True ((Test-Path -LiteralPath (Get-VulnCurrentPath -BasePath $tempRoot) -PathType Leaf)) 'Canonical vuln current file was not materialized for multipart snapshots.'
+        Assert-True ((Test-Path -LiteralPath (Get-VulnHistoryPath -BasePath $tempRoot -PeriodKey '2026Q1') -PathType Leaf)) 'Canonical quarterly vuln history file was not materialized for multipart snapshots.'
+        Assert-True (@(Get-VulnLegacySnapshotFile -BasePath $tempRoot).Count -eq 0) 'Multipart vulnerability snapshots were not removed after publishing.'
+        Assert-True ($publishResult.DownloadedFiles -eq 3) 'Expected all multipart snapshot files to be counted during publish.'
+        Assert-True ($publishResult.CurrentRows -eq 1) 'Expected multipart import to leave one current row for the latest snapshot date.'
+        Assert-True ($publishResult.HistoryYears -eq 1) 'Expected multipart import to create one history period.'
+        Assert-True ($storeRows.Count -eq 3) 'Expected multipart import to preserve all rows across current and history.'
+        Assert-True ($currentRows.Count -eq 1) 'Expected latest multipart snapshot import to retain one current row.'
+        Assert-True ($historyRows.Count -eq 2) 'Expected prior multipart snapshot rows to be preserved in history.'
+    }
+    finally {
+        if (Test-Path -LiteralPath $tempRoot) {
+            Remove-Item -LiteralPath $tempRoot -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+}
+
+function Test-HttpRetryDelayHelperBehavior {
+    [CmdletBinding()]
+    param()
+
+    $fixedNow = [datetimeoffset]'2026-01-01T00:00:00Z'
+    $retryAfterDate = $fixedNow.AddSeconds(9).ToString('r', [System.Globalization.CultureInfo]::InvariantCulture)
+
+    Assert-True ((Get-HttpRetryDelayOverride -Headers @{ 'Retry-After' = '7' } -ReferenceTime $fixedNow) -eq 7000) 'Expected Retry-After integer seconds to convert to milliseconds.'
+    Assert-True ((Get-HttpRetryDelayOverride -Headers @{ 'Retry-After' = $retryAfterDate } -ReferenceTime $fixedNow) -eq 9000) 'Expected Retry-After HTTP-date values to convert to milliseconds.'
+    Assert-True ((Get-HttpRetryDelayOverride -Headers @{ 'x-ms-retry-after-ms' = '250' }) -eq 250) 'Expected retry-after-ms headers to convert directly to milliseconds.'
+    Assert-True ($null -eq (Get-HttpRetryDelayOverride -Headers @{} -ReferenceTime $fixedNow)) 'Expected the retry delay helper to return no override when no retry headers are present.'
+}
+
+function Test-WebRequestWithRetryTransientTransportBehavior {
+    [CmdletBinding()]
+    param()
+
+    $tempRoot = Join-Path ([System.IO.Path]::GetTempPath()) ('webrequest-transient-retry-' + [guid]::NewGuid().ToString('N'))
+    [void](New-Item -Path $tempRoot -ItemType Directory -Force)
+
+    try {
+        $outputFile = Join-Path $tempRoot 'download.bin'
+        $script:TransientWebRequestAttempts = 0
+        $script:TransientWebRequestSleeps = [System.Collections.Generic.List[int]]::new()
+
+        Set-Item -Path Function:Invoke-WebRequest -Value {
+            param(
+                [string]$Uri,
+                [string]$Method,
+                [hashtable]$Headers,
+                [string]$OutFile,
+                [string]$InFile,
+                [string]$ContentType,
+                [int]$TimeoutSec,
+                [string]$ErrorAction
+            )
+
+            $null = $Uri, $Method, $Headers, $InFile, $ContentType, $TimeoutSec, $ErrorAction
+
+            $script:TransientWebRequestAttempts++
+            if ($script:TransientWebRequestAttempts -eq 1) {
+                throw [System.Net.WebException]::new('The operation has timed out', [System.Net.WebExceptionStatus]::Timeout)
+            }
+
+            [System.IO.File]::WriteAllText($OutFile, 'ok', [System.Text.UTF8Encoding]::new($false))
+            return [PSCustomObject]@{ StatusCode = 200 }
+        }
+
+        Set-Item -Path Function:Start-Sleep -Value {
+            param([int]$Milliseconds)
+
+            $script:TransientWebRequestSleeps.Add($Milliseconds)
+        }
+
+        $null = Invoke-WebRequestWithRetry -Uri 'https://example.invalid/blob/data.json.gz?sig=secret' -OutFile $outputFile -MaxRetries 3 -InitialDelayMs 1500 -RetryTransientTransportFailures
+
+        Assert-True ($script:TransientWebRequestAttempts -eq 2) 'Expected transport retries to rerun Invoke-WebRequest after a timeout.'
+        Assert-True ($script:TransientWebRequestSleeps.Count -eq 1 -and $script:TransientWebRequestSleeps[0] -eq 1500) 'Expected the first transport retry to use the configured fallback delay.'
+        Assert-True ((Test-Path -LiteralPath $outputFile -PathType Leaf)) 'Expected transport retry to eventually materialize the requested download file.'
+    }
+    finally {
+        Remove-Item -Path Function:Invoke-WebRequest -ErrorAction SilentlyContinue
+        Remove-Item -Path Function:Start-Sleep -ErrorAction SilentlyContinue
+        Remove-Variable -Name TransientWebRequestAttempts -Scope Script -ErrorAction SilentlyContinue
+        Remove-Variable -Name TransientWebRequestSleeps -Scope Script -ErrorAction SilentlyContinue
+
+        if (Test-Path -LiteralPath $tempRoot) {
+            Remove-Item -LiteralPath $tempRoot -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+}
+
+function Test-BulkVulnerabilitySnapshotDownloadMultipartNameUniqueness {
+    [CmdletBinding()]
+    param()
+
+    $tempRoot = Join-Path ([System.IO.Path]::GetTempPath()) ('bulk-download-multipart-' + [guid]::NewGuid().ToString('N'))
+    [void](New-Item -Path $tempRoot -ItemType Directory -Force)
+
+    $originalRestMethod = (Get-Command -Name Invoke-RestMethodWithRetry -CommandType Function).ScriptBlock
+    $originalWebRequest = (Get-Command -Name Invoke-WebRequestWithRetry -CommandType Function).ScriptBlock
+
+    try {
+        $script:MockMultipartExportFiles = @(
+            'https://example.invalid/flat-va/2026-01-01/org/json/_RbacGroupId=1/part-000.c000.json.gz'
+            'https://example.invalid/flat-va/2026-01-01/org/json/_RbacGroupId=1/part-000.c001.json.gz'
+            'https://example.invalid/flat-va/2026-01-02/org/json/_RbacGroupId=1/part-001.c000.json.gz'
+        )
+
+        Set-Item -Path Function:Invoke-RestMethodWithRetry -Value {
+            param(
+                [string]$Uri,
+                [string]$Method,
+                [hashtable]$Headers,
+                [object]$Body,
+                [string]$ContentType,
+                [int]$MaxRetries,
+                [int]$InitialDelayMs,
+                [double]$BackoffMultiplier,
+                [int]$TimeoutSec,
+                [switch]$RetryTransientTransportFailures
+            )
+
+            $null = $Uri, $Method, $Headers, $Body, $ContentType, $MaxRetries, $InitialDelayMs, $BackoffMultiplier, $TimeoutSec, $RetryTransientTransportFailures
+
+            return [PSCustomObject]@{
+                exportFiles = @($script:MockMultipartExportFiles)
+            }
+        }
+
+        Set-Item -Path Function:Invoke-WebRequestWithRetry -Value {
+            param(
+                [string]$Uri,
+                [string]$Method,
+                [hashtable]$Headers,
+                [string]$OutFile,
+                [string]$InFile,
+                [string]$ContentType,
+                [int]$MaxRetries,
+                [int]$InitialDelayMs,
+                [double]$BackoffMultiplier,
+                [int]$TimeoutSec,
+                [switch]$RetryTransientTransportFailures
+            )
+
+            $null = $Method, $Headers, $InFile, $ContentType, $MaxRetries, $InitialDelayMs, $BackoffMultiplier, $TimeoutSec, $RetryTransientTransportFailures
+
+            [System.IO.File]::WriteAllText($OutFile, $Uri, [System.Text.UTF8Encoding]::new($false))
+        }
+
+        $result = Invoke-MdeBulkVulnerabilitySnapshotDownload -Headers @{} -OutputPath $tempRoot -ExportUrl 'https://example.invalid/api/machines/SoftwareVulnerabilitiesExport'
+        $downloadedNames = @($result.DownloadedFiles | ForEach-Object { Split-Path -Leaf $_ })
+
+        Assert-True ($result.ExportFileCount -eq 3) 'Expected mocked multipart download to surface three export files.'
+        Assert-True ($downloadedNames.Count -eq 3) 'Expected mocked multipart download to emit three local files.'
+        Assert-True (@($downloadedNames | Sort-Object -Unique).Count -eq 3) 'Expected multipart download filenames to remain unique.'
+        Assert-True ('VulnExport_1_2026-01-01_part_0.json.gz' -in $downloadedNames) 'Expected first multipart file name to include part_0.'
+        Assert-True ('VulnExport_1_2026-01-01_part_1.json.gz' -in $downloadedNames) 'Expected second multipart file name to include part_1.'
+        Assert-True ('VulnExport_1_2026-01-02_part_0.json.gz' -in $downloadedNames) 'Expected next snapshot date to reset the multipart counter.'
+    }
+    finally {
+        Set-Item -Path Function:Invoke-RestMethodWithRetry -Value $originalRestMethod
+        Set-Item -Path Function:Invoke-WebRequestWithRetry -Value $originalWebRequest
+        Remove-Variable -Name MockMultipartExportFiles -Scope Script -ErrorAction SilentlyContinue
+
+        if (Test-Path -LiteralPath $tempRoot) {
+            Remove-Item -LiteralPath $tempRoot -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+}
+
+function Test-BulkVulnerabilitySnapshotDownloadStagingBehavior {
+    [CmdletBinding()]
+    param()
+
+    $tempRoot = Join-Path ([System.IO.Path]::GetTempPath()) ('bulk-download-staging-' + [guid]::NewGuid().ToString('N'))
+    [void](New-Item -Path $tempRoot -ItemType Directory -Force)
+
+    $originalRestMethod = (Get-Command -Name Invoke-RestMethodWithRetry -CommandType Function).ScriptBlock
+    $originalWebRequest = (Get-Command -Name Invoke-WebRequestWithRetry -CommandType Function).ScriptBlock
+
+    try {
+        $script:CapturedBulkExportUri = ''
+        $script:CapturedBulkExportMaxRetries = 0
+        $script:CapturedBulkExportTimeoutSec = 0
+        $script:CapturedDownloadOutFiles = [System.Collections.Generic.List[string]]::new()
+        $script:CapturedDownloadMaxRetries = 0
+        $script:CapturedDownloadTimeoutSec = 0
+
+        Set-Item -Path Function:Invoke-RestMethodWithRetry -Value {
+            param(
+                [string]$Uri,
+                [string]$Method,
+                [hashtable]$Headers,
+                [object]$Body,
+                [string]$ContentType,
+                [int]$MaxRetries,
+                [int]$InitialDelayMs,
+                [double]$BackoffMultiplier,
+                [int]$TimeoutSec,
+                [switch]$RetryTransientTransportFailures
+            )
+
+            $null = $Method, $Headers, $Body, $ContentType, $InitialDelayMs, $BackoffMultiplier, $RetryTransientTransportFailures
+
+            $script:CapturedBulkExportUri = $Uri
+            $script:CapturedBulkExportMaxRetries = $MaxRetries
+            $script:CapturedBulkExportTimeoutSec = $TimeoutSec
+
+            return [PSCustomObject]@{
+                exportFiles = @('https://example.invalid/flat-va/2026-01-01/org/json/_RbacGroupId=1/part-000.c000.json.gz?sig=secret')
+            }
+        }
+
+        Set-Item -Path Function:Invoke-WebRequestWithRetry -Value {
+            param(
+                [string]$Uri,
+                [string]$Method,
+                [hashtable]$Headers,
+                [string]$OutFile,
+                [string]$InFile,
+                [string]$ContentType,
+                [int]$MaxRetries,
+                [int]$InitialDelayMs,
+                [double]$BackoffMultiplier,
+                [int]$TimeoutSec,
+                [switch]$RetryTransientTransportFailures
+            )
+
+            $null = $Uri, $Method, $Headers, $InFile, $ContentType, $InitialDelayMs, $BackoffMultiplier, $RetryTransientTransportFailures
+
+            $script:CapturedDownloadOutFiles.Add($OutFile)
+            $script:CapturedDownloadMaxRetries = $MaxRetries
+            $script:CapturedDownloadTimeoutSec = $TimeoutSec
+            [System.IO.File]::WriteAllText($OutFile, 'payload', [System.Text.UTF8Encoding]::new($false))
+        }
+
+        $result = Invoke-MdeBulkVulnerabilitySnapshotDownload -Headers @{} -OutputPath $tempRoot -ExportUrl 'https://example.invalid/api/machines/SoftwareVulnerabilitiesExport'
+        $finalPath = Join-Path $tempRoot 'VulnExport_1_2026-01-01_part_0.json.gz'
+        $stagingPath = Join-Path $tempRoot '.VulnExport_1_2026-01-01_part_0.json.gz.partial'
+
+        Assert-True ($script:CapturedBulkExportUri -eq 'https://example.invalid/api/machines/SoftwareVulnerabilitiesExport?sasValidHours=6') 'Expected bulk export requests to request the maximum supported SAS lifetime.'
+        Assert-True ($script:CapturedBulkExportMaxRetries -eq 4) 'Expected bulk export metadata fetches to use the tighter retry budget.'
+        Assert-True ($script:CapturedBulkExportTimeoutSec -eq 600) 'Expected bulk export metadata fetches to use the configured timeout.'
+        Assert-True ($script:CapturedDownloadOutFiles.Count -eq 1) 'Expected exactly one staged bulk snapshot download.'
+        Assert-True ((Split-Path -Path $script:CapturedDownloadOutFiles[0] -Leaf) -eq '.VulnExport_1_2026-01-01_part_0.json.gz.partial') 'Expected bulk snapshot downloads to stage into transient partial files.'
+        Assert-True ($script:CapturedDownloadMaxRetries -eq 6) 'Expected bulk snapshot downloads to use the higher download retry budget.'
+        Assert-True ($script:CapturedDownloadTimeoutSec -eq 1800) 'Expected bulk snapshot downloads to use the longer download timeout.'
+        Assert-True ((Test-IsTransientExportArtifactName -Name '.VulnExport_1_2026-01-01_part_0.json.gz.partial') -eq $true) 'Expected staged download files to be classified as transient export artifacts.'
+        Assert-True ((Test-Path -LiteralPath $finalPath -PathType Leaf)) 'Expected the staged vulnerability snapshot to be renamed into the final export file.'
+        Assert-True (-not (Test-Path -LiteralPath $stagingPath -PathType Leaf)) 'Expected staging files to be removed after a successful download.'
+        Assert-True ($result.DownloadedFiles.Count -eq 1 -and $result.DownloadedFiles[0] -eq $finalPath) 'Expected the downloader to report only the finalized export file.'
+    }
+    finally {
+        Set-Item -Path Function:Invoke-RestMethodWithRetry -Value $originalRestMethod
+        Set-Item -Path Function:Invoke-WebRequestWithRetry -Value $originalWebRequest
+        Remove-Variable -Name CapturedBulkExportUri -Scope Script -ErrorAction SilentlyContinue
+        Remove-Variable -Name CapturedBulkExportMaxRetries -Scope Script -ErrorAction SilentlyContinue
+        Remove-Variable -Name CapturedBulkExportTimeoutSec -Scope Script -ErrorAction SilentlyContinue
+        Remove-Variable -Name CapturedDownloadOutFiles -Scope Script -ErrorAction SilentlyContinue
+        Remove-Variable -Name CapturedDownloadMaxRetries -Scope Script -ErrorAction SilentlyContinue
+        Remove-Variable -Name CapturedDownloadTimeoutSec -Scope Script -ErrorAction SilentlyContinue
+
+        if (Test-Path -LiteralPath $tempRoot) {
+            Remove-Item -LiteralPath $tempRoot -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+}
+
+function Test-BulkVulnerabilitySnapshotDownloadCleanupBehavior {
+    [CmdletBinding()]
+    param()
+
+    $tempRoot = Join-Path ([System.IO.Path]::GetTempPath()) ('bulk-download-staging-failure-' + [guid]::NewGuid().ToString('N'))
+    [void](New-Item -Path $tempRoot -ItemType Directory -Force)
+
+    $originalRestMethod = (Get-Command -Name Invoke-RestMethodWithRetry -CommandType Function).ScriptBlock
+    $originalWebRequest = (Get-Command -Name Invoke-WebRequestWithRetry -CommandType Function).ScriptBlock
+
+    try {
+        Set-Item -Path Function:Invoke-RestMethodWithRetry -Value {
+            param(
+                [string]$Uri,
+                [string]$Method,
+                [hashtable]$Headers,
+                [object]$Body,
+                [string]$ContentType,
+                [int]$MaxRetries,
+                [int]$InitialDelayMs,
+                [double]$BackoffMultiplier,
+                [int]$TimeoutSec,
+                [switch]$RetryTransientTransportFailures
+            )
+
+            $null = $Uri, $Method, $Headers, $Body, $ContentType, $MaxRetries, $InitialDelayMs, $BackoffMultiplier, $TimeoutSec, $RetryTransientTransportFailures
+
+            return [PSCustomObject]@{
+                exportFiles = @('https://example.invalid/flat-va/2026-01-01/org/json/_RbacGroupId=1/part-000.c000.json.gz?sig=secret')
+            }
+        }
+
+        Set-Item -Path Function:Invoke-WebRequestWithRetry -Value {
+            param(
+                [string]$Uri,
+                [string]$Method,
+                [hashtable]$Headers,
+                [string]$OutFile,
+                [string]$InFile,
+                [string]$ContentType,
+                [int]$MaxRetries,
+                [int]$InitialDelayMs,
+                [double]$BackoffMultiplier,
+                [int]$TimeoutSec,
+                [switch]$RetryTransientTransportFailures
+            )
+
+            $null = $Uri, $Method, $Headers, $InFile, $ContentType, $MaxRetries, $InitialDelayMs, $BackoffMultiplier, $TimeoutSec, $RetryTransientTransportFailures
+
+            [System.IO.File]::WriteAllText($OutFile, 'partial', [System.Text.UTF8Encoding]::new($false))
+            throw [System.TimeoutException]::new('The download timed out')
+        }
+
+        $downloadFailure = $null
+        try {
+            $null = Invoke-MdeBulkVulnerabilitySnapshotDownload -Headers @{} -OutputPath $tempRoot -ExportUrl 'https://example.invalid/api/machines/SoftwareVulnerabilitiesExport'
+        }
+        catch {
+            $downloadFailure = $_
+        }
+
+        Assert-True ($null -ne $downloadFailure) 'Expected staged bulk snapshot downloads to surface failures when the download never completes.'
+        Assert-True (-not (Test-Path -LiteralPath (Join-Path $tempRoot '.VulnExport_1_2026-01-01_part_0.json.gz.partial') -PathType Leaf)) 'Expected failed staged downloads to remove their partial files.'
+        Assert-True (-not (Test-Path -LiteralPath (Join-Path $tempRoot 'VulnExport_1_2026-01-01_part_0.json.gz') -PathType Leaf)) 'Expected failed staged downloads to avoid leaving behind a finalized snapshot file.'
+    }
+    finally {
+        Set-Item -Path Function:Invoke-RestMethodWithRetry -Value $originalRestMethod
+        Set-Item -Path Function:Invoke-WebRequestWithRetry -Value $originalWebRequest
+
+        if (Test-Path -LiteralPath $tempRoot) {
+            Remove-Item -LiteralPath $tempRoot -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+}
+
 function Test-VulnCurrentFileRejectsDuplicateId {
     [CmdletBinding()]
     param()
@@ -2425,6 +2807,18 @@ Test-BulkSnapshotImportSmoke
 Write-Output '  Bulk snapshot import smoke checks passed.'
 Test-BulkSnapshotImportSingleSnapshot
 Write-Output '  Single-snapshot vulnerability import checks passed.'
+Test-BulkSnapshotImportMultipartSnapshot
+Write-Output '  Multipart vulnerability import checks passed.'
+Test-HttpRetryDelayHelperBehavior
+Write-Output '  Retry delay helper checks passed.'
+Test-WebRequestWithRetryTransientTransportBehavior
+Write-Output '  Web request transient transport retry checks passed.'
+Test-BulkVulnerabilitySnapshotDownloadMultipartNameUniqueness
+Write-Output '  Multipart vulnerability download naming checks passed.'
+Test-BulkVulnerabilitySnapshotDownloadStagingBehavior
+Write-Output '  Multipart vulnerability download staging checks passed.'
+Test-BulkVulnerabilitySnapshotDownloadCleanupBehavior
+Write-Output '  Multipart vulnerability failed-download cleanup checks passed.'
 Test-VulnCurrentFileRejectsDuplicateId
 Write-Output '  Current-file duplicate Id checks passed.'
 Test-RepairVulnHistoryLayoutSkipsCanonicalQuarterlyStore


### PR DESCRIPTION
## Summary
- preserve multipart MDE via-files snapshots by writing unique `_part_<n>` filenames and accepting multipart legacy snapshot names during import
- harden the via-files export path with extended SAS lifetime requests, retry support for HTTP 408/429/5xx and transient transport failures, and staged `.partial` downloads with cleanup
- add focused shared-helper regressions for multipart import/download behavior, retry-delay parsing, transient transport retry behavior, and staged-download cleanup
- regenerate the tracked Azure runbook artifact from the shared source changes

## Validation
- `pwsh -NoProfile -File .\build\Invoke-RegressionValidation.ps1`
- manual local live export + dashboard generation using a Defender token from Azure CLI: export succeeded, 3 multipart files downloaded, dashboard generated
- `pwsh -NoProfile -File .\tests\Measure-StressRun.ps1 -Name resiliency-large-raw-replay -SyntheticOutputPath .\.local\large-import-coverage\synthetic-raw-live -DashboardOutputPath .\.local\perf-review\resiliency-large-raw-replay.html -ReportOutputPath .\.local\perf-review\resiliency-large-raw-replay.json -ClearDashboardCache -Validate`
- `pwsh -NoProfile -File .\tests\Measure-RunbookOnlyAzureBenchmark.ps1 -RepoPath (Get-Location).Path -ExpectedTotalRows 1500000 -UseExistingExportsOnly:$false -SkipTemplateUpload -ResultsOutputPath .\.local\large-azure-validation\runbook-vuln-export-resiliency-fresh-export-20260423-024316.result.json`

## Notes
- the manual live dashboard row-comparison failure and the synthetic `RemediationChart` validation failure both reproduce on the detached `main` worktree against the same datasets, so they were treated as preexisting validation issues rather than regressions from this change
- the Azure fresh-export benchmark completed with `used_cached_payload = false`, `skipped_fresh_export = false`, peak working set `320.4 MB`, peak GC heap `98.6 MB`, and elapsed time `96 s`
