### PR TITLE
Refine remediation version grouping and large replay validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,8 @@ flowchart TD
 - Run `./build/Invoke-RegressionValidation.ps1` for the deterministic local and PR-aligned preflight path.
 - Run `./tests/Invoke-HotPhaseReview.ps1 -DirectoryPath <dataset>` when you want a local phase-and-memory review before taking changes to the heavier benchmark or Azure paths.
 - Run `./tests/New-BenchmarkDataset.ps1 -DatasetId benchmark-medium-v1` to materialize the standard durable benchmark dataset before recording baseline captures.
+- Run `./tests/New-BenchmarkDataset.ps1 -DatasetId benchmark-large-50k-v1` to register or refresh the reusable 50k-device large Azure seed without regenerating it when the cached dataset already exists.
+- Run `./tests/New-SyntheticSnapshotDelta.ps1 -SourcePath <large-seed> -OutputPath <delta-overlay> -TargetLatestDate <yyyy-MM-dd>` when you want to replay a fresh incoming vulnerability export date on top of an existing large seed for Azure validation.
 - Run `./tests/Invoke-BenchmarkSeries.ps1 -BenchmarkDatasetId benchmark-medium-v1 -Iterations 3 -IncludePersistentLocalWorkflow` when you want the repeatable multi-run benchmark cadence used for durable baseline refreshes.
 - Run `./build/Invoke-LiveDashboardDryRun.ps1 -UseExistingAzContext` when you want the local command that mirrors the live GitHub Actions export and dashboard generation path.
 - Run `./build/Invoke-AzureDeploymentValidation.ps1 -AutomationAccountName <name> -FunctionAppName <name>` when you want the repo-owned manual validation path that rebuilds locally, redeploys Azure Automation and Function App, and executes both live Azure validation flows.

--- a/VulnerabilityDashboard.html
+++ b/VulnerabilityDashboard.html
@@ -1528,16 +1528,36 @@ tbody tr:hover {
 }
 
 .update-details-column {
-    min-width: 15rem;
-    width: 15rem;
+    min-width: 13rem;
+    width: 13rem;
+    max-width: 13rem;
+}
+
+th.update-details-column,
+td.update-details-column {
+    padding-left: 10px;
+    padding-right: 10px;
 }
 
 td.update-details-column .remediation-update-entry-list {
-    display: inline-flex;
+    display: flex;
     align-items: flex-start;
-    flex-wrap: nowrap;
+    flex-wrap: wrap;
+    gap: 3px;
     justify-content: flex-start;
-    width: max-content;
+    width: 100%;
+    max-width: 100%;
+}
+
+td.update-details-column .stat-badge,
+td.update-details-column .remediation-link {
+    padding: 2px 6px;
+    font-size: 0.75rem;
+    line-height: 1.1;
+}
+
+td.update-details-column .remediation-link {
+    gap: 3px;
 }
 
 .devices-table tbody tr:last-child td {
@@ -6110,6 +6130,90 @@ function formatSoftwareName(vendor, product) {
     return `${vendorPart} - ${productPart}`;
 }
 
+function normalizeOsVersionGroupingLabel(osPlatform, osVersion) {
+    const versionText = normalizeRemediationText(osVersion);
+    if (!versionText || versionText === 'Unknown') {
+        return '';
+    }
+
+    const versionParts = versionText
+        .split('.')
+        .map(part => part.trim())
+        .filter(part => /^\d+$/.test(part));
+
+    if (versionParts.length === 0) {
+        return versionText;
+    }
+
+    const normalizedParts = versionParts.slice(0, Math.min(3, versionParts.length));
+    const platformText = normalizeRemediationText(osPlatform).toLowerCase();
+
+    if (!platformText.startsWith('windows')) {
+        while (normalizedParts.length > 1 && normalizedParts[normalizedParts.length - 1] === '0') {
+            normalizedParts.pop();
+        }
+    }
+
+    return normalizedParts.join('.');
+}
+
+function getVersionAwareSoftwareLabel(software, osPlatform, osVersion, splitByVersion) {
+    if (!splitByVersion) {
+        return software;
+    }
+
+    const versionLabel = normalizeOsVersionGroupingLabel(osPlatform, osVersion);
+    if (!versionLabel || !software || software === 'Unknown') {
+        return software;
+    }
+
+    return `${software} (${versionLabel})`;
+}
+
+function getOsFamilyComparisonKey(text) {
+    return normalizeRemediationText(text)
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, '');
+}
+
+function shouldSplitRemediationByOsVersion(software, osPlatform) {
+    const softwareKey = getOsFamilyComparisonKey(software);
+    const platformKey = getOsFamilyComparisonKey(osPlatform);
+
+    if (!softwareKey || !platformKey) {
+        return false;
+    }
+
+    return softwareKey === platformKey
+        || softwareKey.startsWith(platformKey)
+        || platformKey.startsWith(softwareKey);
+}
+
+function getVersionAwareImpactDisplayName(descriptor, software, osPlatform, osVersion, splitByVersion) {
+    const baseName = getScopedRemediationDisplayTitle(descriptor);
+    if (!splitByVersion) {
+        return baseName;
+    }
+
+    const baseSoftwareLabel = formatSoftwarePart(software)
+        || normalizeRemediationText(descriptor?.softwareLabel)
+        || normalizeRemediationText(descriptor?.scopeLabel)
+        || 'Unknown';
+    const versionedSoftwareLabel = getVersionAwareSoftwareLabel(baseSoftwareLabel, osPlatform, osVersion, true);
+
+    if (!versionedSoftwareLabel || versionedSoftwareLabel === baseSoftwareLabel) {
+        return baseName;
+    }
+
+    const separatorIndex = baseName.indexOf(':');
+    if (separatorIndex >= 0) {
+        const suffix = baseName.slice(separatorIndex + 1).trim();
+        return suffix ? `${versionedSoftwareLabel}: ${suffix}` : versionedSoftwareLabel;
+    }
+
+    return `${versionedSoftwareLabel}: ${baseName}`;
+}
+
 function getPointInTimeReferenceDate(state = filterState) {
     return state.endDate || mostRecentLastSeenDate;
 }
@@ -7290,10 +7394,13 @@ function addRemediationUpdateEntry(updateEntryMap, remediation) {
     if (!existing) {
         updateEntryMap.set(entryKey, {
             referenceText: referenceText || 'Update Details',
-            referenceUrl: referenceUrl || ''
+            referenceUrl: referenceUrl || '',
+            observationCount: 1
         });
         return;
     }
+
+    existing.observationCount = (existing.observationCount || 0) + 1;
 
     if (!existing.referenceUrl && referenceUrl) {
         existing.referenceUrl = referenceUrl;
@@ -7301,8 +7408,27 @@ function addRemediationUpdateEntry(updateEntryMap, remediation) {
 }
 
 function finalizeRemediationUpdateEntries(updateEntryMap) {
-    return Array.from((updateEntryMap || new Map()).values())
+    const entries = Array.from((updateEntryMap || new Map()).values())
         .filter(entry => entry && entry.referenceText)
+        .map(entry => ({
+            referenceText: entry.referenceText,
+            referenceUrl: entry.referenceUrl || '',
+            observationCount: entry.observationCount > 0 ? entry.observationCount : 1
+        }));
+
+    let filteredEntries = entries;
+    const kbEntries = entries.filter(entry => /^KB\d+$/i.test(entry.referenceText || ''));
+    if (entries.length > 1 && kbEntries.length === entries.length) {
+        const sortedByCount = [...entries].sort((a, b) => b.observationCount - a.observationCount);
+        const dominantEntry = sortedByCount[0];
+        const totalObservations = sortedByCount.reduce((sum, entry) => sum + entry.observationCount, 0);
+
+        if (dominantEntry && totalObservations > 0 && (dominantEntry.observationCount / totalObservations) >= 0.9) {
+            filteredEntries = sortedByCount.filter(entry => entry.observationCount === dominantEntry.observationCount);
+        }
+    }
+
+    return filteredEntries
         .sort((a, b) => {
             const referenceCompare = a.referenceText.localeCompare(
                 b.referenceText,
@@ -7319,7 +7445,11 @@ function finalizeRemediationUpdateEntries(updateEntryMap) {
                 undefined,
                 { numeric: true, sensitivity: 'base' }
             );
-        });
+        })
+        .map(entry => ({
+            referenceText: entry.referenceText,
+            referenceUrl: entry.referenceUrl || ''
+        }));
 }
 
 function summarizeRemediationUpdateEntries(updateEntries) {
@@ -7863,6 +7993,8 @@ function getRemediationTableData() {
 
     const remediationMap = {};
     const activeRows = getActiveRowsForCurrentSelection();
+    const remediationDescriptors = new Array(activeRows.length);
+    const versionBucketsByBaseKey = new Map();
 
     const formatCache = new Map();
     const formatPart = (text) => {
@@ -7878,15 +8010,43 @@ function getRemediationTableData() {
     for (let i = 0, len = activeRows.length; i < len; i++) {
         const v = activeRows[i];
         const remediation = buildRemediationDescriptor(v);
+        const vendor = formatPart(v.SoftwareVendor);
+        const software = formatPart(v.SoftwareName);
+        const baseKey = `${vendor}|${software}|${remediation.key}`;
+        const canSplitByOsVersion = shouldSplitRemediationByOsVersion(software, v.OSPlatform);
+        const versionBucket = normalizeOsVersionGroupingLabel(v.OSPlatform, v.OSVersion);
+
+        remediationDescriptors[i] = remediation;
+
+        if (!canSplitByOsVersion || !versionBucket) {
+            continue;
+        }
+
+        let versionBuckets = versionBucketsByBaseKey.get(baseKey);
+        if (!versionBuckets) {
+            versionBuckets = new Set();
+            versionBucketsByBaseKey.set(baseKey, versionBuckets);
+        }
+
+        versionBuckets.add(versionBucket);
+    }
+
+    for (let i = 0, len = activeRows.length; i < len; i++) {
+        const v = activeRows[i];
+        const remediation = remediationDescriptors[i];
         const compactRemediation = getCompactRemediationTitle(remediation);
         const vendor = formatPart(v.SoftwareVendor);
         const software = formatPart(v.SoftwareName);
-        const key = `${vendor}|${software}|${remediation.key}`;
+        const baseKey = `${vendor}|${software}|${remediation.key}`;
+        const splitByVersion = shouldSplitRemediationByOsVersion(software, v.OSPlatform)
+            && (versionBucketsByBaseKey.get(baseKey)?.size || 0) > 1;
+        const softwareLabel = getVersionAwareSoftwareLabel(software, v.OSPlatform, v.OSVersion, splitByVersion);
+        const key = splitByVersion ? `${baseKey}|${softwareLabel}` : baseKey;
 
         if (!remediationMap[key]) {
             remediationMap[key] = {
                 vendor: vendor,
-                software: software,
+                software: softwareLabel,
                 remediationDescriptor: remediation,
                 descriptorObservationMap: new Map(),
                 remediation: compactRemediation,
@@ -7926,7 +8086,10 @@ function getRemediationTableData() {
             data.updateEntries = finalizeRemediationUpdateEntries(data.updateEntryMap);
             data.updateUrl = getSingleRemediationUpdateUrlFromEntries(data.updateEntries) || data.remediationDescriptor.updateUrl;
             data.remediation = getActiveRemediationTableTitle(data.remediationDescriptor);
-            data.modalTitle = getRemediationTitleWithReferenceSuffix(getScopedRemediationDisplayTitle(data.remediationDescriptor), data.updateEntries);
+            const modalBaseTitle = data.software && data.software !== 'Unknown'
+                ? `${data.software}: ${data.remediation}`
+                : getScopedRemediationDisplayTitle(data.remediationDescriptor);
+            data.modalTitle = getRemediationTitleWithReferenceSuffix(modalBaseTitle, data.updateEntries);
             data.remediationHtml = buildRemediationTitleCellHtml(data.remediation);
             const updateDisplay = buildSeparatedRemediationUpdateDisplay(data.remediation, data.remediationDescriptor, data.updateEntries);
             data.updateValue = updateDisplay.value;
@@ -8077,15 +8240,46 @@ function getImpactAnalysisData() {
 
     const remediationMap = {};
     const activeRows = getActiveRowsForCurrentSelection();
-    activeRows.forEach(v => {
+    const remediationDescriptors = new Array(activeRows.length);
+    const versionBucketsByBaseKey = new Map();
+
+    for (let i = 0, len = activeRows.length; i < len; i++) {
+        const v = activeRows[i];
         const remediation = buildRemediationDescriptor(v);
-        const key = remediation.key;
+        const formattedSoftware = formatSoftwarePart(v.SoftwareName);
+        const baseKey = remediation.key;
+        const canSplitByOsVersion = shouldSplitRemediationByOsVersion(formattedSoftware, v.OSPlatform);
+        const versionBucket = normalizeOsVersionGroupingLabel(v.OSPlatform, v.OSVersion);
+
+        remediationDescriptors[i] = remediation;
+
+        if (!canSplitByOsVersion || !versionBucket) {
+            continue;
+        }
+
+        let versionBuckets = versionBucketsByBaseKey.get(baseKey);
+        if (!versionBuckets) {
+            versionBuckets = new Set();
+            versionBucketsByBaseKey.set(baseKey, versionBuckets);
+        }
+
+        versionBuckets.add(versionBucket);
+    }
+
+    activeRows.forEach((v, index) => {
+        const remediation = remediationDescriptors[index];
+        const formattedSoftware = formatSoftwarePart(v.SoftwareName);
+        const baseKey = remediation.key;
+        const splitByVersion = shouldSplitRemediationByOsVersion(formattedSoftware, v.OSPlatform)
+            && (versionBucketsByBaseKey.get(baseKey)?.size || 0) > 1;
+        const impactName = getVersionAwareImpactDisplayName(remediation, formattedSoftware, v.OSPlatform, v.OSVersion, splitByVersion);
+        const key = splitByVersion ? `${baseKey}|${impactName}` : baseKey;
 
         if (!remediationMap[key]) {
             remediationMap[key] = {
                 remediationDescriptor: remediation,
                 descriptorObservationMap: new Map(),
-                name: remediation.title,
+                name: impactName,
                 updateEntryMap: new Map(),
                 devices: new Set(),
                 vulnerabilities: []
@@ -8103,12 +8297,13 @@ function getImpactAnalysisData() {
     const top25 = Object.values(mergedRemediationMap)
         .map(data => ({
             remediationDescriptor: getDominantRemediationDescriptor(data) || data.remediationDescriptor,
+            name: data.name,
             updateEntries: finalizeRemediationUpdateEntries(data.updateEntryMap),
             impact: data.devices.size * new Set(data.vulnerabilities.map(v => v.CveId)).size,
             vulnerabilities: data.vulnerabilities
         }))
         .map(data => {
-            const name = getScopedRemediationDisplayTitle(data.remediationDescriptor);
+            const name = data.name || getScopedRemediationDisplayTitle(data.remediationDescriptor);
             const updateDisplay = buildSeparatedRemediationUpdateDisplay(name, data.remediationDescriptor, data.updateEntries);
             return {
                 name: name,

--- a/azure/Invoke-DashboardPipeline.ps1
+++ b/azure/Invoke-DashboardPipeline.ps1
@@ -17040,7 +17040,7 @@ try {
             throw "UseExistingExportsOnly was specified, but no vulnerability store, content-store sidecars, or legacy vulnerability snapshots were found in '$tempExports'."
         }
 
-        if ($hasExistingLegacyVulnerabilitySnapshots -and -not (Test-VulnStoreExistence -BasePath $tempExports) -and -not (Test-VulnContentStoreExistence -BasePath $tempExports)) {
+        if ($hasExistingLegacyVulnerabilitySnapshots) {
             Write-Output 'Canonicalizing downloaded legacy vulnerability snapshots...'
             $vulnStore = Publish-VulnStoreFromBulkSnapshot -BasePath $tempExports -RemoveSnapshotFiles
             Write-Output "  Saved vulnerability current/history store with $($vulnStore.CurrentRows) current row(s) across $($vulnStore.HistoryYears) history period file(s)"

--- a/azure/Invoke-DashboardPipeline.ps1
+++ b/azure/Invoke-DashboardPipeline.ps1
@@ -16976,7 +16976,7 @@ try {
         elseif (($blobName -in $legacyAdvancedHuntingBlobs) -and ($IncludeAdvancedHunting -or $hasAdvancedHuntingCurrentBlob)) {
             $shouldDownload = $false
         }
-        elseif (($blobName -in $legacyVulnerabilityBlobs) -and $hasCanonicalVulnStore) {
+        elseif (($blobName -in $legacyVulnerabilityBlobs) -and $hasCanonicalVulnStore -and -not $UseExistingExportsOnly) {
             $shouldDownload = $false
         }
         elseif ((Test-IsMachineHistorySegmentFileName -Name $blobName) -and $hasMachineCurrentBlob) {

--- a/build/azure/runbook-source.ps1
+++ b/build/azure/runbook-source.ps1
@@ -1124,7 +1124,7 @@ try {
         elseif (($blobName -in $legacyAdvancedHuntingBlobs) -and ($IncludeAdvancedHunting -or $hasAdvancedHuntingCurrentBlob)) {
             $shouldDownload = $false
         }
-        elseif (($blobName -in $legacyVulnerabilityBlobs) -and $hasCanonicalVulnStore) {
+        elseif (($blobName -in $legacyVulnerabilityBlobs) -and $hasCanonicalVulnStore -and -not $UseExistingExportsOnly) {
             $shouldDownload = $false
         }
         elseif ((Test-IsMachineHistorySegmentFileName -Name $blobName) -and $hasMachineCurrentBlob) {

--- a/build/azure/runbook-source.ps1
+++ b/build/azure/runbook-source.ps1
@@ -1188,7 +1188,7 @@ try {
             throw "UseExistingExportsOnly was specified, but no vulnerability store, content-store sidecars, or legacy vulnerability snapshots were found in '$tempExports'."
         }
 
-        if ($hasExistingLegacyVulnerabilitySnapshots -and -not (Test-VulnStoreExistence -BasePath $tempExports) -and -not (Test-VulnContentStoreExistence -BasePath $tempExports)) {
+        if ($hasExistingLegacyVulnerabilitySnapshots) {
             Write-Output 'Canonicalizing downloaded legacy vulnerability snapshots...'
             $vulnStore = Publish-VulnStoreFromBulkSnapshot -BasePath $tempExports -RemoveSnapshotFiles
             Write-Output "  Saved vulnerability current/history store with $($vulnStore.CurrentRows) current row(s) across $($vulnStore.HistoryYears) history period file(s)"

--- a/templates/dashboard.css
+++ b/templates/dashboard.css
@@ -1536,16 +1536,36 @@ tbody tr:hover {
 }
 
 .update-details-column {
-    min-width: 15rem;
-    width: 15rem;
+    min-width: 13rem;
+    width: 13rem;
+    max-width: 13rem;
+}
+
+th.update-details-column,
+td.update-details-column {
+    padding-left: 10px;
+    padding-right: 10px;
 }
 
 td.update-details-column .remediation-update-entry-list {
-    display: inline-flex;
+    display: flex;
     align-items: flex-start;
-    flex-wrap: nowrap;
+    flex-wrap: wrap;
+    gap: 3px;
     justify-content: flex-start;
-    width: max-content;
+    width: 100%;
+    max-width: 100%;
+}
+
+td.update-details-column .stat-badge,
+td.update-details-column .remediation-link {
+    padding: 2px 6px;
+    font-size: 0.75rem;
+    line-height: 1.1;
+}
+
+td.update-details-column .remediation-link {
+    gap: 3px;
 }
 
 .devices-table tbody tr:last-child td {

--- a/templates/dashboard.js
+++ b/templates/dashboard.js
@@ -3838,6 +3838,90 @@ function formatSoftwareName(vendor, product) {
     return `${vendorPart} - ${productPart}`;
 }
 
+function normalizeOsVersionGroupingLabel(osPlatform, osVersion) {
+    const versionText = normalizeRemediationText(osVersion);
+    if (!versionText || versionText === 'Unknown') {
+        return '';
+    }
+
+    const versionParts = versionText
+        .split('.')
+        .map(part => part.trim())
+        .filter(part => /^\d+$/.test(part));
+
+    if (versionParts.length === 0) {
+        return versionText;
+    }
+
+    const normalizedParts = versionParts.slice(0, Math.min(3, versionParts.length));
+    const platformText = normalizeRemediationText(osPlatform).toLowerCase();
+
+    if (!platformText.startsWith('windows')) {
+        while (normalizedParts.length > 1 && normalizedParts[normalizedParts.length - 1] === '0') {
+            normalizedParts.pop();
+        }
+    }
+
+    return normalizedParts.join('.');
+}
+
+function getVersionAwareSoftwareLabel(software, osPlatform, osVersion, splitByVersion) {
+    if (!splitByVersion) {
+        return software;
+    }
+
+    const versionLabel = normalizeOsVersionGroupingLabel(osPlatform, osVersion);
+    if (!versionLabel || !software || software === 'Unknown') {
+        return software;
+    }
+
+    return `${software} (${versionLabel})`;
+}
+
+function getOsFamilyComparisonKey(text) {
+    return normalizeRemediationText(text)
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, '');
+}
+
+function shouldSplitRemediationByOsVersion(software, osPlatform) {
+    const softwareKey = getOsFamilyComparisonKey(software);
+    const platformKey = getOsFamilyComparisonKey(osPlatform);
+
+    if (!softwareKey || !platformKey) {
+        return false;
+    }
+
+    return softwareKey === platformKey
+        || softwareKey.startsWith(platformKey)
+        || platformKey.startsWith(softwareKey);
+}
+
+function getVersionAwareImpactDisplayName(descriptor, software, osPlatform, osVersion, splitByVersion) {
+    const baseName = getScopedRemediationDisplayTitle(descriptor);
+    if (!splitByVersion) {
+        return baseName;
+    }
+
+    const baseSoftwareLabel = formatSoftwarePart(software)
+        || normalizeRemediationText(descriptor?.softwareLabel)
+        || normalizeRemediationText(descriptor?.scopeLabel)
+        || 'Unknown';
+    const versionedSoftwareLabel = getVersionAwareSoftwareLabel(baseSoftwareLabel, osPlatform, osVersion, true);
+
+    if (!versionedSoftwareLabel || versionedSoftwareLabel === baseSoftwareLabel) {
+        return baseName;
+    }
+
+    const separatorIndex = baseName.indexOf(':');
+    if (separatorIndex >= 0) {
+        const suffix = baseName.slice(separatorIndex + 1).trim();
+        return suffix ? `${versionedSoftwareLabel}: ${suffix}` : versionedSoftwareLabel;
+    }
+
+    return `${versionedSoftwareLabel}: ${baseName}`;
+}
+
 function getPointInTimeReferenceDate(state = filterState) {
     return state.endDate || mostRecentLastSeenDate;
 }
@@ -5018,10 +5102,13 @@ function addRemediationUpdateEntry(updateEntryMap, remediation) {
     if (!existing) {
         updateEntryMap.set(entryKey, {
             referenceText: referenceText || 'Update Details',
-            referenceUrl: referenceUrl || ''
+            referenceUrl: referenceUrl || '',
+            observationCount: 1
         });
         return;
     }
+
+    existing.observationCount = (existing.observationCount || 0) + 1;
 
     if (!existing.referenceUrl && referenceUrl) {
         existing.referenceUrl = referenceUrl;
@@ -5029,8 +5116,27 @@ function addRemediationUpdateEntry(updateEntryMap, remediation) {
 }
 
 function finalizeRemediationUpdateEntries(updateEntryMap) {
-    return Array.from((updateEntryMap || new Map()).values())
+    const entries = Array.from((updateEntryMap || new Map()).values())
         .filter(entry => entry && entry.referenceText)
+        .map(entry => ({
+            referenceText: entry.referenceText,
+            referenceUrl: entry.referenceUrl || '',
+            observationCount: entry.observationCount > 0 ? entry.observationCount : 1
+        }));
+
+    let filteredEntries = entries;
+    const kbEntries = entries.filter(entry => /^KB\d+$/i.test(entry.referenceText || ''));
+    if (entries.length > 1 && kbEntries.length === entries.length) {
+        const sortedByCount = [...entries].sort((a, b) => b.observationCount - a.observationCount);
+        const dominantEntry = sortedByCount[0];
+        const totalObservations = sortedByCount.reduce((sum, entry) => sum + entry.observationCount, 0);
+
+        if (dominantEntry && totalObservations > 0 && (dominantEntry.observationCount / totalObservations) >= 0.9) {
+            filteredEntries = sortedByCount.filter(entry => entry.observationCount === dominantEntry.observationCount);
+        }
+    }
+
+    return filteredEntries
         .sort((a, b) => {
             const referenceCompare = a.referenceText.localeCompare(
                 b.referenceText,
@@ -5047,7 +5153,11 @@ function finalizeRemediationUpdateEntries(updateEntryMap) {
                 undefined,
                 { numeric: true, sensitivity: 'base' }
             );
-        });
+        })
+        .map(entry => ({
+            referenceText: entry.referenceText,
+            referenceUrl: entry.referenceUrl || ''
+        }));
 }
 
 function summarizeRemediationUpdateEntries(updateEntries) {
@@ -5591,6 +5701,8 @@ function getRemediationTableData() {
 
     const remediationMap = {};
     const activeRows = getActiveRowsForCurrentSelection();
+    const remediationDescriptors = new Array(activeRows.length);
+    const versionBucketsByBaseKey = new Map();
 
     const formatCache = new Map();
     const formatPart = (text) => {
@@ -5606,15 +5718,43 @@ function getRemediationTableData() {
     for (let i = 0, len = activeRows.length; i < len; i++) {
         const v = activeRows[i];
         const remediation = buildRemediationDescriptor(v);
+        const vendor = formatPart(v.SoftwareVendor);
+        const software = formatPart(v.SoftwareName);
+        const baseKey = `${vendor}|${software}|${remediation.key}`;
+        const canSplitByOsVersion = shouldSplitRemediationByOsVersion(software, v.OSPlatform);
+        const versionBucket = normalizeOsVersionGroupingLabel(v.OSPlatform, v.OSVersion);
+
+        remediationDescriptors[i] = remediation;
+
+        if (!canSplitByOsVersion || !versionBucket) {
+            continue;
+        }
+
+        let versionBuckets = versionBucketsByBaseKey.get(baseKey);
+        if (!versionBuckets) {
+            versionBuckets = new Set();
+            versionBucketsByBaseKey.set(baseKey, versionBuckets);
+        }
+
+        versionBuckets.add(versionBucket);
+    }
+
+    for (let i = 0, len = activeRows.length; i < len; i++) {
+        const v = activeRows[i];
+        const remediation = remediationDescriptors[i];
         const compactRemediation = getCompactRemediationTitle(remediation);
         const vendor = formatPart(v.SoftwareVendor);
         const software = formatPart(v.SoftwareName);
-        const key = `${vendor}|${software}|${remediation.key}`;
+        const baseKey = `${vendor}|${software}|${remediation.key}`;
+        const splitByVersion = shouldSplitRemediationByOsVersion(software, v.OSPlatform)
+            && (versionBucketsByBaseKey.get(baseKey)?.size || 0) > 1;
+        const softwareLabel = getVersionAwareSoftwareLabel(software, v.OSPlatform, v.OSVersion, splitByVersion);
+        const key = splitByVersion ? `${baseKey}|${softwareLabel}` : baseKey;
 
         if (!remediationMap[key]) {
             remediationMap[key] = {
                 vendor: vendor,
-                software: software,
+                software: softwareLabel,
                 remediationDescriptor: remediation,
                 descriptorObservationMap: new Map(),
                 remediation: compactRemediation,
@@ -5654,7 +5794,10 @@ function getRemediationTableData() {
             data.updateEntries = finalizeRemediationUpdateEntries(data.updateEntryMap);
             data.updateUrl = getSingleRemediationUpdateUrlFromEntries(data.updateEntries) || data.remediationDescriptor.updateUrl;
             data.remediation = getActiveRemediationTableTitle(data.remediationDescriptor);
-            data.modalTitle = getRemediationTitleWithReferenceSuffix(getScopedRemediationDisplayTitle(data.remediationDescriptor), data.updateEntries);
+            const modalBaseTitle = data.software && data.software !== 'Unknown'
+                ? `${data.software}: ${data.remediation}`
+                : getScopedRemediationDisplayTitle(data.remediationDescriptor);
+            data.modalTitle = getRemediationTitleWithReferenceSuffix(modalBaseTitle, data.updateEntries);
             data.remediationHtml = buildRemediationTitleCellHtml(data.remediation);
             const updateDisplay = buildSeparatedRemediationUpdateDisplay(data.remediation, data.remediationDescriptor, data.updateEntries);
             data.updateValue = updateDisplay.value;
@@ -5805,15 +5948,46 @@ function getImpactAnalysisData() {
 
     const remediationMap = {};
     const activeRows = getActiveRowsForCurrentSelection();
-    activeRows.forEach(v => {
+    const remediationDescriptors = new Array(activeRows.length);
+    const versionBucketsByBaseKey = new Map();
+
+    for (let i = 0, len = activeRows.length; i < len; i++) {
+        const v = activeRows[i];
         const remediation = buildRemediationDescriptor(v);
-        const key = remediation.key;
+        const formattedSoftware = formatSoftwarePart(v.SoftwareName);
+        const baseKey = remediation.key;
+        const canSplitByOsVersion = shouldSplitRemediationByOsVersion(formattedSoftware, v.OSPlatform);
+        const versionBucket = normalizeOsVersionGroupingLabel(v.OSPlatform, v.OSVersion);
+
+        remediationDescriptors[i] = remediation;
+
+        if (!canSplitByOsVersion || !versionBucket) {
+            continue;
+        }
+
+        let versionBuckets = versionBucketsByBaseKey.get(baseKey);
+        if (!versionBuckets) {
+            versionBuckets = new Set();
+            versionBucketsByBaseKey.set(baseKey, versionBuckets);
+        }
+
+        versionBuckets.add(versionBucket);
+    }
+
+    activeRows.forEach((v, index) => {
+        const remediation = remediationDescriptors[index];
+        const formattedSoftware = formatSoftwarePart(v.SoftwareName);
+        const baseKey = remediation.key;
+        const splitByVersion = shouldSplitRemediationByOsVersion(formattedSoftware, v.OSPlatform)
+            && (versionBucketsByBaseKey.get(baseKey)?.size || 0) > 1;
+        const impactName = getVersionAwareImpactDisplayName(remediation, formattedSoftware, v.OSPlatform, v.OSVersion, splitByVersion);
+        const key = splitByVersion ? `${baseKey}|${impactName}` : baseKey;
 
         if (!remediationMap[key]) {
             remediationMap[key] = {
                 remediationDescriptor: remediation,
                 descriptorObservationMap: new Map(),
-                name: remediation.title,
+                name: impactName,
                 updateEntryMap: new Map(),
                 devices: new Set(),
                 vulnerabilities: []
@@ -5831,12 +6005,13 @@ function getImpactAnalysisData() {
     const top25 = Object.values(mergedRemediationMap)
         .map(data => ({
             remediationDescriptor: getDominantRemediationDescriptor(data) || data.remediationDescriptor,
+            name: data.name,
             updateEntries: finalizeRemediationUpdateEntries(data.updateEntryMap),
             impact: data.devices.size * new Set(data.vulnerabilities.map(v => v.CveId)).size,
             vulnerabilities: data.vulnerabilities
         }))
         .map(data => {
-            const name = getScopedRemediationDisplayTitle(data.remediationDescriptor);
+            const name = data.name || getScopedRemediationDisplayTitle(data.remediationDescriptor);
             const updateDisplay = buildSeparatedRemediationUpdateDisplay(name, data.remediationDescriptor, data.updateEntries);
             return {
                 name: name,

--- a/templates/dashboard.js
+++ b/templates/dashboard.js
@@ -3840,7 +3840,7 @@ function formatSoftwareName(vendor, product) {
 
 function normalizeOsVersionGroupingLabel(osPlatform, osVersion) {
     const versionText = normalizeRemediationText(osVersion);
-    if (!versionText || versionText === 'Unknown') {
+    if (!versionText) {
         return '';
     }
 

--- a/tests/Generate-SyntheticLargeExports.ps1
+++ b/tests/Generate-SyntheticLargeExports.ps1
@@ -386,6 +386,34 @@ function ConvertTo-SyntheticMachineRecord {
     return $machine
 }
 
+function Get-RowProfileFallbackValue {
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory = $true)]
+        $RowProfile,
+
+        [Parameter(Mandatory = $true)]
+        [string]$PropertyName
+    )
+
+    $fallbackRow = if ($RowProfile.CurrentRows.Count -gt 0) {
+        $RowProfile.CurrentRows[0]
+    }
+    elseif ($RowProfile.HistoryEntries.Count -gt 0) {
+        $RowProfile.HistoryEntries[0].Row
+    }
+    else {
+        $null
+    }
+
+    if ($null -eq $fallbackRow) {
+        return ''
+    }
+
+    return [string](Get-RowPropertyValue -Row $fallbackRow -Name $PropertyName)
+}
+
 function ConvertTo-SyntheticRow {
     [CmdletBinding()]
     param(
@@ -1131,6 +1159,23 @@ $writtenHistoryRows = 0
 try {
     foreach ($plan in $plans) {
         $syntheticMachine = ConvertTo-SyntheticMachineRecord -TemplateMachine $plan.MachineTemplate -DeviceId ([string]$plan.DeviceId) -DeviceName ([string]$plan.DeviceName) -ObservedOn $generationDate
+        $templateProfileKey = Get-ProfileKey `
+            -DeviceId ([string](Get-MachineRecordValue -Machine $plan.MachineTemplate -Name 'id')) `
+            -DeviceName ([string](Get-MachineRecordValue -Machine $plan.MachineTemplate -Name 'computerDnsName'))
+        $templateMachineRowProfile = if ($rowProfileMap.ContainsKey($templateProfileKey)) { $rowProfileMap[$templateProfileKey] } else { $null }
+        if ([string]::IsNullOrWhiteSpace([string](Get-MachineRecordValue -Machine $syntheticMachine -Name 'osVersion'))) {
+            $fallbackOsVersion = if ($null -ne $templateMachineRowProfile) {
+                Get-RowProfileFallbackValue -RowProfile $templateMachineRowProfile -PropertyName 'OSVersion'
+            }
+            else {
+                ''
+            }
+            if (-not [string]::IsNullOrWhiteSpace($fallbackOsVersion)) {
+                Add-ObjectProperty -InputObject $syntheticMachine -Name 'osVersion' -Value $fallbackOsVersion
+                Add-ObjectProperty -InputObject $syntheticMachine -Name 'stateHash' -Value (Get-MachineStateHash -Machine $syntheticMachine)
+            }
+        }
+
         Write-GzipJsonRecordLine -WriterState $machineWriter -Record (New-MachineSnapshotRecord -Machine $syntheticMachine -ObservedOn $generationDate)
 
         $planDeviceProfileRow = [PSCustomObject]@{

--- a/tests/New-SyntheticSnapshotDelta.ps1
+++ b/tests/New-SyntheticSnapshotDelta.ps1
@@ -238,7 +238,7 @@ function Initialize-ReferenceMetadataLookup {
     }
 }
 
-function Resolve-ReferenceDeviceMetadata {
+function Resolve-ReferenceDeviceContext {
     [CmdletBinding()]
     [OutputType([hashtable])]
     param(
@@ -349,7 +349,7 @@ function Invoke-CurrentSnapshotJsonLines {
         $ref = $refLine | ConvertFrom-Json -Depth 10
         $device = $dictionary.deviceProfiles[[int]$ref[1]]
         $content = $dictionary.contentTemplates[[int]$ref[2]]
-        $referenceMetadata = Resolve-ReferenceDeviceMetadata -DeviceId ([string]$device.id) -GroupName ([string]$device.g)
+        $referenceMetadata = Resolve-ReferenceDeviceContext -DeviceId ([string]$device.id) -GroupName ([string]$device.g)
         $row = [PSCustomObject]@{
             Id = [string]$ref[0]
             DeviceId = [string]$device.id
@@ -608,14 +608,14 @@ foreach ($file in $seedFileNames) {
         -CopiedFileCount ([ref]$copiedFileCount)
 }
 
-Write-Host ('Source latest date: {0}' -f $sourceLatestDate)
-Write-Host ('Target latest date: {0}' -f $resolvedTargetLatestDate)
-Write-Host ('Creating synthetic delta snapshot: +{0} day(s)' -f $script:DateShiftDays)
+Write-Output ('Source latest date: {0}' -f $sourceLatestDate)
+Write-Output ('Target latest date: {0}' -f $resolvedTargetLatestDate)
+Write-Output ('Creating synthetic delta snapshot: +{0} day(s)' -f $script:DateShiftDays)
 
 $machineWriter = $null
 $machineCount = 0
 try {
-    Write-Host 'Shifting machine current snapshot...'
+    Write-Output 'Shifting machine current snapshot...'
     $machineWriter = New-GzipWriterState -Path (Get-MachineCurrentPath -BasePath $resolvedOutputPath)
     foreach ($line in Read-VulnNdjsonLinesFromPath -Path $sourceMachinePath) {
         if ([string]::IsNullOrWhiteSpace($line)) {
@@ -627,7 +627,7 @@ try {
         $machineGroupName = Get-JsonStringPropertyValue -JsonLine $shiftedMachineLine -PropertyName 'rbacGroupName'
         $machineOsVersion = Get-JsonStringPropertyValue -JsonLine $shiftedMachineLine -PropertyName 'osVersion'
         if ([string]::IsNullOrWhiteSpace($machineOsVersion)) {
-            $referenceMetadata = Resolve-ReferenceDeviceMetadata -DeviceId $machineDeviceId -GroupName $machineGroupName
+            $referenceMetadata = Resolve-ReferenceDeviceContext -DeviceId $machineDeviceId -GroupName $machineGroupName
             if (-not [string]::IsNullOrWhiteSpace([string]$referenceMetadata.OSVersion)) {
                 $pattern = '"osVersion"\s*:\s*(?:null|"")'
                 $replacement = '"osVersion":"' + [string]$referenceMetadata.OSVersion + '"'
@@ -646,7 +646,7 @@ finally {
 $snapshotWriterStates = @{}
 $deltaRowCount = 0
 try {
-    Write-Host 'Writing legacy vulnerability snapshot delta files...'
+    Write-Output 'Writing legacy vulnerability snapshot delta files...'
     foreach ($line in Invoke-CurrentSnapshotJsonLines -BasePath $resolvedSourcePath) {
         $shiftedLine = Shift-JsonLineDateFields -JsonLine $line -FieldNames @('FirstSeenTimestamp', 'LastSeenTimestamp')
         $groupId = Get-LegacySnapshotGroupIdFromJsonLine -JsonLine $shiftedLine
@@ -699,9 +699,9 @@ $manifest = [ordered]@{
 
 $manifest | ConvertTo-Json -Depth 10 | Set-Content -LiteralPath (Join-Path $resolvedOutputPath 'synthetic-manifest.json') -Encoding utf8
 
-Write-Host ''
-Write-Host ('Synthetic delta overlay created at: {0}' -f $resolvedOutputPath) -ForegroundColor Green
-Write-Host ('  Seed files: {0} hard-linked, {1} copied' -f $linkedFileCount, $copiedFileCount)
-Write-Host ('  Shifted machine rows: {0}' -f $machineCount)
-Write-Host ('  Delta snapshot rows: {0}' -f $deltaRowCount)
-Write-Host ('  Delta snapshot files: {0}' -f ($deltaSnapshotFiles -join ', '))
+Write-Output ''
+Write-Output ('Synthetic delta overlay created at: {0}' -f $resolvedOutputPath)
+Write-Output ('  Seed files: {0} hard-linked, {1} copied' -f $linkedFileCount, $copiedFileCount)
+Write-Output ('  Shifted machine rows: {0}' -f $machineCount)
+Write-Output ('  Delta snapshot rows: {0}' -f $deltaRowCount)
+Write-Output ('  Delta snapshot files: {0}' -f ($deltaSnapshotFiles -join ', '))

--- a/tests/New-SyntheticSnapshotDelta.ps1
+++ b/tests/New-SyntheticSnapshotDelta.ps1
@@ -1,0 +1,707 @@
+﻿#Requires -Version 7.0
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $false)]
+    [string]$SourcePath = (Join-Path (Split-Path -Path $PSScriptRoot -Parent) '.local\large-datasets\synthetic-50k-1_5m'),
+
+    [Parameter(Mandatory = $false)]
+    [string]$OutputPath = (Join-Path (Split-Path -Path $PSScriptRoot -Parent) '.local\large-datasets\synthetic-50k-1_5m-delta'),
+
+    [Parameter(Mandatory = $false)]
+    [string]$TargetLatestDate = (Get-Date).ToUniversalTime().ToString('yyyy-MM-dd'),
+
+    [Parameter(Mandatory = $false)]
+    [switch]$Force,
+
+    [Parameter(Mandatory = $false)]
+    [switch]$CopyOnly
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+$ProgressPreference = 'SilentlyContinue'
+
+$repoRoot = Split-Path -Path $PSScriptRoot -Parent
+. (Join-Path $repoRoot 'build\Import-SharedHelpers.ps1')
+
+$script:InvariantCulture = [System.Globalization.CultureInfo]::InvariantCulture
+$script:DateShiftDays = 0
+$script:ShiftedDateCache = [System.Collections.Generic.Dictionary[string, string]]::new([System.StringComparer]::Ordinal)
+$script:ReferenceDeviceMetadataByBaseId = $null
+$script:ReferenceGroupIdByGroupName = $null
+
+function Test-EquivalentPath {
+    [CmdletBinding()]
+    [OutputType([bool])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Left,
+
+        [Parameter(Mandatory = $true)]
+        [string]$Right
+    )
+
+    $trimChars = [char[]]@([System.IO.Path]::DirectorySeparatorChar, [System.IO.Path]::AltDirectorySeparatorChar)
+    $leftPath = [System.IO.Path]::GetFullPath($Left).TrimEnd($trimChars)
+    $rightPath = [System.IO.Path]::GetFullPath($Right).TrimEnd($trimChars)
+    return [System.StringComparer]::OrdinalIgnoreCase.Equals($leftPath, $rightPath)
+}
+
+function Get-JsonStringPropertyValue {
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$JsonLine,
+
+        [Parameter(Mandatory = $true)]
+        [string]$PropertyName
+    )
+
+    $pattern = '"' + [regex]::Escape($PropertyName) + '"\s*:\s*"(?<value>[^"]*)"'
+    $match = [regex]::Match($JsonLine, $pattern)
+    if (-not $match.Success) {
+        return ''
+    }
+
+    return $match.Groups['value'].Value
+}
+
+function Get-SyntheticBaseDeviceId {
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory = $false)]
+        [AllowEmptyString()]
+        [string]$DeviceId
+    )
+
+    if ([string]::IsNullOrWhiteSpace($DeviceId)) {
+        return ''
+    }
+
+    $match = [regex]::Match($DeviceId, '^sim-\d{5}-(?<base>.+)$')
+    if ($match.Success) {
+        return [string]$match.Groups['base'].Value
+    }
+
+    return $DeviceId
+}
+
+function Get-ShiftedDateValue {
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [AllowEmptyString()]
+        [string]$Value
+    )
+
+    if ([string]::IsNullOrWhiteSpace($Value) -or $script:DateShiftDays -eq 0) {
+        return $Value
+    }
+
+    if ($script:ShiftedDateCache.ContainsKey($Value)) {
+        return $script:ShiftedDateCache[$Value]
+    }
+
+    $shiftedValue = $Value
+    $dateOnly = [datetime]::MinValue
+    $dateTimeOffset = [datetimeoffset]::MinValue
+    $dateTime = [datetime]::MinValue
+
+    if ([datetime]::TryParseExact($Value, 'yyyy-MM-dd', $script:InvariantCulture, [System.Globalization.DateTimeStyles]::None, [ref]$dateOnly)) {
+        $shiftedValue = $dateOnly.AddDays($script:DateShiftDays).ToString('yyyy-MM-dd', $script:InvariantCulture)
+    }
+    elseif ([datetimeoffset]::TryParse($Value, $script:InvariantCulture, [System.Globalization.DateTimeStyles]::RoundtripKind, [ref]$dateTimeOffset)) {
+        $shiftedOffset = $dateTimeOffset.AddDays($script:DateShiftDays)
+        if ($Value.EndsWith('Z', [System.StringComparison]::OrdinalIgnoreCase)) {
+            $shiftedValue = $shiftedOffset.UtcDateTime.ToString('yyyy-MM-ddTHH:mm:ss.fffffffZ', $script:InvariantCulture)
+        }
+        else {
+            $shiftedValue = $shiftedOffset.ToString('o', $script:InvariantCulture)
+        }
+    }
+    elseif ([datetime]::TryParse($Value, $script:InvariantCulture, [System.Globalization.DateTimeStyles]::AssumeUniversal, [ref]$dateTime)) {
+        $shiftedValue = $dateTime.ToUniversalTime().AddDays($script:DateShiftDays).ToString('yyyy-MM-ddTHH:mm:ss.fffffffZ', $script:InvariantCulture)
+    }
+
+    $script:ShiftedDateCache[$Value] = $shiftedValue
+    return $shiftedValue
+}
+
+function Shift-JsonLineDateFields {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseApprovedVerbs', '', Justification = 'Internal helper for rewriting JSON date fields during synthetic delta generation.')]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '', Justification = 'Internal helper accepts multiple field names by design.')]
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$JsonLine,
+
+        [Parameter(Mandatory = $true)]
+        [string[]]$FieldNames
+    )
+
+    $updatedLine = $JsonLine
+    foreach ($fieldName in $FieldNames) {
+        $originalValue = Get-JsonStringPropertyValue -JsonLine $updatedLine -PropertyName $fieldName
+        if ([string]::IsNullOrWhiteSpace($originalValue)) {
+            continue
+        }
+
+        $shiftedValue = Get-ShiftedDateValue -Value $originalValue
+        $originalAssignment = '"' + $fieldName + '":"' + $originalValue + '"'
+        $updatedAssignment = '"' + $fieldName + '":"' + $shiftedValue + '"'
+
+        if ($updatedLine.Contains($originalAssignment)) {
+            $updatedLine = $updatedLine.Replace($originalAssignment, $updatedAssignment)
+        }
+        else {
+            $pattern = '"' + [regex]::Escape($fieldName) + '"\s*:\s*"' + [regex]::Escape($originalValue) + '"'
+            $updatedLine = [regex]::Replace($updatedLine, $pattern, $updatedAssignment)
+        }
+    }
+
+    return $updatedLine
+}
+
+function Initialize-ReferenceMetadataLookup {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$ReferencePath
+    )
+
+    if ($null -ne $script:ReferenceDeviceMetadataByBaseId -and $null -ne $script:ReferenceGroupIdByGroupName) {
+        return
+    }
+
+    $script:ReferenceDeviceMetadataByBaseId = @{}
+    $script:ReferenceGroupIdByGroupName = @{}
+
+    if (-not (Test-Path -LiteralPath $ReferencePath -PathType Container)) {
+        return
+    }
+
+    $referenceFiles = @()
+    $referenceCurrentPath = Get-VulnCurrentPath -BasePath $ReferencePath
+    if (Test-Path -LiteralPath $referenceCurrentPath -PathType Leaf) {
+        $referenceFiles += $referenceCurrentPath
+    }
+
+    $referenceFiles += @(
+        Get-ChildItem -LiteralPath $ReferencePath -Filter 'VulnHistoryRows_*.json.gz' -File -ErrorAction SilentlyContinue |
+            Sort-Object -Property Name |
+            ForEach-Object { $_.FullName }
+    )
+
+    foreach ($referenceFile in $referenceFiles) {
+        foreach ($line in Read-VulnNdjsonLinesFromPath -Path $referenceFile) {
+            if ([string]::IsNullOrWhiteSpace($line)) {
+                continue
+            }
+
+            $row = $line | ConvertFrom-Json -Depth 20
+            $baseDeviceId = Get-SyntheticBaseDeviceId -DeviceId ([string]$row.DeviceId)
+            $groupName = [string]$row.RbacGroupName
+            $groupId = [string]$row.RbacGroupId
+            $osVersion = [string]$row.OSVersion
+
+            if (-not [string]::IsNullOrWhiteSpace($baseDeviceId)) {
+                if (-not $script:ReferenceDeviceMetadataByBaseId.ContainsKey($baseDeviceId)) {
+                    $script:ReferenceDeviceMetadataByBaseId[$baseDeviceId] = [ordered]@{
+                        GroupName = $groupName
+                        GroupId = $groupId
+                        OSVersion = $osVersion
+                    }
+                }
+                else {
+                    $metadata = $script:ReferenceDeviceMetadataByBaseId[$baseDeviceId]
+                    if ([string]::IsNullOrWhiteSpace([string]$metadata.GroupName) -and -not [string]::IsNullOrWhiteSpace($groupName)) {
+                        $metadata.GroupName = $groupName
+                    }
+                    if ([string]::IsNullOrWhiteSpace([string]$metadata.GroupId) -and -not [string]::IsNullOrWhiteSpace($groupId)) {
+                        $metadata.GroupId = $groupId
+                    }
+                    if ([string]::IsNullOrWhiteSpace([string]$metadata.OSVersion) -and -not [string]::IsNullOrWhiteSpace($osVersion)) {
+                        $metadata.OSVersion = $osVersion
+                    }
+                }
+            }
+
+            if (-not [string]::IsNullOrWhiteSpace($groupName) -and -not [string]::IsNullOrWhiteSpace($groupId) -and -not $script:ReferenceGroupIdByGroupName.ContainsKey($groupName)) {
+                $script:ReferenceGroupIdByGroupName[$groupName] = $groupId
+            }
+        }
+    }
+}
+
+function Resolve-ReferenceDeviceMetadata {
+    [CmdletBinding()]
+    [OutputType([hashtable])]
+    param(
+        [Parameter(Mandatory = $false)]
+        [AllowEmptyString()]
+        [string]$DeviceId,
+
+        [Parameter(Mandatory = $false)]
+        [AllowEmptyString()]
+        [string]$GroupName
+    )
+
+    $resolved = [ordered]@{
+        GroupId = ''
+        OSVersion = ''
+    }
+
+    $baseDeviceId = Get-SyntheticBaseDeviceId -DeviceId $DeviceId
+    if (-not [string]::IsNullOrWhiteSpace($baseDeviceId) -and $script:ReferenceDeviceMetadataByBaseId.ContainsKey($baseDeviceId)) {
+        $metadata = $script:ReferenceDeviceMetadataByBaseId[$baseDeviceId]
+        $resolved.GroupId = [string]$metadata.GroupId
+        $resolved.OSVersion = [string]$metadata.OSVersion
+    }
+
+    if ([string]::IsNullOrWhiteSpace([string]$resolved.GroupId) -and -not [string]::IsNullOrWhiteSpace($GroupName) -and $script:ReferenceGroupIdByGroupName.ContainsKey($GroupName)) {
+        $resolved.GroupId = [string]$script:ReferenceGroupIdByGroupName[$GroupName]
+    }
+
+    return $resolved
+}
+
+function Get-LegacySnapshotGroupIdFromJsonLine {
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$JsonLine
+    )
+
+    $match = [regex]::Match($JsonLine, '"RbacGroupId"\s*:\s*(?:(?:"(?<text>[^"]*)")|(?<number>-?\d+)|null)')
+    if (-not $match.Success) {
+        return '0'
+    }
+
+    $rawValue = if ($match.Groups['text'].Success) {
+        [string]$match.Groups['text'].Value
+    }
+    elseif ($match.Groups['number'].Success) {
+        [string]$match.Groups['number'].Value
+    }
+    else {
+        ''
+    }
+
+    if ([string]::IsNullOrWhiteSpace($rawValue)) {
+        return '0'
+    }
+
+    $trimmed = $rawValue.Trim()
+    if ($trimmed -match '^\d+$') {
+        return $trimmed
+    }
+
+    $digitMatch = [regex]::Match($trimmed, '\d+')
+    if ($digitMatch.Success) {
+        return [string]$digitMatch.Value
+    }
+
+    return '0'
+}
+
+function Invoke-CurrentSnapshotJsonLines {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '', Justification = 'Internal helper streams multiple current vulnerability JSON lines by design.')]
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$BasePath
+    )
+
+    $currentPath = Get-VulnCurrentPath -BasePath $BasePath
+    if (Test-Path -LiteralPath $currentPath -PathType Leaf) {
+        foreach ($line in Read-VulnNdjsonLinesFromPath -Path $currentPath) {
+            if ([string]::IsNullOrWhiteSpace($line)) {
+                continue
+            }
+
+            Write-Output $line
+        }
+
+        return
+    }
+
+    if (-not (Test-VulnContentStoreExistence -BasePath $BasePath)) {
+        throw "Current vulnerability export not found: $currentPath"
+    }
+
+    $currentRefsPath = Get-VulnCurrentRefsPath -BasePath $BasePath
+    if (-not (Test-Path -LiteralPath $currentRefsPath -PathType Leaf)) {
+        throw "Current vulnerability refs were not found: $currentRefsPath"
+    }
+
+    $dictionary = Read-VulnContentDictionary -Path (Get-VulnContentDictionaryPath -BasePath $BasePath)
+    foreach ($refLine in Read-VulnNdjsonLinesFromPath -Path $currentRefsPath) {
+        if ([string]::IsNullOrWhiteSpace($refLine)) {
+            continue
+        }
+
+        $ref = $refLine | ConvertFrom-Json -Depth 10
+        $device = $dictionary.deviceProfiles[[int]$ref[1]]
+        $content = $dictionary.contentTemplates[[int]$ref[2]]
+        $referenceMetadata = Resolve-ReferenceDeviceMetadata -DeviceId ([string]$device.id) -GroupName ([string]$device.g)
+        $row = [PSCustomObject]@{
+            Id = [string]$ref[0]
+            DeviceId = [string]$device.id
+            DeviceName = [string]$device.n
+            RbacGroupName = [string]$device.g
+            RbacGroupId = [string]$referenceMetadata.GroupId
+            OSPlatform = [string]$device.o
+            OSVersion = if (-not [string]::IsNullOrWhiteSpace([string]$device.ov)) { [string]$device.ov } else { [string]$referenceMetadata.OSVersion }
+            MachineTags = @($device.t)
+            CveId = [string]$content.c
+            SoftwareVendor = [string]$content.sv
+            SoftwareName = [string]$content.sn
+            SoftwareVersion = [string]$content.ver
+            VulnerabilitySeverityLevel = [string]$content.sev
+            CvssScore = $content.sc
+            ExploitabilityLevel = [string]$content.ex
+            RecommendationReference = [string]$content.rr
+            RecommendedSecurityUpdate = [string]$content.ru
+            RecommendedSecurityUpdateId = [string]$content.rid
+            RecommendedSecurityUpdateUrl = [string]$content.url
+            SecurityUpdateAvailable = ($content.ua -eq $true)
+            FirstSeenTimestamp = [string]$ref[3]
+            LastSeenTimestamp = [string]$ref[4]
+            DiskPaths = @($content.dp)
+            RegistryPaths = @($content.rp)
+            CveBatchTitle = [string]$content.bt
+            CveBatchUrl = [string]$content.bu
+            IsOnboarded = ($device.ob -eq $true)
+        }
+
+        Write-Output (ConvertTo-Json -InputObject $row -Compress -Depth 20)
+    }
+}
+
+function New-GzipWriterState {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '', Justification = 'Internal helper stages gzip output files for this synthetic delta generator.')]
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Path
+    )
+
+    $directoryPath = Split-Path -Path $Path -Parent
+    if (-not [string]::IsNullOrWhiteSpace($directoryPath) -and -not (Test-Path -LiteralPath $directoryPath)) {
+        $null = New-Item -Path $directoryPath -ItemType Directory -Force
+    }
+
+    $fileStream = [System.IO.File]::Create($Path)
+    $gzipStream = [System.IO.Compression.GZipStream]::new($fileStream, [System.IO.Compression.CompressionMode]::Compress)
+    $writer = [System.IO.StreamWriter]::new($gzipStream, [System.Text.UTF8Encoding]::new($false))
+    return [PSCustomObject]@{
+        Path = $Path
+        FileStream = $fileStream
+        GzipStream = $gzipStream
+        Writer = $writer
+        RowCount = 0
+    }
+}
+
+function Close-GzipWriterState {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $false)]
+        [AllowNull()]
+        $State
+    )
+
+    if ($null -eq $State) {
+        return
+    }
+
+    if ($State.Writer) {
+        $State.Writer.Dispose()
+        $State.Writer = $null
+    }
+    elseif ($State.GzipStream) {
+        $State.GzipStream.Dispose()
+        $State.GzipStream = $null
+    }
+    elseif ($State.FileStream) {
+        $State.FileStream.Dispose()
+        $State.FileStream = $null
+    }
+}
+
+function Get-SnapshotWriterState {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [hashtable]$WritersByGroup,
+
+        [Parameter(Mandatory = $true)]
+        [string]$OutputRoot,
+
+        [Parameter(Mandatory = $true)]
+        [string]$SnapshotDate,
+
+        [Parameter(Mandatory = $true)]
+        [string]$GroupId
+    )
+
+    if (-not $WritersByGroup.ContainsKey($GroupId)) {
+        $path = Join-Path -Path $OutputRoot -ChildPath ('VulnExport_{0}_{1}.json.gz' -f $GroupId, $SnapshotDate)
+        $WritersByGroup[$GroupId] = New-GzipWriterState -Path $path
+    }
+
+    return $WritersByGroup[$GroupId]
+}
+
+function Close-SnapshotWriterStates {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '', Justification = 'Internal helper closes all tracked gzip writer states.')]
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [hashtable]$WritersByGroup
+    )
+
+    foreach ($groupId in @($WritersByGroup.Keys)) {
+        Close-GzipWriterState -State $WritersByGroup[$groupId]
+    }
+}
+
+function Copy-OrLinkFile {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '', Justification = 'Internal helper stages a read-only overlay dataset by linking or copying unchanged files.')]
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$SourceFilePath,
+
+        [Parameter(Mandatory = $true)]
+        [string]$DestinationFilePath,
+
+        [Parameter(Mandatory = $true)]
+        [bool]$CopyOnly,
+
+        [Parameter(Mandatory = $true)]
+        [ref]$LinkedFileCount,
+
+        [Parameter(Mandatory = $true)]
+        [ref]$CopiedFileCount
+    )
+
+    $destinationDirectory = Split-Path -Path $DestinationFilePath -Parent
+    if (-not [string]::IsNullOrWhiteSpace($destinationDirectory) -and -not (Test-Path -LiteralPath $destinationDirectory)) {
+        $null = New-Item -Path $destinationDirectory -ItemType Directory -Force
+    }
+
+    if (Test-Path -LiteralPath $DestinationFilePath -PathType Leaf) {
+        Remove-Item -LiteralPath $DestinationFilePath -Force -ErrorAction SilentlyContinue
+    }
+
+    $linked = $false
+    if ((-not $CopyOnly) -and $IsWindows) {
+        $sourceRoot = [System.IO.Path]::GetPathRoot([System.IO.Path]::GetFullPath($SourceFilePath))
+        $destinationRoot = [System.IO.Path]::GetPathRoot([System.IO.Path]::GetFullPath($DestinationFilePath))
+        if ([System.StringComparer]::OrdinalIgnoreCase.Equals($sourceRoot, $destinationRoot)) {
+            try {
+                $null = New-Item -ItemType HardLink -Path $DestinationFilePath -Target $SourceFilePath -ErrorAction Stop
+                $linked = $true
+            }
+            catch {
+                $linked = $false
+            }
+        }
+    }
+
+    if ($linked) {
+        $LinkedFileCount.Value++
+        return
+    }
+
+    Copy-Item -LiteralPath $SourceFilePath -Destination $DestinationFilePath -Force
+    $CopiedFileCount.Value++
+}
+
+$resolvedSourcePath = [System.IO.Path]::GetFullPath($SourcePath)
+$resolvedOutputPath = [System.IO.Path]::GetFullPath($OutputPath)
+$resolvedTargetLatestDate = Convert-ToYmdDate -DateValue $TargetLatestDate
+
+if (-not (Test-Path -LiteralPath $resolvedSourcePath -PathType Container)) {
+    throw "Source path not found: $resolvedSourcePath"
+}
+
+if ([string]::IsNullOrWhiteSpace($resolvedTargetLatestDate)) {
+    throw "Unable to parse TargetLatestDate '$TargetLatestDate' as yyyy-MM-dd."
+}
+
+if (Test-EquivalentPath -Left $resolvedSourcePath -Right $resolvedOutputPath) {
+    throw 'OutputPath must differ from SourcePath.'
+}
+
+if (Test-Path -LiteralPath $resolvedOutputPath) {
+    if (-not $Force) {
+        throw "Output path already exists: $resolvedOutputPath"
+    }
+
+    Remove-Item -LiteralPath $resolvedOutputPath -Recurse -Force -ErrorAction SilentlyContinue
+}
+
+$null = New-Item -Path $resolvedOutputPath -ItemType Directory -Force
+
+$sourceManifestPath = Join-Path $resolvedSourcePath 'synthetic-manifest.json'
+$sourceManifest = if (Test-Path -LiteralPath $sourceManifestPath -PathType Leaf) {
+    Get-Content -LiteralPath $sourceManifestPath -Raw | ConvertFrom-Json -Depth 20
+}
+else {
+    $null
+}
+
+$sourceMachinePath = Get-MachineCurrentPath -BasePath $resolvedSourcePath
+$sourceAdvancedHuntingPath = Get-AdvancedHuntingCurrentPath -BasePath $resolvedSourcePath
+$referencePath = Join-Path $repoRoot 'exports'
+
+Initialize-ReferenceMetadataLookup -ReferencePath $referencePath
+
+if (-not (Test-Path -LiteralPath $sourceMachinePath -PathType Leaf)) {
+    throw "Machine export not found: $sourceMachinePath"
+}
+
+$sourceLatestDate = Get-VulnStoreLatestSnapshotDate -BasePath $resolvedSourcePath
+if ([string]::IsNullOrWhiteSpace($sourceLatestDate)) {
+    throw "Unable to determine the latest vulnerability snapshot date in '$resolvedSourcePath'."
+}
+
+$script:DateShiftDays = [int](New-TimeSpan -Start ([datetime]$sourceLatestDate) -End ([datetime]$resolvedTargetLatestDate)).TotalDays
+if ($script:DateShiftDays -le 0) {
+    throw "TargetLatestDate '$resolvedTargetLatestDate' must be later than the source latest date '$sourceLatestDate' to create a synthetic delta snapshot."
+}
+
+$linkedFileCount = 0
+$copiedFileCount = 0
+$seedFileNames = @(
+    Get-ChildItem -LiteralPath $resolvedSourcePath -File |
+        Where-Object {
+            $_.Name -match '\.json(\.gz)?$' -and
+            $_.Name -notin @(
+                '.synthetic-progress.json',
+                '.synthetic-progress.json.gz',
+                'stress-validation-report.json',
+                'stress-validation-report.json.gz',
+                'synthetic-manifest.json',
+                'benchmark-dataset.json',
+                (Split-Path -Path $sourceMachinePath -Leaf)
+            ) -and
+            (-not (Test-IsLegacyVulnSnapshotFileName -Name $_.Name))
+        } |
+        Sort-Object -Property Name
+)
+
+foreach ($file in $seedFileNames) {
+    Copy-OrLinkFile `
+        -SourceFilePath $file.FullName `
+        -DestinationFilePath (Join-Path $resolvedOutputPath $file.Name) `
+        -CopyOnly ($CopyOnly -eq $true) `
+        -LinkedFileCount ([ref]$linkedFileCount) `
+        -CopiedFileCount ([ref]$copiedFileCount)
+}
+
+Write-Host ('Source latest date: {0}' -f $sourceLatestDate)
+Write-Host ('Target latest date: {0}' -f $resolvedTargetLatestDate)
+Write-Host ('Creating synthetic delta snapshot: +{0} day(s)' -f $script:DateShiftDays)
+
+$machineWriter = $null
+$machineCount = 0
+try {
+    Write-Host 'Shifting machine current snapshot...'
+    $machineWriter = New-GzipWriterState -Path (Get-MachineCurrentPath -BasePath $resolvedOutputPath)
+    foreach ($line in Read-VulnNdjsonLinesFromPath -Path $sourceMachinePath) {
+        if ([string]::IsNullOrWhiteSpace($line)) {
+            continue
+        }
+
+        $shiftedMachineLine = Shift-JsonLineDateFields -JsonLine $line -FieldNames @('firstSeen', 'lastSeen', 'observedOn')
+        $machineDeviceId = Get-JsonStringPropertyValue -JsonLine $shiftedMachineLine -PropertyName 'id'
+        $machineGroupName = Get-JsonStringPropertyValue -JsonLine $shiftedMachineLine -PropertyName 'rbacGroupName'
+        $machineOsVersion = Get-JsonStringPropertyValue -JsonLine $shiftedMachineLine -PropertyName 'osVersion'
+        if ([string]::IsNullOrWhiteSpace($machineOsVersion)) {
+            $referenceMetadata = Resolve-ReferenceDeviceMetadata -DeviceId $machineDeviceId -GroupName $machineGroupName
+            if (-not [string]::IsNullOrWhiteSpace([string]$referenceMetadata.OSVersion)) {
+                $pattern = '"osVersion"\s*:\s*(?:null|"")'
+                $replacement = '"osVersion":"' + [string]$referenceMetadata.OSVersion + '"'
+                $shiftedMachineLine = [regex]::Replace($shiftedMachineLine, $pattern, $replacement, 1)
+            }
+        }
+
+        $machineWriter.Writer.WriteLine($shiftedMachineLine)
+        $machineCount++
+    }
+}
+finally {
+    Close-GzipWriterState -State $machineWriter
+}
+
+$snapshotWriterStates = @{}
+$deltaRowCount = 0
+try {
+    Write-Host 'Writing legacy vulnerability snapshot delta files...'
+    foreach ($line in Invoke-CurrentSnapshotJsonLines -BasePath $resolvedSourcePath) {
+        $shiftedLine = Shift-JsonLineDateFields -JsonLine $line -FieldNames @('FirstSeenTimestamp', 'LastSeenTimestamp')
+        $groupId = Get-LegacySnapshotGroupIdFromJsonLine -JsonLine $shiftedLine
+        $writerState = Get-SnapshotWriterState -WritersByGroup $snapshotWriterStates -OutputRoot $resolvedOutputPath -SnapshotDate $resolvedTargetLatestDate -GroupId $groupId
+        $writerState.Writer.WriteLine($shiftedLine)
+        $writerState.RowCount++
+        $deltaRowCount++
+    }
+}
+finally {
+    Close-SnapshotWriterStates -WritersByGroup $snapshotWriterStates
+}
+
+if ($deltaRowCount -le 0) {
+    throw 'The source current vulnerability store contained no rows to project into a synthetic delta snapshot.'
+}
+
+$deltaSnapshotFiles = @(
+    Get-ChildItem -LiteralPath $resolvedOutputPath -Filter ('VulnExport_*_{0}.json.gz' -f $resolvedTargetLatestDate) -File -ErrorAction SilentlyContinue |
+        Sort-Object -Property Name |
+        ForEach-Object { $_.Name }
+)
+
+$manifest = [ordered]@{
+    preset = 'SyntheticSnapshotDelta'
+    generatedOnUtc = [datetime]::UtcNow.ToString('o')
+    sourcePath = $resolvedSourcePath
+    outputPath = $resolvedOutputPath
+    sourcePreset = if ($null -ne $sourceManifest -and $sourceManifest.PSObject.Properties['preset']) { [string]$sourceManifest.preset } else { $null }
+    sourceSeed = if ($null -ne $sourceManifest -and $sourceManifest.PSObject.Properties['seed']) { $sourceManifest.seed } else { $null }
+    sourceGeneratedOnUtc = if ($null -ne $sourceManifest -and $sourceManifest.PSObject.Properties['generatedOnUtc']) { [string]$sourceManifest.generatedOnUtc } else { $null }
+    sourceLatestDate = $sourceLatestDate
+    targetLatestDate = $resolvedTargetLatestDate
+    dateShiftDays = $script:DateShiftDays
+    deltaSnapshotDate = $resolvedTargetLatestDate
+    deltaSnapshotFiles = $deltaSnapshotFiles
+    deltaSnapshotRows = $deltaRowCount
+    snapshotGroupCount = $deltaSnapshotFiles.Count
+    actualDeviceCount = $machineCount
+    actualCurrentRows = if ($null -ne $sourceManifest -and $sourceManifest.PSObject.Properties['actualCurrentRows']) { [int]$sourceManifest.actualCurrentRows } else { $deltaRowCount }
+    actualHistoryRows = if ($null -ne $sourceManifest -and $sourceManifest.PSObject.Properties['actualHistoryRows']) { [int]$sourceManifest.actualHistoryRows } else { 0 }
+    actualTotalVulnRows = if ($null -ne $sourceManifest -and $sourceManifest.PSObject.Properties['actualTotalVulnRows']) { [int]$sourceManifest.actualTotalVulnRows } else { $deltaRowCount }
+    targetDeviceCount = if ($null -ne $sourceManifest -and $sourceManifest.PSObject.Properties['targetDeviceCount']) { [int]$sourceManifest.targetDeviceCount } else { $machineCount }
+    targetTotalVulnRows = if ($null -ne $sourceManifest -and $sourceManifest.PSObject.Properties['targetTotalVulnRows']) { [int]$sourceManifest.targetTotalVulnRows } else { $deltaRowCount }
+    hardLinkedSeedFiles = $linkedFileCount
+    copiedSeedFiles = $copiedFileCount
+    contentStoreReady = (Test-VulnContentStoreExistence -BasePath $resolvedOutputPath)
+    advancedHuntingCopied = (Test-Path -LiteralPath (Join-Path $resolvedOutputPath (Split-Path -Path $sourceAdvancedHuntingPath -Leaf)) -PathType Leaf)
+}
+
+$manifest | ConvertTo-Json -Depth 10 | Set-Content -LiteralPath (Join-Path $resolvedOutputPath 'synthetic-manifest.json') -Encoding utf8
+
+Write-Host ''
+Write-Host ('Synthetic delta overlay created at: {0}' -f $resolvedOutputPath) -ForegroundColor Green
+Write-Host ('  Seed files: {0} hard-linked, {1} copied' -f $linkedFileCount, $copiedFileCount)
+Write-Host ('  Shifted machine rows: {0}' -f $machineCount)
+Write-Host ('  Delta snapshot rows: {0}' -f $deltaRowCount)
+Write-Host ('  Delta snapshot files: {0}' -f ($deltaSnapshotFiles -join ', '))

--- a/tests/README.md
+++ b/tests/README.md
@@ -225,6 +225,32 @@ That dataset definition currently maps to:
 - seed: `20260322`
 - output path: `.local\benchmark-datasets\benchmark-medium-v1`
 
+For the larger reusable Azure stress seed, materialize or register the existing 50k-device dataset with:
+
+```powershell
+pwsh -NoProfile -File .\tests\New-BenchmarkDataset.ps1 -DatasetId benchmark-large-50k-v1
+```
+
+That dataset definition maps to:
+- dataset id: `benchmark-large-50k-v1`
+- preset: `BalancedMediumHeavy`
+- target devices: `50,000`
+- target vulnerability rows: `1,500,000`
+- seed: `20260322`
+- output path: `.local\large-datasets\synthetic-50k-1_5m`
+
+When you want to keep the large seed current and exercise the vulnerability-store merge path without regenerating 1.5M rows, create a shifted current-snapshot delta overlay with:
+
+```powershell
+pwsh -NoProfile -File .\tests\New-SyntheticSnapshotDelta.ps1 -SourcePath .\.local\large-datasets\synthetic-50k-1_5m -OutputPath .\.local\large-datasets\synthetic-50k-1_5m-delta-<date> -TargetLatestDate <yyyy-MM-dd>
+```
+
+That command:
+- reuses the large canonical store as the base seed instead of rebuilding it
+- writes a fresh `Machines_Current.json.gz` with shifted observation dates
+- writes a new `VulnExport_<group>_<date>.json.gz` snapshot representing the next full bulk export date
+- is intended for Azure replay paths that merge incoming snapshots into the existing canonical store
+
 Capture a repeatable multi-run benchmark series against the standard dataset with:
 
 ```powershell
@@ -259,5 +285,6 @@ Recommendations:
 - keep raw benchmark outputs under `.local/`
 - use `.local\benchmark-history\benchmark-history.jsonl` plus `.local\benchmark-history\latest-summary.md` for repeated review and Azure acceptance captures that you want to compare over time
 - prefer `benchmark-medium-v1` plus `Invoke-BenchmarkSeries.ps1` when you need the durable, merge-tracked benchmark cadence instead of an ad hoc review capture
+- prefer `benchmark-large-50k-v1` plus `New-SyntheticSnapshotDelta.ps1` when you need a reusable large Azure seed with a fresh incoming snapshot date
 - use the staged local copy behavior in `Measure-BranchVsMainBenchmark.ps1` when benchmarking raw datasets without sidecars
 - use `docs/performance-baselines.md` only for accepted durable datasets that should remain merge-tracked as baseline documentation

--- a/tests/Run-SharedHelperRegression.ps1
+++ b/tests/Run-SharedHelperRegression.ps1
@@ -437,6 +437,49 @@ function Test-BulkSnapshotImportMultipartSnapshot {
     }
 }
 
+function Test-BulkSnapshotImportMergesIntoExistingCanonicalStore {
+    [CmdletBinding()]
+    param()
+
+    $tempRoot = Join-Path ([System.IO.Path]::GetTempPath()) ('bulk-snapshot-import-existing-store-' + [guid]::NewGuid().ToString('N'))
+    [void](New-Item -Path $tempRoot -ItemType Directory -Force)
+
+    try {
+        $initialSnapshotPath = Join-Path $tempRoot 'VulnExport_1_2026-01-01.json'
+        $initialRows = @(
+            (Get-TestVulnRow -Id 'merge-001' -CveId 'CVE-2026-2001' -SnapshotDate '2026-01-01' -Version '1.0.0')
+        )
+        [System.IO.File]::WriteAllLines($initialSnapshotPath, @($initialRows | ForEach-Object { $_ | ConvertTo-Json -Compress -Depth 8 }), [System.Text.UTF8Encoding]::new($false))
+
+        $null = Publish-VulnStoreFromBulkSnapshot -BasePath $tempRoot -RemoveSnapshotFiles
+
+        $deltaSnapshotPath = Join-Path $tempRoot 'VulnExport_1_2026-01-02.json'
+        $deltaRows = @(
+            (Get-TestVulnRow -Id 'merge-001' -CveId 'CVE-2026-2001' -SnapshotDate '2026-01-02' -Version '1.0.0')
+            (Get-TestVulnRow -Id 'merge-002' -CveId 'CVE-2026-2002' -SnapshotDate '2026-01-02' -Version '2.0.0')
+        )
+        [System.IO.File]::WriteAllLines($deltaSnapshotPath, @($deltaRows | ForEach-Object { $_ | ConvertTo-Json -Compress -Depth 8 }), [System.Text.UTF8Encoding]::new($false))
+
+        $publishResult = Publish-VulnStoreFromBulkSnapshot -BasePath $tempRoot -RemoveSnapshotFiles
+        $storeRows = @(Read-VulnStoreRow -BasePath $tempRoot)
+        $storeIds = @($storeRows | ForEach-Object { [string](Get-VulnPropertyValue -InputObject $_ -Name 'Id') })
+
+        Assert-True ((Test-Path -LiteralPath (Get-VulnCurrentPath -BasePath $tempRoot) -PathType Leaf)) 'Canonical vuln current file was not preserved when merging into an existing store.'
+        Assert-True (@(Get-ChildItem -Path $tempRoot -Filter 'VulnHistory_*.json.gz' -File -ErrorAction SilentlyContinue).Count -eq 0) 'Merging an unchanged carry-forward snapshot into an existing store should not create history.'
+        Assert-True (@(Get-VulnLegacySnapshotFile -BasePath $tempRoot).Count -eq 0) 'Delta vulnerability snapshots were not removed after merging into an existing store.'
+        Assert-True ($publishResult.CurrentRows -eq 2) 'Expected the existing canonical store merge to retain both current rows from the latest snapshot.'
+        Assert-True ($publishResult.HistoryYears -eq 0) 'Expected the existing canonical store merge to avoid creating history when rows are only carried forward or added.'
+        Assert-True ([string]$publishResult.LatestSnapshotDate -eq '2026-01-02') 'Expected the existing canonical store merge to advance the latest snapshot date.'
+        Assert-True ($storeRows.Count -eq 2) 'Expected the merged existing store to expose exactly the carried-forward and newly added current rows.'
+        Assert-True (('merge-001' -in $storeIds) -and ('merge-002' -in $storeIds)) 'Expected the merged existing store to retain the original row and add the new row.'
+    }
+    finally {
+        if (Test-Path -LiteralPath $tempRoot) {
+            Remove-Item -LiteralPath $tempRoot -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+}
+
 function Test-HttpRetryDelayHelperBehavior {
     [CmdletBinding()]
     param()
@@ -2811,6 +2854,8 @@ Test-BulkSnapshotImportSingleSnapshot
 Write-Output '  Single-snapshot vulnerability import checks passed.'
 Test-BulkSnapshotImportMultipartSnapshot
 Write-Output '  Multipart vulnerability import checks passed.'
+Test-BulkSnapshotImportMergesIntoExistingCanonicalStore
+Write-Output '  Existing-store vulnerability merge checks passed.'
 Test-HttpRetryDelayHelperBehavior
 Write-Output '  Retry delay helper checks passed.'
 Test-WebRequestWithRetryTransientTransportBehavior

--- a/tests/benchmark-datasets.json
+++ b/tests/benchmark-datasets.json
@@ -12,5 +12,19 @@
       "benchmark-medium-v1",
       "durable-baseline"
     ]
+  },
+  {
+    "id": "benchmark-large-50k-v1",
+    "description": "Durable large benchmark seed dataset for Azure replay and delta-snapshot validation.",
+    "preset": "BalancedMediumHeavy",
+    "seed": 20260322,
+    "targetDeviceCount": 50000,
+    "targetTotalVulnRows": 1500000,
+    "sourceRelativePath": "exports",
+    "outputRelativePath": ".local/large-datasets/synthetic-50k-1_5m",
+    "historyTags": [
+      "benchmark-large-50k-v1",
+      "large-seed"
+    ]
   }
 ]


### PR DESCRIPTION
## Summary
This PR tightens remediation grouping in the dashboard and hardens the large Azure replay workflow used to validate hosted runs.

## What changed
- refine remediation grouping so Windows versions are split more accurately in the dashboard output
- update the Azure replay pipeline to merge incoming legacy VulnExport snapshots even when a canonical store already exists
- add a reusable large benchmark dataset definition and a delta-overlay generator for replaying fresh snapshot dates without rebuilding the full dataset
- preserve OS version metadata in future synthetic seed generation and backfill missing OS version and RBAC group metadata during large-seed delta overlay generation
- add regression coverage for merging new snapshots into an existing canonical vulnerability store
- document the large-seed and delta-overlay workflow in repo docs

## Validation
- ran `pwsh -NoProfile -File .\tests\Run-SharedHelperRegression.ps1`
- ran `pwsh -NoProfile -File .\build\Invoke-RegressionValidation.ps1`
- validated Azure Automation and Function App replay against the large delta overlay in the primary hosted environment
- verified the repaired large-seed delta overlay emits `VulnExport_131_*`, `VulnExport_341_*`, and `VulnExport_343_*` with restored OS version data

## Notes
- `AGENTS.md` was intentionally left out of the PR
- local `.local` benchmark seeds and overlays remain untracked and are not included in this PR