### PR TITLE
Optimize dashboard validation and remediation reporting

### DIFF
--- a/DASHBOARD_OPTIMIZATION_WORKING.md
+++ b/DASHBOARD_OPTIMIZATION_WORKING.md
@@ -1,0 +1,520 @@
+﻿# Dashboard Optimization Working Plan
+
+Last updated: 2026-04-25
+Status: Item 1 completed and validated; large-result modal stability, devices-by-remediation density, and impact-analysis data-path slices implemented; deterministic preflight, large-dataset artifact replay, live dry run, Edge inspection, and final large-dataset semantic replay all passed
+
+## Goals
+
+- Reduce large-dataset dashboard time-to-usable and report-switch latency for both hosted and self-contained packaging.
+- Preserve dashboard semantics and visible structure across all five report modes.
+- Capture repeatable validation and perf evidence after every implementation slice.
+
+## Review Outcomes Applied
+
+- Item 1 now explicitly owns the telemetry contract and the first round of browser-level invariant validation.
+- Item ordering has been adjusted so worker-oriented filter preparation happens before generator-side precomputed aggregates, and card virtualization happens after those data-shape changes settle.
+- Success criteria now use explicit outputs or measurable targets instead of qualitative language only.
+- Validation gates now distinguish between always-on checks and the new checks that Item 1 must add before later slices proceed.
+
+## Baseline
+
+Dataset baseline:
+
+- 50,000 devices
+- 1,500,000 vulnerability rows
+- 3,097 CVEs
+
+Browser baseline from Edge local artifact profiling:
+
+| Metric | Hosted split-assets | Self-contained |
+| --- | ---: | ---: |
+| Init total | 3.97 s | 3.57 s |
+| LCP | 11.10 s | 5.88 s |
+| Long-task total | 9.55 s | 9.31 s |
+| Max long task | 3.46 s | 3.53 s |
+| JS heap used | 679.45 MB | 679.42 MB |
+| DOM nodes | 997,558 | 997,562 |
+| Devices by remediation first open | 4.42 s | 4.38 s |
+| Remediations by device first open | 1.91 s | 1.75 s |
+
+## Invariants To Preserve
+
+The dashboard is not considered valid after a change unless these remain present and functional:
+
+- Main heading, report selector, and Export to PDF button.
+- Summary cards for Critical, High, Medium, and Low counts.
+- Filter bar controls for Date, Device Groups, Device Tags, Platform, Severity, Device, and Clear All.
+- Report selector options for Active Vulnerabilities, Remediation Activity, Impact Analysis, Devices by Remediation, and Remediations by Device.
+- Active Vulnerabilities table with Vendor, Software, Remediation, Update Details, Assets, Vulnerabilities, Exploits, and Kits columns.
+- Remediation Activity report chart and details table.
+- Impact Analysis chart and table.
+- Devices by Remediation card view.
+- Remediations by Device card view.
+
+## Validation Gate After Every Item
+
+From Item 2 onward, every slice must pass the iterative gate below before the next change starts. The expensive semantic replay now moves to milestone or pre-commit local sign-off instead of every small slice.
+
+1. Deterministic preflight:
+
+   `pwsh -NoProfile -File .\build\Invoke-RegressionValidation.ps1`
+
+2. Targeted dashboard regression scripts relevant to the touched slice.
+
+3. Large-dataset packaging and artifact-parity replay:
+
+   `pwsh -NoProfile -File .\tests\Invoke-LargeDatasetValidation.ps1 -SkipSyntheticGeneration -SyntheticOutputPath .\.local\large-datasets\synthetic-50k-1_5m -Validate -ValidationMode artifacts`
+
+4. Performance regression comparison against a checked-in baseline for the large dataset.
+
+5. Dual-package asset and parity checks when packaging or browser-runtime assets are touched.
+
+6. Browser invariant validation against both hosted and self-contained generated outputs.
+
+7. Manual visual verification only when the slice changes CSS, layout, or report presentation.
+
+8. Record outcome, validation status, and metric deltas in this document before starting the next slice.
+
+Milestone or pre-commit local sign-off:
+
+- `pwsh -NoProfile -File .\tests\Invoke-LargeDatasetValidation.ps1 -SkipSyntheticGeneration -SyntheticOutputPath .\.local\large-datasets\synthetic-50k-1_5m -Validate -ValidationMode semantic`
+
+## Item 1 Telemetry Contract
+
+Item 1 must establish the minimum client-side observability contract used by later work:
+
+- `window.dashboardMetrics` object with numeric millisecond values for `loadDataMs`, `denormalizeMs`, `applyFiltersMs`, `initTotalMs`, and per-report render timings.
+- `window.dashboardValidation` object with the current `activeReportId`, summary-card values, available report ids, and a compact element/invariant snapshot.
+- `dashboard-ready` browser event fired after initialization and first filter application settle.
+- No reliance on console output as the only machine-readable perf source after Item 1.
+
+## Implementation Order
+
+### Item 1: Structured telemetry and validation foundation
+
+Status: Completed
+
+Objective:
+
+- Emit structured client-side timings and readiness markers instead of relying only on console timers.
+- Add repo-local automated checks for invariant elements, browser readiness, and package-asset correctness.
+
+Why first:
+
+- Later performance changes need better measurements, parity checks, and repeatable page verification.
+
+Likely files:
+
+- `templates/dashboard.js`
+- `tests/helpers/dashboard-test-harness.js`
+- `tests/` validation entrypoints
+- optional `build/` validation helpers if asset checks fit better there
+
+Success criteria:
+
+- Generated dashboards expose `window.dashboardMetrics` and `window.dashboardValidation` using the contract above.
+- Hosted and self-contained generated outputs can be checked automatically for invariant elements.
+- Asset-path validation exists for split-assets output.
+- This item adds the automated checks required before Item 2 can begin.
+
+### Priority Insert: Large-result remediation modal stability fallback
+
+Status: In progress
+
+Objective:
+
+- Prevent large remediation detail drills from locking the browser when the grouped modal layout degenerates into thousands of per-device sections.
+- Preserve modal semantics while switching large result sets to a dense virtualized layout.
+
+Why inserted here:
+
+- Live Edge repro on the hosted dashboard showed the Windows 11 April 2026 remediation row taking about 229 seconds to open.
+- The modal path created 16,594 tables, 16,594 device-bubble groups, and about 3.25 million DOM nodes for that single interaction.
+
+Likely files:
+
+- `templates/dashboard.js`
+- `tests/Assert-DashboardModalResponsiveness.js`
+
+Success criteria:
+
+- Large remediation detail sets stop building one virtualized table per CVE-signature group.
+- The same Edge repro opens the modal in under 1 second on the local hosted artifact built from the live payload snapshot.
+- Deterministic regression validation passes with the new modal fallback path.
+
+### Priority Insert: Devices-by-remediation card density guard
+
+Status: In progress
+
+Objective:
+
+- Prevent the devices-by-remediation report from inflating the DOM by rendering every device row for the largest remediation cards.
+- Preserve access to the full device list in both hosted and self-contained packaging without regressing PDF export.
+
+Why inserted here:
+
+- After the modal fix, Edge profiling still showed the devices-by-remediation report adding about 972,329 DOM nodes and 64,924 table rows across the first 20 cards.
+- The worst card was still trying to materialize more than 11,000 device rows inside a single remediation card.
+
+Likely files:
+
+- `templates/dashboard.js`
+- `templates/dashboard.css`
+
+Success criteria:
+
+- Oversized devices-by-remediation cards render bounded virtualized device tables during normal interactive browsing.
+- The regenerated hosted and self-contained artifacts both keep the report under 10,000 added DOM nodes on the first 20 cards.
+- PDF export still forces a full-row render path before capture.
+
+### Item 2: Explicit empty states and layout-stability guards
+
+Status: Planned
+
+Objective:
+
+- Make zero-result or filtered-empty reports unambiguous.
+- Reserve space or otherwise reduce avoidable layout shift in heavy sections.
+
+Likely files:
+
+- `templates/dashboard.html`
+- `templates/dashboard.css`
+- `templates/dashboard.js`
+
+Success criteria:
+
+- Every report can distinguish between loading, empty result, and rendered result states.
+- No heavy report section appears blank without explanatory copy.
+- Layout-shift score improves versus the current large-dataset baseline in both package modes.
+
+### Item 3: Move filter and report preparation further off the main thread
+
+Status: Planned
+
+Objective:
+
+- Shift expensive filtering, grouping, and report-preparation work away from the UI thread where possible.
+- Reduce long tasks during initialization and report switching.
+
+Likely files:
+
+- `templates/dashboard.js`
+- any new worker-side helper assets required by the current packaging model
+
+Success criteria:
+
+- Large-dataset long-task total falls below 7 seconds in local Edge profiling.
+- Largest single long task falls below 2.5 seconds.
+- Switching between reports remains semantically identical under validation.
+
+### Item 4: Precompute browser-ready aggregates during generation
+
+Status: Planned
+
+Objective:
+
+- Push more normalization and aggregate shaping into generation so the browser consumes prepared structures instead of rebuilding them at load time.
+
+Likely files:
+
+- `src/powershell/Shared/Dashboard/DashboardGeneration.ps1`
+- `Generate-VulnerabilityDashboard.ps1`
+- `templates/dashboard.js`
+
+Success criteria:
+
+- Large-dataset denormalization time drops by at least 40 percent from the current baseline.
+- Cache versioning or invalidation is updated so old normalized artifacts cannot be misread as the new payload shape.
+- Browser payload remains semantically equivalent under validation.
+
+### Item 5: Card-report virtualization and DOM reduction
+
+Status: Planned
+
+Objective:
+
+- Replace the current batch-only strategy with true viewport-aware virtualization for card-heavy reports.
+- Reduce live DOM node count and first-open latency for Devices by Remediation and Remediations by Device.
+
+Likely files:
+
+- `templates/dashboard.js`
+- `templates/dashboard.css`
+- targeted dashboard tests
+
+Success criteria:
+
+- Devices by Remediation first-open time falls below 1.5 seconds on the large dataset.
+- Remediations by Device first-open time falls below 1.0 second on the large dataset.
+- Live DOM node count falls below 300,000 after both card reports have been visited.
+
+### Item 6: Repeatable hosted profiling lane
+
+Status: Planned
+
+Objective:
+
+- Turn the ad hoc Edge profiling work into a supported repo workflow for hosted and local artifacts.
+- Allow future optimization work to compare like-for-like runs without rebuilding temporary tools.
+
+Likely files:
+
+- `tests/` profiling entrypoints
+- optional helper scripts under `build/` or `tests/manual/`
+- documentation if needed
+
+Success criteria:
+
+- The repo contains a documented, repeatable profiling path for hosted and self-contained artifacts.
+- Hosted profiling explicitly documents the auth or session prerequisite instead of failing opaquely.
+
+   - confirm the invariant element checklist above
+   - switch across all five reports
+   - confirm the dashboard reaches ready state
+   - compare summary-card counts against the baseline dataset expectations for the run
+
+6. Record outcome, validation status, and any metric deltas in this document before starting the next slice.
+
+## Implementation Order
+
+### Item 1: Structured telemetry and repeatable browser validation
+
+Status: Planned
+
+Objective:
+
+- Emit structured client-side timings and readiness markers instead of relying only on console timers.
+- Add a repo-local validation harness that can assert the required dashboard elements on generated hosted and self-contained artifacts.
+
+Why first:
+
+- Later performance changes need better measurements and a stable page-check lane.
+
+Likely files:
+
+- `templates/dashboard.js`
+- `tests/helpers/dashboard-test-harness.js`
+- `tests/` browser or validation entrypoints
+
+Success criteria:
+
+- Generated dashboard exposes structured telemetry for init, load, denormalization, filter application, and report rendering.
+- A repeatable validation script can verify core elements across both packaging modes.
+
+### Item 2: Explicit empty states and layout-stability guards
+
+Status: Planned
+
+Objective:
+
+- Make zero-result or filtered-empty reports unambiguous.
+- Reserve space or otherwise reduce avoidable layout shift in heavy sections.
+
+Likely files:
+
+- `templates/dashboard.html`
+- `templates/dashboard.css`
+- `templates/dashboard.js`
+
+Success criteria:
+
+- Empty reports explain whether the filter window or dataset produced zero rows.
+- Layout shift drops measurably during first load and report switching.
+
+### Item 3: Card-report virtualization and DOM reduction
+
+Status: Planned
+
+Objective:
+
+- Replace the current batch-only strategy with true viewport-aware virtualization for card-heavy reports.
+- Reduce live DOM node count and first-open latency for Devices by Remediation and Remediations by Device.
+
+Likely files:
+
+- `templates/dashboard.js`
+- `templates/dashboard.css`
+- targeted dashboard tests
+
+Success criteria:
+
+- Card-report first-open time improves materially.
+- Live DOM node count drops substantially from the current baseline.
+
+### Item 4: Move filter and report preparation further off the main thread
+
+Status: Planned
+
+Objective:
+
+- Shift expensive filtering, grouping, and report-preparation work away from the UI thread where possible.
+- Reduce long tasks during initialization and report switching.
+
+Likely files:
+
+- `templates/dashboard.js`
+- any new worker-side helper assets required by the current packaging model
+
+Success criteria:
+
+- Long-task total and max long task improve on the large dataset.
+- Switching between reports remains semantically identical.
+
+### Item 5: Precompute browser-ready aggregates during generation
+
+Status: Planned
+
+Objective:
+
+- Push more normalization and aggregate shaping into generation so the browser consumes prepared structures instead of rebuilding them at load time.
+
+Likely files:
+
+- `src/powershell/Shared/Dashboard/DashboardGeneration.ps1`
+- `Generate-VulnerabilityDashboard.ps1`
+- `templates/dashboard.js`
+
+Success criteria:
+
+- Init-time denormalization cost drops measurably.
+- Browser payload remains semantically equivalent under validation.
+
+### Item 6: Repeatable hosted profiling lane
+
+Status: Planned
+
+Objective:
+
+- Turn the ad hoc Edge profiling work into a supported repo workflow for hosted and local artifacts.
+- Allow future optimization work to compare like-for-like runs without rebuilding temporary tools.
+
+Likely files:
+
+- `tests/` profiling entrypoints
+- optional helper scripts under `build/` or `tests/manual/`
+- documentation if needed
+
+Success criteria:
+
+- The repo contains a documented, repeatable profiling path for hosted and self-contained artifacts.
+- Hosted profiling explicitly documents the auth/session prerequisite instead of failing opaquely.
+
+## Progress Log
+
+| Item | Status | Notes |
+| --- | --- | --- |
+| Plan draft | Complete | Initial plan created from current dashboard profiling and repo validation entrypoints. |
+| Agent review | Complete | Incorporated review feedback on sequencing, telemetry contract, and validation gaps. |
+| Validation workflow tightening | Complete | `tests/Invoke-LargeDatasetValidation.ps1` now supports `-ValidationMode artifacts` for iterative dual-package artifact parity checks; the 50k-device, 1.5M-row replay completed in about 71 seconds and `-ValidationMode semantic` remains available for final local sign-off. |
+| Item 1 | Complete | Added `window.dashboardMetrics`, `window.dashboardValidation`, and `dashboard-ready`; added `tests/Assert-DashboardTelemetry.js`; added `tests/Validate-DashboardGeneratedArtifacts.js`; fixture smoke generation now validates hosted and self-contained outputs. |
+| Priority insert: modal stability | Complete | Large-result remediation details now switch to a dense virtualized layout instead of creating one grouped section per device-signature bucket; focused harness tests, deterministic preflight, iterative large-dataset artifact replay, live dry run, Edge inspection, and final 50k-device semantic sign-off all passed. |
+| Priority insert: devices-by-remediation density | Complete | Oversized remediation cards now render virtualized device tables during interactive browsing and temporarily force full rows for PDF export; deterministic preflight, large-dataset artifact replay, Edge parity checks, and final semantic sign-off all passed. |
+| Priority insert: impact-analysis data-path reuse | Complete | Impact-analysis now reuses per-row formatted software, split eligibility, and raw remediation keys across its ranking passes; deterministic preflight, live dry run, Edge report sweeps, and final semantic sign-off all passed. |
+| Item 2 | Pending | Empty-state and layout-stability work paused until the modal stability slice clears the full validation gate. |
+| Item 3 | Pending | Not started. |
+| Item 4 | Pending | Not started. |
+| Item 5 | Pending | Not started. |
+| Item 6 | Pending | Not started. |
+
+## Validation History
+
+### Item 1
+
+Status: Passed
+
+Checks run:
+
+- `node .\tests\Assert-DashboardTelemetry.js`
+- fixture Dual-package generation plus `node .\tests\Validate-DashboardGeneratedArtifacts.js <self> <hosted>`
+- `pwsh -NoProfile -File .\build\Invoke-RegressionValidation.ps1`
+
+Outcome:
+
+- telemetry contract validated through the existing Node harness
+- generated hosted and self-contained outputs validated for invariant elements and hosted asset references
+- full deterministic repo preflight passed, including the new dual-package fixture validation
+
+### Priority insert: modal stability
+
+Status: In progress
+
+Checks run:
+
+- `node .\tests\Assert-DashboardModalResponsiveness.js`
+- `node .\tests\Assert-DashboardRemediationViews.js`
+- `pwsh -NoProfile -File .\build\Invoke-RegressionValidation.ps1`
+- Edge + Playwright repro against `http://127.0.0.1:41731/VulnerabilityDashboard.Hosted.html` after refreshing `VulnerabilityDashboard.Hosted.assets\dashboard.js`
+- `pwsh -NoProfile -File .\tests\Invoke-LargeDatasetValidation.ps1 -SkipSyntheticGeneration -SyntheticOutputPath .\.local\large-datasets\synthetic-50k-1_5m -Validate -ValidationMode artifacts`
+
+Outcome so far:
+
+- the modal no longer builds 16,594 grouped tables for the Windows 11 April 2026 row
+- local Edge repro dropped from about 228.9 s modal-ready latency to about 127.8 ms
+- `attachVirtualTables` dropped from 151,490 ms across 16,594 tables to 13.3 ms across 2 tables
+- local repro DOM node delta dropped from about 3,253,939 nodes to 1,556 nodes
+- iterative 50k-device, 1.5M-row large-dataset replay rebuilt and validated hosted plus self-contained artifacts in about 71.09 seconds without invoking the full semantic audit
+- 2026-04-25 live dry run generated and validated a fresh dashboard from current exports in about 89 seconds total, and Edge inspection confirmed all five reports render with the updated telemetry and modal helpers
+
+### Priority insert: devices-by-remediation density
+
+Status: In progress
+
+Checks run:
+
+- `node .\tests\Assert-DashboardModalResponsiveness.js`
+- `node .\tests\Assert-DashboardRemediationViews.js`
+- `pwsh -NoProfile -File .\build\Invoke-RegressionValidation.ps1`
+- `pwsh -NoProfile -File .\Generate-VulnerabilityDashboard.ps1 -DirectoryPath .\.local\large-datasets\synthetic-50k-1_5m -OutputPath .\.local\live-dashboard\2026-04-24-dual-run\VulnerabilityDashboard.html -HostedOutputPath .\.local\live-dashboard\2026-04-24-dual-run\VulnerabilityDashboard.Hosted.html -DualPackage -PackageOnly -ExportMachineData:$false`
+- Edge + Playwright report and modal parity checks against regenerated hosted and self-contained outputs
+
+Outcome so far:
+
+- devices-by-remediation no longer materializes the full device list for oversized cards during interactive browsing
+- hosted devices-by-remediation first open dropped from about 972,329 added DOM nodes and 64,924 rendered rows to about 8,876 nodes and 500 rows on the first 20 cards
+- self-contained devices-by-remediation matched the hosted density guard with about 8,876 nodes, 500 rows, and 20 virtualized tables on the regenerated artifact
+- hosted modal open on the regenerated dual-package artifact stayed fast at about 67 ms modal-ready latency, and self-contained matched at about 71 ms
+
+### Priority insert: impact-analysis data-path reuse
+
+Status: In progress
+
+Checks run:
+
+- `pwsh -NoProfile -File .\Generate-VulnerabilityDashboard.ps1 -DirectoryPath .\.local\large-datasets\synthetic-50k-1_5m -OutputPath .\.local\live-dashboard\2026-04-24-dual-run\VulnerabilityDashboard.html -HostedOutputPath .\.local\live-dashboard\2026-04-24-dual-run\VulnerabilityDashboard.Hosted.html -DualPackage -PackageOnly -ExportMachineData:$false`
+- self-contained Edge helper timing pass against regenerated `VulnerabilityDashboard.html`
+- self-contained Edge full report sweep against regenerated `VulnerabilityDashboard.html`
+- `pwsh -NoProfile -File .\build\Invoke-RegressionValidation.ps1`
+
+Outcome so far:
+
+- `getImpactAnalysisData()` on the regenerated self-contained artifact dropped from about 3284.9 ms to about 2178.7 ms for the 3-month large-dataset window
+- self-contained impact-analysis report render dropped from about 2855.1 ms to about 2449.2 ms in the consistent full report sweep
+- self-contained impact-analysis report switch dropped from about 4397 ms to about 3998 ms in the same sweep order
+- deterministic regression validation completed successfully after the change
+
+### Current sign-off state
+
+Status: Passed
+
+Checks completed on 2026-04-25:
+
+- `pwsh -NoProfile -File .\tests\Run-SharedHelperRegression.ps1`
+- `pwsh -NoProfile -File .\build\Invoke-RegressionValidation.ps1`
+- `pwsh -NoProfile -File .\tests\Invoke-LargeDatasetValidation.ps1 -SkipSyntheticGeneration -SyntheticOutputPath .\.local\large-datasets\synthetic-50k-1_5m -Validate -ValidationMode artifacts`
+- `pwsh -NoProfile -File .\build\Invoke-LiveDashboardDryRun.ps1 -UseExistingAzContext`
+- Edge inspection against `.local\local-reports\live-dashboard-dry-run\VulnerabilityDashboard.html`
+- Edge inspection against `C:\Users\NathanMcNulty\AppData\Local\Temp\stress-dashboard-cf0ea392fb3b44cf9041d6d0ac3ba241.html`
+
+Remaining check:
+
+- none
+
+Final semantic replay result:
+
+- `pwsh -NoProfile -File .\tests\Invoke-LargeDatasetValidation.ps1 -SkipSyntheticGeneration -SyntheticOutputPath .\.local\large-datasets\synthetic-50k-1_5m -Validate -ValidationMode semantic`
+- completed successfully on 2026-04-25
+- row parity matched: 1,500,000 expected / 1,500,000 actual
+- payload byte parity matched cached payload
+- total audit time: about 10,852 seconds
+- stress validation elapsed time: about 10,966 seconds

--- a/azure/Invoke-DashboardPipeline.ps1
+++ b/azure/Invoke-DashboardPipeline.ps1
@@ -7589,6 +7589,58 @@ function Get-StringArray {
     return @([string]$Value)
 }
 
+function Get-NullableProjectionString {
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory = $false)]
+        [AllowNull()]
+        $Value
+    )
+
+    if ($null -eq $Value) {
+        return $null
+    }
+
+    $text = [string]$Value
+    if ([string]::IsNullOrWhiteSpace($text)) {
+        return $null
+    }
+
+    return $text
+}
+
+function Get-RecordPropertyValueIfPresent {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $false)]
+        [AllowNull()]
+        $Record,
+
+        [Parameter(Mandatory = $true)]
+        [string]$PropertyName
+    )
+
+    if ($null -eq $Record) {
+        return $null
+    }
+
+    if ($Record -is [System.Collections.IDictionary]) {
+        if ($Record.Contains($PropertyName)) {
+            return $Record[$PropertyName]
+        }
+
+        return $null
+    }
+
+    $property = $Record.PSObject.Properties[$PropertyName]
+    if ($null -eq $property) {
+        return $null
+    }
+
+    return $property.Value
+}
+
 function New-MachineInfoObject {
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '')]
     [CmdletBinding()]
@@ -7657,10 +7709,10 @@ function Get-MachineProjection {
     $firstSeen = & $getScalarValue 9 'firstSeen'
 
     return [PSCustomObject]@{
-        ComputerDnsName = [string](& $getScalarValue 11 'computerDnsName')
-        RbacGroupName = [string](& $getScalarValue 12 'rbacGroupName')
-        OSPlatform = [string](& $getScalarValue 13 'osPlatform')
-        OSVersion = [string](& $getScalarValue 10 'osVersion')
+        ComputerDnsName = Get-NullableProjectionString (& $getScalarValue 11 'computerDnsName')
+        RbacGroupName = Get-NullableProjectionString (& $getScalarValue 12 'rbacGroupName')
+        OSPlatform = Get-NullableProjectionString (& $getScalarValue 13 'osPlatform')
+        OSVersion = Get-NullableProjectionString (& $getScalarValue 10 'osVersion')
         MachineTags = @($machineTags)
         MachineInfo = [PSCustomObject]@{
             ip = & $getScalarValue 0 'lastIpAddress'
@@ -7735,13 +7787,14 @@ function Get-SourceCveEnrichment {
 
     $ahRecord = if ($null -ne $AdvancedHunting) { $AdvancedHunting[$CveId] } else { $null }
     $nvdRecord = if ($null -ne $NvdCveData) { $NvdCveData[$CveId] } else { $null }
+    $exploitAvailability = Get-RecordPropertyValueIfPresent -Record $ahRecord -PropertyName 'IsExploitAvailable'
 
     return [PSCustomObject]@{
         PublishedDate = if ($ahRecord -and $ahRecord.PublishedDate) { [string]$ahRecord.PublishedDate } elseif ($nvdRecord) { [string]$nvdRecord.PublishedDate } else { $null }
         VulnerabilityDescription = if ($ahRecord -and $ahRecord.VulnerabilityDescription) { [string]$ahRecord.VulnerabilityDescription } elseif ($nvdRecord) { [string]$nvdRecord.VulnerabilityDescription } else { $null }
         EpssScore = if ($ahRecord) { $ahRecord.EpssScore } else { $null }
         AffectedSoftware = Get-FilteredAffectedSoftware -AdvancedHuntingRecord $ahRecord -VendorSet $VendorSet
-        IsExploitAvailable = if ($ahRecord -is [hashtable] -and $ahRecord.ContainsKey('IsExploitAvailable')) { $ahRecord.IsExploitAvailable } else { $null }
+        IsExploitAvailable = $exploitAvailability
         NvdLastModifiedDate = if ($nvdRecord) { [string]$nvdRecord.LastModifiedDate } else { $null }
         NvdBaseScore = if ($nvdRecord) { $nvdRecord.BaseScore } else { $null }
         NvdBaseSeverity = if ($nvdRecord) { [string]$nvdRecord.BaseSeverity } else { $null }
@@ -13718,7 +13771,7 @@ function Add-NormalizedDevice {
         }
         $groupIdx = Get-OrCreateIndex -value $resolvedGroupName -list $lookups.groups -indexMap $groupIndex
 
-        $osPlat = if ($null -ne $machine) { $machinePlatform } else { $OsPlatform }
+        $osPlat = if (-not [string]::IsNullOrWhiteSpace([string]$machinePlatform)) { $machinePlatform } else { $OsPlatform }
         $platIdx = Get-OrCreateIndex -value $osPlat -list $lookups.platforms -indexMap $platformIndex
 
         $effectiveTags = if ($null -ne $machine -and @($machineResolvedTags).Count -gt 0) { @($machineResolvedTags) } elseif ($MachineTags) { @($MachineTags) } else { @() }
@@ -13752,10 +13805,10 @@ function Add-NormalizedDevice {
 
         $lookups.devices.Add([PSCustomObject]@{
             id = $DeviceId
-            n = if ($null -ne $machine) { $machineDeviceName } elseif ($DeviceName) { $DeviceName } else { '(no machine data)' }
+            n = if (-not [string]::IsNullOrWhiteSpace([string]$machineDeviceName)) { $machineDeviceName } elseif (-not [string]::IsNullOrWhiteSpace([string]$DeviceName)) { $DeviceName } else { '(no machine data)' }
             g = $groupIdx
             o = $platIdx
-            ov = if ($null -ne $machineOsVersion) { $machineOsVersion } elseif ($OsVersion) { $OsVersion } else { $null }
+            ov = if (-not [string]::IsNullOrWhiteSpace([string]$machineOsVersion)) { $machineOsVersion } elseif (-not [string]::IsNullOrWhiteSpace([string]$OsVersion)) { $OsVersion } else { $null }
             t = $tagIndices
             m = $machineInfo
         })

--- a/azure/Invoke-DashboardPipeline.ps1
+++ b/azure/Invoke-DashboardPipeline.ps1
@@ -5202,8 +5202,24 @@ function ConvertTo-NormalizationMachineTuple {
         return $null
     }
 
-    if ($Machine -is [System.Array] -and $Machine.Length -ge 10) {
-        return [object[]]$Machine
+    if ($Machine -is [System.Array]) {
+        $tuple = [object[]]$Machine
+        if ($tuple.Length -ge 15) {
+            return $tuple
+        }
+
+        if ($tuple.Length -ge 10) {
+            $extendedTuple = [System.Collections.Generic.List[object]]::new()
+            foreach ($value in $tuple) {
+                $extendedTuple.Add($value) | Out-Null
+            }
+
+            while ($extendedTuple.Count -lt 15) {
+                $extendedTuple.Add($null) | Out-Null
+            }
+
+            return [object[]]@($extendedTuple)
+        }
     }
 
     $ip = $Machine.PSObject.Properties['lastIpAddress']?.Value
@@ -5216,6 +5232,11 @@ function ConvertTo-NormalizationMachineTuple {
     $isAadJoined = $Machine.PSObject.Properties['isAadJoined']?.Value
     $lastSeen = $Machine.PSObject.Properties['lastSeen']?.Value
     $firstSeen = $Machine.PSObject.Properties['firstSeen']?.Value
+    $osVersion = $Machine.PSObject.Properties['osVersion']?.Value
+    $computerDnsName = $Machine.PSObject.Properties['computerDnsName']?.Value
+    $rbacGroupName = $Machine.PSObject.Properties['rbacGroupName']?.Value
+    $osPlatform = $Machine.PSObject.Properties['osPlatform']?.Value
+    $machineTags = @(Get-NormalizedMachineTag -Tags $Machine.PSObject.Properties['machineTags']?.Value)
 
     if (
         $null -eq $ip -and
@@ -5227,7 +5248,12 @@ function ConvertTo-NormalizationMachineTuple {
         $null -eq $managedBy -and
         $null -eq $isAadJoined -and
         $null -eq $lastSeen -and
-        $null -eq $firstSeen
+        $null -eq $firstSeen -and
+        $null -eq $osVersion -and
+        $null -eq $computerDnsName -and
+        $null -eq $rbacGroupName -and
+        $null -eq $osPlatform -and
+        @($machineTags).Count -eq 0
     ) {
         return $null
     }
@@ -5242,7 +5268,12 @@ function ConvertTo-NormalizationMachineTuple {
         $managedBy,
         $isAadJoined,
         $lastSeen,
-        $firstSeen
+        $firstSeen,
+        $osVersion,
+        $computerDnsName,
+        $rbacGroupName,
+        $osPlatform,
+        @($machineTags)
     )
 }
 
@@ -5409,7 +5440,12 @@ function ConvertFrom-MachineJsonElementToNormalizationEntry {
         (Get-MachineJsonElementScalarValue -Element $MachineElement -Name 'managedBy'),
         (Get-MachineJsonElementScalarValue -Element $MachineElement -Name 'isAadJoined'),
         (Get-MachineJsonElementScalarValue -Element $MachineElement -Name 'lastSeen'),
-        (Get-MachineJsonElementScalarValue -Element $MachineElement -Name 'firstSeen')
+        (Get-MachineJsonElementScalarValue -Element $MachineElement -Name 'firstSeen'),
+        (Get-MachineJsonElementScalarValue -Element $MachineElement -Name 'osVersion'),
+        (Get-MachineJsonElementScalarValue -Element $MachineElement -Name 'computerDnsName'),
+        (Get-MachineJsonElementScalarValue -Element $MachineElement -Name 'rbacGroupName'),
+        (Get-MachineJsonElementScalarValue -Element $MachineElement -Name 'osPlatform'),
+        @(Get-MachineJsonElementStringArrayValue -Element $MachineElement -Name 'machineTags')
     )
 
     $hasTupleValue = $false
@@ -6306,6 +6342,10 @@ function Convert-ToYmdDate {
 
     if ($raw -match '^\d{4}-\d{2}-\d{2}$') {
         return $raw
+    }
+
+    if ($raw.Length -ge 10 -and $raw[4] -eq '-' -and $raw[7] -eq '-') {
+        return $raw.Substring(0, 10)
     }
 
     if ($raw -match '^(\d{1,2})/(\d{1,2})/(\d{4})') {
@@ -7562,17 +7602,78 @@ function New-MachineInfoObject {
         return $null
     }
 
+    $projection = Get-MachineProjection -Machine $Machine
+    if ($null -eq $projection) {
+        return $null
+    }
+
+    return $projection.MachineInfo
+}
+
+function Get-MachineProjection {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '')]
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $false)]
+        [AllowNull()]
+        $Machine
+    )
+
+    if ($null -eq $Machine) {
+        return $null
+    }
+
+    $machineTuple = if ($Machine -is [System.Array]) {
+        ConvertTo-NormalizationMachineTuple -Machine $Machine
+    }
+    else {
+        $null
+    }
+
+    $getScalarValue = {
+        param(
+            [int]$TupleIndex,
+            [string]$PropertyName
+        )
+
+        if ($machineTuple -and $machineTuple.Length -gt $TupleIndex) {
+            return $machineTuple[$TupleIndex]
+        }
+
+        return $Machine.PSObject.Properties[$PropertyName]?.Value
+    }
+
+    $machineTags = if ($machineTuple -and $machineTuple.Length -ge 15) {
+        @(Get-StringArray -Value $machineTuple[14])
+    }
+    elseif ($Machine.PSObject.Properties['machineTags']?.Value) {
+        @(Get-StringArray -Value $Machine.PSObject.Properties['machineTags']?.Value)
+    }
+    else {
+        @()
+    }
+
+    $lastSeen = & $getScalarValue 8 'lastSeen'
+    $firstSeen = & $getScalarValue 9 'firstSeen'
+
     return [PSCustomObject]@{
-        ip = $Machine.lastIpAddress
-        eip = $Machine.lastExternalIpAddress
-        hs = $Machine.healthStatus
-        rs = $Machine.riskScore
-        el = $Machine.exposureLevel
-        dv = $Machine.deviceValue
-        mb = $Machine.managedBy
-        aad = $Machine.isAadJoined
-        ls = Convert-ToYmdDate -DateValue $Machine.lastSeen
-        fs = Convert-ToYmdDate -DateValue $Machine.firstSeen
+        ComputerDnsName = [string](& $getScalarValue 11 'computerDnsName')
+        RbacGroupName = [string](& $getScalarValue 12 'rbacGroupName')
+        OSPlatform = [string](& $getScalarValue 13 'osPlatform')
+        OSVersion = [string](& $getScalarValue 10 'osVersion')
+        MachineTags = @($machineTags)
+        MachineInfo = [PSCustomObject]@{
+            ip = & $getScalarValue 0 'lastIpAddress'
+            eip = & $getScalarValue 1 'lastExternalIpAddress'
+            hs = & $getScalarValue 2 'healthStatus'
+            rs = & $getScalarValue 3 'riskScore'
+            el = & $getScalarValue 4 'exposureLevel'
+            dv = & $getScalarValue 5 'deviceValue'
+            mb = & $getScalarValue 6 'managedBy'
+            aad = & $getScalarValue 7 'isAadJoined'
+            ls = Convert-ToYmdDate -DateValue $lastSeen
+            fs = Convert-ToYmdDate -DateValue $firstSeen
+        }
     }
 }
 
@@ -12624,7 +12725,7 @@ function Get-DashboardSemanticValidationLogicVersion {
     [OutputType([string])]
     param()
 
-    return 'streaming-large-dataset-v2'
+    return 'streaming-large-dataset-v3'
 }
 
 function Set-NormalizedPayloadSemanticValidationAttestation {
@@ -13554,6 +13655,51 @@ function Add-NormalizedDevice {
     if (-not $deviceIndex.ContainsKey($deviceKey)) {
         $machine = if (-not [string]::IsNullOrWhiteSpace($DeviceId)) { $Context.Machines[$DeviceId] } else { $null }
         $machineTuple = if ($machine -is [System.Array] -and $machine.Length -ge 10) { $machine } else { $null }
+        $machineOsVersion = if ($machineTuple -and $machineTuple.Length -ge 11) {
+            [string]$machineTuple[10]
+        }
+        elseif ($machine -and -not $machineTuple) {
+            [string]$machine.PSObject.Properties['osVersion']?.Value
+        }
+        else {
+            $null
+        }
+        $machineDeviceName = if ($machineTuple -and $machineTuple.Length -ge 12) {
+            [string]$machineTuple[11]
+        }
+        elseif ($machine -and -not $machineTuple) {
+            [string]$machine.PSObject.Properties['computerDnsName']?.Value
+        }
+        else {
+            $null
+        }
+        $machineGroupName = if ($machineTuple -and $machineTuple.Length -ge 13) {
+            [string]$machineTuple[12]
+        }
+        elseif ($machine -and -not $machineTuple) {
+            [string]$machine.PSObject.Properties['rbacGroupName']?.Value
+        }
+        else {
+            $null
+        }
+        $machinePlatform = if ($machineTuple -and $machineTuple.Length -ge 14) {
+            [string]$machineTuple[13]
+        }
+        elseif ($machine -and -not $machineTuple) {
+            [string]$machine.PSObject.Properties['osPlatform']?.Value
+        }
+        else {
+            $null
+        }
+        $machineResolvedTags = if ($machineTuple -and $machineTuple.Length -ge 15) {
+            @($machineTuple[14])
+        }
+        elseif ($machine -and -not $machineTuple) {
+            @(Get-NormalizedMachineTag -Tags $machine.PSObject.Properties['machineTags']?.Value)
+        }
+        else {
+            @()
+        }
         $machineUsers = [string[]]@()
         if ($null -ne $Context.AdvancedHuntingDeviceUsers -and -not [string]::IsNullOrWhiteSpace($DeviceId)) {
             $rawMachineUsers = $Context.AdvancedHuntingDeviceUsers[[string]$DeviceId]
@@ -13566,16 +13712,16 @@ function Add-NormalizedDevice {
             }
         }
 
-        $resolvedGroupName = $GroupName
+        $resolvedGroupName = if ($null -ne $machine) { $machineGroupName } else { $GroupName }
         if ([string]::IsNullOrWhiteSpace([string]$resolvedGroupName)) {
             $resolvedGroupName = if ([string]::IsNullOrWhiteSpace([string]$GroupName)) { '(none)' } else { $GroupName }
         }
         $groupIdx = Get-OrCreateIndex -value $resolvedGroupName -list $lookups.groups -indexMap $groupIndex
 
-        $osPlat = $OsPlatform
+        $osPlat = if ($null -ne $machine) { $machinePlatform } else { $OsPlatform }
         $platIdx = Get-OrCreateIndex -value $osPlat -list $lookups.platforms -indexMap $platformIndex
 
-        $effectiveTags = if ($MachineTags) { $MachineTags } else { @() }
+        $effectiveTags = if ($null -ne $machine -and @($machineResolvedTags).Count -gt 0) { @($machineResolvedTags) } elseif ($MachineTags) { @($MachineTags) } else { @() }
         $tagIndices = [System.Collections.Generic.List[int]]::new()
         foreach ($tag in $effectiveTags) {
             $tagIdx = Get-OrCreateIndex -value $tag -list $lookups.tags -indexMap $tagIndex
@@ -13606,10 +13752,10 @@ function Add-NormalizedDevice {
 
         $lookups.devices.Add([PSCustomObject]@{
             id = $DeviceId
-            n = if ($DeviceName) { $DeviceName } elseif ($machine -and -not $machineTuple) { $machine.PSObject.Properties['computerDnsName']?.Value } else { '(no machine data)' }
+            n = if ($null -ne $machine) { $machineDeviceName } elseif ($DeviceName) { $DeviceName } else { '(no machine data)' }
             g = $groupIdx
             o = $platIdx
-            ov = if ($OsVersion) { $OsVersion } elseif ($machine -and -not $machineTuple) { $machine.PSObject.Properties['osVersion']?.Value } else { $null }
+            ov = if ($null -ne $machineOsVersion) { $machineOsVersion } elseif ($OsVersion) { $OsVersion } else { $null }
             t = $tagIndices
             m = $machineInfo
         })

--- a/build/Invoke-LiveDashboardDryRun.ps1
+++ b/build/Invoke-LiveDashboardDryRun.ps1
@@ -191,19 +191,36 @@ function Get-DefenderApiAccessToken {
     [OutputType([string])]
     param()
 
-    if (-not (Get-Command -Name Get-AzAccessToken -ErrorAction Ignore)) {
-        throw 'Get-AzAccessToken is not available. Install Az.Accounts before running this script.'
+    Write-Verbose 'Getting Microsoft Defender API access token...'
+
+    if (Get-Command -Name Get-AzAccessToken -ErrorAction Ignore) {
+        try {
+            $tokenResponse = Get-AzAccessToken -ResourceUrl 'https://api.securitycenter.microsoft.com' -AsSecureString -ErrorAction Stop
+            $secureStringPointer = [System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($tokenResponse.Token)
+            try {
+                return [System.Runtime.InteropServices.Marshal]::PtrToStringBSTR($secureStringPointer)
+            }
+            finally {
+                [System.Runtime.InteropServices.Marshal]::ZeroFreeBSTR($secureStringPointer)
+            }
+        }
+        catch {
+            Write-Warning ("Get-AzAccessToken failed for the Defender API. Falling back to Azure CLI token acquisition if available. {0}" -f $_.Exception.Message)
+        }
     }
 
-    Write-Verbose 'Getting Microsoft Defender API access token...'
-    $tokenResponse = Get-AzAccessToken -ResourceUrl 'https://api.securitycenter.microsoft.com' -AsSecureString
-    $secureStringPointer = [System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($tokenResponse.Token)
-    try {
-        return [System.Runtime.InteropServices.Marshal]::PtrToStringBSTR($secureStringPointer)
+    $azCommand = Get-Command -Name 'az' -ErrorAction Ignore
+    if ($null -eq $azCommand) {
+        throw 'Unable to acquire a Defender API access token. Get-AzAccessToken failed and Azure CLI is not available.'
     }
-    finally {
-        [System.Runtime.InteropServices.Marshal]::ZeroFreeBSTR($secureStringPointer)
+
+    $tokenJson = & $azCommand.Source account get-access-token --resource https://api.securitycenter.microsoft.com --output json
+    $tokenResult = $tokenJson | ConvertFrom-Json -Depth 10
+    if ($null -eq $tokenResult -or [string]::IsNullOrWhiteSpace([string]$tokenResult.accessToken)) {
+        throw 'Azure CLI did not return a Defender API access token.'
     }
+
+    return [string]$tokenResult.accessToken
 }
 
 function Get-OutputFileDetail {

--- a/build/Invoke-LiveDashboardDryRun.ps1
+++ b/build/Invoke-LiveDashboardDryRun.ps1
@@ -214,13 +214,17 @@ function Get-DefenderApiAccessToken {
         throw 'Unable to acquire a Defender API access token. Get-AzAccessToken failed and Azure CLI is not available.'
     }
 
-    $tokenJson = & $azCommand.Source account get-access-token --resource https://api.securitycenter.microsoft.com --output json
-    $tokenResult = $tokenJson | ConvertFrom-Json -Depth 10
-    if ($null -eq $tokenResult -or [string]::IsNullOrWhiteSpace([string]$tokenResult.accessToken)) {
+    $token = & $azCommand.Source account get-access-token --resource https://api.securitycenter.microsoft.com --query accessToken --output tsv --only-show-errors
+    $token = [string]$token
+    if ($null -ne $token) {
+        $token = $token.Trim()
+    }
+
+    if ([string]::IsNullOrWhiteSpace($token)) {
         throw 'Azure CLI did not return a Defender API access token.'
     }
 
-    return [string]$tokenResult.accessToken
+    return $token
 }
 
 function Get-OutputFileDetail {

--- a/build/Invoke-RegressionValidation.ps1
+++ b/build/Invoke-RegressionValidation.ps1
@@ -239,13 +239,29 @@ if (-not $SkipDashboardFixtureValidation) {
         }
 
         $fixtureHtmlPath = Join-Path $tempRoot 'fixture-dashboard.html'
+        $fixtureHostedHtmlPath = Join-Path $tempRoot 'fixture-dashboard.Hosted.html'
         Write-Output 'Running dashboard fixture smoke generation...'
         & (Join-Path $repoRoot 'Generate-VulnerabilityDashboard.ps1') `
             -DirectoryPath $fixtureDataPath `
             -OutputPath $fixtureHtmlPath `
+            -HostedOutputPath $fixtureHostedHtmlPath `
+            -DualPackage `
             -ExportMachineData:$false
         if (Test-LastExitCodeFailed) {
             throw 'Generate-VulnerabilityDashboard.ps1 fixture smoke generation failed.'
+        }
+
+        $generatedArtifactsValidatorPath = Join-Path $repoRoot 'tests\Validate-DashboardGeneratedArtifacts.js'
+        $nodeCommand = Get-Command node -ErrorAction SilentlyContinue
+        if ($null -eq $nodeCommand) {
+            throw 'Node.js is required to validate generated dashboard artifacts.'
+        }
+
+        Write-Output 'Validating generated dashboard artifacts...'
+        Reset-LastExitCode
+        & $nodeCommand.Source $generatedArtifactsValidatorPath $fixtureHtmlPath $fixtureHostedHtmlPath
+        if (Test-LastExitCodeFailed) {
+            throw 'Generated dashboard artifact validation failed.'
         }
     }
     finally {

--- a/docs/performance-baselines.md
+++ b/docs/performance-baselines.md
@@ -85,6 +85,8 @@ Import-path spot checks:
 ```powershell
 pwsh -NoProfile -File .\tests\Generate-SyntheticLargeExports.ps1 -OutputPath .\.local\large-datasets\synthetic-raw -IncludeRawRows -AllowLargeDataset
 pwsh -NoProfile -File .\tests\New-SyntheticLiveExport.ps1 -SourcePath .\.local\large-datasets\synthetic-raw -OutputPath .\.local\large-datasets\synthetic-raw-live -SkipContentStoreSidecars -Force
-pwsh -NoProfile -File .\tests\Invoke-LargeDatasetValidation.ps1 -SkipSyntheticGeneration -SyntheticOutputPath .\.local\large-datasets\synthetic-raw-live -Validate
+pwsh -NoProfile -File .\tests\Invoke-LargeDatasetValidation.ps1 -SkipSyntheticGeneration -SyntheticOutputPath .\.local\large-datasets\synthetic-raw-live -Validate -ValidationMode artifacts
 pwsh -NoProfile -File .\tests\Measure-RunbookOnlyAzureBenchmark.ps1 -UseExistingExportsOnly:$false
 ```
+
+Use `-ValidationMode semantic` only for the final local replay when you need the full semantic audit before Azure or merge validation.

--- a/src/powershell/Shared/Dashboard/DashboardGeneration.ps1
+++ b/src/powershell/Shared/Dashboard/DashboardGeneration.ps1
@@ -3331,7 +3331,7 @@ function Get-DashboardSemanticValidationLogicVersion {
     [OutputType([string])]
     param()
 
-    return 'streaming-large-dataset-v2'
+    return 'streaming-large-dataset-v3'
 }
 
 function Set-NormalizedPayloadSemanticValidationAttestation {
@@ -4261,6 +4261,51 @@ function Add-NormalizedDevice {
     if (-not $deviceIndex.ContainsKey($deviceKey)) {
         $machine = if (-not [string]::IsNullOrWhiteSpace($DeviceId)) { $Context.Machines[$DeviceId] } else { $null }
         $machineTuple = if ($machine -is [System.Array] -and $machine.Length -ge 10) { $machine } else { $null }
+        $machineOsVersion = if ($machineTuple -and $machineTuple.Length -ge 11) {
+            [string]$machineTuple[10]
+        }
+        elseif ($machine -and -not $machineTuple) {
+            [string]$machine.PSObject.Properties['osVersion']?.Value
+        }
+        else {
+            $null
+        }
+        $machineDeviceName = if ($machineTuple -and $machineTuple.Length -ge 12) {
+            [string]$machineTuple[11]
+        }
+        elseif ($machine -and -not $machineTuple) {
+            [string]$machine.PSObject.Properties['computerDnsName']?.Value
+        }
+        else {
+            $null
+        }
+        $machineGroupName = if ($machineTuple -and $machineTuple.Length -ge 13) {
+            [string]$machineTuple[12]
+        }
+        elseif ($machine -and -not $machineTuple) {
+            [string]$machine.PSObject.Properties['rbacGroupName']?.Value
+        }
+        else {
+            $null
+        }
+        $machinePlatform = if ($machineTuple -and $machineTuple.Length -ge 14) {
+            [string]$machineTuple[13]
+        }
+        elseif ($machine -and -not $machineTuple) {
+            [string]$machine.PSObject.Properties['osPlatform']?.Value
+        }
+        else {
+            $null
+        }
+        $machineResolvedTags = if ($machineTuple -and $machineTuple.Length -ge 15) {
+            @($machineTuple[14])
+        }
+        elseif ($machine -and -not $machineTuple) {
+            @(Get-NormalizedMachineTag -Tags $machine.PSObject.Properties['machineTags']?.Value)
+        }
+        else {
+            @()
+        }
         $machineUsers = [string[]]@()
         if ($null -ne $Context.AdvancedHuntingDeviceUsers -and -not [string]::IsNullOrWhiteSpace($DeviceId)) {
             $rawMachineUsers = $Context.AdvancedHuntingDeviceUsers[[string]$DeviceId]
@@ -4273,16 +4318,16 @@ function Add-NormalizedDevice {
             }
         }
 
-        $resolvedGroupName = $GroupName
+        $resolvedGroupName = if ($null -ne $machine) { $machineGroupName } else { $GroupName }
         if ([string]::IsNullOrWhiteSpace([string]$resolvedGroupName)) {
             $resolvedGroupName = if ([string]::IsNullOrWhiteSpace([string]$GroupName)) { '(none)' } else { $GroupName }
         }
         $groupIdx = Get-OrCreateIndex -value $resolvedGroupName -list $lookups.groups -indexMap $groupIndex
 
-        $osPlat = $OsPlatform
+        $osPlat = if ($null -ne $machine) { $machinePlatform } else { $OsPlatform }
         $platIdx = Get-OrCreateIndex -value $osPlat -list $lookups.platforms -indexMap $platformIndex
 
-        $effectiveTags = if ($MachineTags) { $MachineTags } else { @() }
+        $effectiveTags = if ($null -ne $machine -and @($machineResolvedTags).Count -gt 0) { @($machineResolvedTags) } elseif ($MachineTags) { @($MachineTags) } else { @() }
         $tagIndices = [System.Collections.Generic.List[int]]::new()
         foreach ($tag in $effectiveTags) {
             $tagIdx = Get-OrCreateIndex -value $tag -list $lookups.tags -indexMap $tagIndex
@@ -4313,10 +4358,10 @@ function Add-NormalizedDevice {
 
         $lookups.devices.Add([PSCustomObject]@{
             id = $DeviceId
-            n = if ($DeviceName) { $DeviceName } elseif ($machine -and -not $machineTuple) { $machine.PSObject.Properties['computerDnsName']?.Value } else { '(no machine data)' }
+            n = if ($null -ne $machine) { $machineDeviceName } elseif ($DeviceName) { $DeviceName } else { '(no machine data)' }
             g = $groupIdx
             o = $platIdx
-            ov = if ($OsVersion) { $OsVersion } elseif ($machine -and -not $machineTuple) { $machine.PSObject.Properties['osVersion']?.Value } else { $null }
+            ov = if ($null -ne $machineOsVersion) { $machineOsVersion } elseif ($OsVersion) { $OsVersion } else { $null }
             t = $tagIndices
             m = $machineInfo
         })

--- a/src/powershell/Shared/Dashboard/DashboardGeneration.ps1
+++ b/src/powershell/Shared/Dashboard/DashboardGeneration.ps1
@@ -4324,7 +4324,7 @@ function Add-NormalizedDevice {
         }
         $groupIdx = Get-OrCreateIndex -value $resolvedGroupName -list $lookups.groups -indexMap $groupIndex
 
-        $osPlat = if ($null -ne $machine) { $machinePlatform } else { $OsPlatform }
+        $osPlat = if (-not [string]::IsNullOrWhiteSpace([string]$machinePlatform)) { $machinePlatform } else { $OsPlatform }
         $platIdx = Get-OrCreateIndex -value $osPlat -list $lookups.platforms -indexMap $platformIndex
 
         $effectiveTags = if ($null -ne $machine -and @($machineResolvedTags).Count -gt 0) { @($machineResolvedTags) } elseif ($MachineTags) { @($MachineTags) } else { @() }
@@ -4358,10 +4358,10 @@ function Add-NormalizedDevice {
 
         $lookups.devices.Add([PSCustomObject]@{
             id = $DeviceId
-            n = if ($null -ne $machine) { $machineDeviceName } elseif ($DeviceName) { $DeviceName } else { '(no machine data)' }
+            n = if (-not [string]::IsNullOrWhiteSpace([string]$machineDeviceName)) { $machineDeviceName } elseif (-not [string]::IsNullOrWhiteSpace([string]$DeviceName)) { $DeviceName } else { '(no machine data)' }
             g = $groupIdx
             o = $platIdx
-            ov = if ($null -ne $machineOsVersion) { $machineOsVersion } elseif ($OsVersion) { $OsVersion } else { $null }
+            ov = if (-not [string]::IsNullOrWhiteSpace([string]$machineOsVersion)) { $machineOsVersion } elseif (-not [string]::IsNullOrWhiteSpace([string]$OsVersion)) { $OsVersion } else { $null }
             t = $tagIndices
             m = $machineInfo
         })

--- a/src/powershell/Shared/Enrichment/EnrichmentProjection.ps1
+++ b/src/powershell/Shared/Enrichment/EnrichmentProjection.ps1
@@ -30,6 +30,58 @@ function Get-StringArray {
     return @([string]$Value)
 }
 
+function Get-NullableProjectionString {
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory = $false)]
+        [AllowNull()]
+        $Value
+    )
+
+    if ($null -eq $Value) {
+        return $null
+    }
+
+    $text = [string]$Value
+    if ([string]::IsNullOrWhiteSpace($text)) {
+        return $null
+    }
+
+    return $text
+}
+
+function Get-RecordPropertyValueIfPresent {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $false)]
+        [AllowNull()]
+        $Record,
+
+        [Parameter(Mandatory = $true)]
+        [string]$PropertyName
+    )
+
+    if ($null -eq $Record) {
+        return $null
+    }
+
+    if ($Record -is [System.Collections.IDictionary]) {
+        if ($Record.Contains($PropertyName)) {
+            return $Record[$PropertyName]
+        }
+
+        return $null
+    }
+
+    $property = $Record.PSObject.Properties[$PropertyName]
+    if ($null -eq $property) {
+        return $null
+    }
+
+    return $property.Value
+}
+
 function New-MachineInfoObject {
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '')]
     [CmdletBinding()]
@@ -98,10 +150,10 @@ function Get-MachineProjection {
     $firstSeen = & $getScalarValue 9 'firstSeen'
 
     return [PSCustomObject]@{
-        ComputerDnsName = [string](& $getScalarValue 11 'computerDnsName')
-        RbacGroupName = [string](& $getScalarValue 12 'rbacGroupName')
-        OSPlatform = [string](& $getScalarValue 13 'osPlatform')
-        OSVersion = [string](& $getScalarValue 10 'osVersion')
+        ComputerDnsName = Get-NullableProjectionString (& $getScalarValue 11 'computerDnsName')
+        RbacGroupName = Get-NullableProjectionString (& $getScalarValue 12 'rbacGroupName')
+        OSPlatform = Get-NullableProjectionString (& $getScalarValue 13 'osPlatform')
+        OSVersion = Get-NullableProjectionString (& $getScalarValue 10 'osVersion')
         MachineTags = @($machineTags)
         MachineInfo = [PSCustomObject]@{
             ip = & $getScalarValue 0 'lastIpAddress'
@@ -176,13 +228,14 @@ function Get-SourceCveEnrichment {
 
     $ahRecord = if ($null -ne $AdvancedHunting) { $AdvancedHunting[$CveId] } else { $null }
     $nvdRecord = if ($null -ne $NvdCveData) { $NvdCveData[$CveId] } else { $null }
+    $exploitAvailability = Get-RecordPropertyValueIfPresent -Record $ahRecord -PropertyName 'IsExploitAvailable'
 
     return [PSCustomObject]@{
         PublishedDate = if ($ahRecord -and $ahRecord.PublishedDate) { [string]$ahRecord.PublishedDate } elseif ($nvdRecord) { [string]$nvdRecord.PublishedDate } else { $null }
         VulnerabilityDescription = if ($ahRecord -and $ahRecord.VulnerabilityDescription) { [string]$ahRecord.VulnerabilityDescription } elseif ($nvdRecord) { [string]$nvdRecord.VulnerabilityDescription } else { $null }
         EpssScore = if ($ahRecord) { $ahRecord.EpssScore } else { $null }
         AffectedSoftware = Get-FilteredAffectedSoftware -AdvancedHuntingRecord $ahRecord -VendorSet $VendorSet
-        IsExploitAvailable = if ($ahRecord -is [hashtable] -and $ahRecord.ContainsKey('IsExploitAvailable')) { $ahRecord.IsExploitAvailable } else { $null }
+        IsExploitAvailable = $exploitAvailability
         NvdLastModifiedDate = if ($nvdRecord) { [string]$nvdRecord.LastModifiedDate } else { $null }
         NvdBaseScore = if ($nvdRecord) { $nvdRecord.BaseScore } else { $null }
         NvdBaseSeverity = if ($nvdRecord) { [string]$nvdRecord.BaseSeverity } else { $null }

--- a/src/powershell/Shared/Enrichment/EnrichmentProjection.ps1
+++ b/src/powershell/Shared/Enrichment/EnrichmentProjection.ps1
@@ -43,17 +43,78 @@ function New-MachineInfoObject {
         return $null
     }
 
+    $projection = Get-MachineProjection -Machine $Machine
+    if ($null -eq $projection) {
+        return $null
+    }
+
+    return $projection.MachineInfo
+}
+
+function Get-MachineProjection {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '')]
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $false)]
+        [AllowNull()]
+        $Machine
+    )
+
+    if ($null -eq $Machine) {
+        return $null
+    }
+
+    $machineTuple = if ($Machine -is [System.Array]) {
+        ConvertTo-NormalizationMachineTuple -Machine $Machine
+    }
+    else {
+        $null
+    }
+
+    $getScalarValue = {
+        param(
+            [int]$TupleIndex,
+            [string]$PropertyName
+        )
+
+        if ($machineTuple -and $machineTuple.Length -gt $TupleIndex) {
+            return $machineTuple[$TupleIndex]
+        }
+
+        return $Machine.PSObject.Properties[$PropertyName]?.Value
+    }
+
+    $machineTags = if ($machineTuple -and $machineTuple.Length -ge 15) {
+        @(Get-StringArray -Value $machineTuple[14])
+    }
+    elseif ($Machine.PSObject.Properties['machineTags']?.Value) {
+        @(Get-StringArray -Value $Machine.PSObject.Properties['machineTags']?.Value)
+    }
+    else {
+        @()
+    }
+
+    $lastSeen = & $getScalarValue 8 'lastSeen'
+    $firstSeen = & $getScalarValue 9 'firstSeen'
+
     return [PSCustomObject]@{
-        ip = $Machine.lastIpAddress
-        eip = $Machine.lastExternalIpAddress
-        hs = $Machine.healthStatus
-        rs = $Machine.riskScore
-        el = $Machine.exposureLevel
-        dv = $Machine.deviceValue
-        mb = $Machine.managedBy
-        aad = $Machine.isAadJoined
-        ls = Convert-ToYmdDate -DateValue $Machine.lastSeen
-        fs = Convert-ToYmdDate -DateValue $Machine.firstSeen
+        ComputerDnsName = [string](& $getScalarValue 11 'computerDnsName')
+        RbacGroupName = [string](& $getScalarValue 12 'rbacGroupName')
+        OSPlatform = [string](& $getScalarValue 13 'osPlatform')
+        OSVersion = [string](& $getScalarValue 10 'osVersion')
+        MachineTags = @($machineTags)
+        MachineInfo = [PSCustomObject]@{
+            ip = & $getScalarValue 0 'lastIpAddress'
+            eip = & $getScalarValue 1 'lastExternalIpAddress'
+            hs = & $getScalarValue 2 'healthStatus'
+            rs = & $getScalarValue 3 'riskScore'
+            el = & $getScalarValue 4 'exposureLevel'
+            dv = & $getScalarValue 5 'deviceValue'
+            mb = & $getScalarValue 6 'managedBy'
+            aad = & $getScalarValue 7 'isAadJoined'
+            ls = Convert-ToYmdDate -DateValue $lastSeen
+            fs = Convert-ToYmdDate -DateValue $firstSeen
+        }
     }
 }
 

--- a/src/powershell/Shared/Stores/MachineStore.ps1
+++ b/src/powershell/Shared/Stores/MachineStore.ps1
@@ -41,8 +41,24 @@ function ConvertTo-NormalizationMachineTuple {
         return $null
     }
 
-    if ($Machine -is [System.Array] -and $Machine.Length -ge 10) {
-        return [object[]]$Machine
+    if ($Machine -is [System.Array]) {
+        $tuple = [object[]]$Machine
+        if ($tuple.Length -ge 15) {
+            return $tuple
+        }
+
+        if ($tuple.Length -ge 10) {
+            $extendedTuple = [System.Collections.Generic.List[object]]::new()
+            foreach ($value in $tuple) {
+                $extendedTuple.Add($value) | Out-Null
+            }
+
+            while ($extendedTuple.Count -lt 15) {
+                $extendedTuple.Add($null) | Out-Null
+            }
+
+            return [object[]]@($extendedTuple)
+        }
     }
 
     $ip = $Machine.PSObject.Properties['lastIpAddress']?.Value
@@ -55,6 +71,11 @@ function ConvertTo-NormalizationMachineTuple {
     $isAadJoined = $Machine.PSObject.Properties['isAadJoined']?.Value
     $lastSeen = $Machine.PSObject.Properties['lastSeen']?.Value
     $firstSeen = $Machine.PSObject.Properties['firstSeen']?.Value
+    $osVersion = $Machine.PSObject.Properties['osVersion']?.Value
+    $computerDnsName = $Machine.PSObject.Properties['computerDnsName']?.Value
+    $rbacGroupName = $Machine.PSObject.Properties['rbacGroupName']?.Value
+    $osPlatform = $Machine.PSObject.Properties['osPlatform']?.Value
+    $machineTags = @(Get-NormalizedMachineTag -Tags $Machine.PSObject.Properties['machineTags']?.Value)
 
     if (
         $null -eq $ip -and
@@ -66,7 +87,12 @@ function ConvertTo-NormalizationMachineTuple {
         $null -eq $managedBy -and
         $null -eq $isAadJoined -and
         $null -eq $lastSeen -and
-        $null -eq $firstSeen
+        $null -eq $firstSeen -and
+        $null -eq $osVersion -and
+        $null -eq $computerDnsName -and
+        $null -eq $rbacGroupName -and
+        $null -eq $osPlatform -and
+        @($machineTags).Count -eq 0
     ) {
         return $null
     }
@@ -81,7 +107,12 @@ function ConvertTo-NormalizationMachineTuple {
         $managedBy,
         $isAadJoined,
         $lastSeen,
-        $firstSeen
+        $firstSeen,
+        $osVersion,
+        $computerDnsName,
+        $rbacGroupName,
+        $osPlatform,
+        @($machineTags)
     )
 }
 
@@ -248,7 +279,12 @@ function ConvertFrom-MachineJsonElementToNormalizationEntry {
         (Get-MachineJsonElementScalarValue -Element $MachineElement -Name 'managedBy'),
         (Get-MachineJsonElementScalarValue -Element $MachineElement -Name 'isAadJoined'),
         (Get-MachineJsonElementScalarValue -Element $MachineElement -Name 'lastSeen'),
-        (Get-MachineJsonElementScalarValue -Element $MachineElement -Name 'firstSeen')
+        (Get-MachineJsonElementScalarValue -Element $MachineElement -Name 'firstSeen'),
+        (Get-MachineJsonElementScalarValue -Element $MachineElement -Name 'osVersion'),
+        (Get-MachineJsonElementScalarValue -Element $MachineElement -Name 'computerDnsName'),
+        (Get-MachineJsonElementScalarValue -Element $MachineElement -Name 'rbacGroupName'),
+        (Get-MachineJsonElementScalarValue -Element $MachineElement -Name 'osPlatform'),
+        @(Get-MachineJsonElementStringArrayValue -Element $MachineElement -Name 'machineTags')
     )
 
     $hasTupleValue = $false
@@ -1145,6 +1181,10 @@ function Convert-ToYmdDate {
 
     if ($raw -match '^\d{4}-\d{2}-\d{2}$') {
         return $raw
+    }
+
+    if ($raw.Length -ge 10 -and $raw[4] -eq '-' -and $raw[7] -eq '-') {
+        return $raw.Substring(0, 10)
     }
 
     if ($raw -match '^(\d{1,2})/(\d{1,2})/(\d{4})') {

--- a/src/powershell/Validation/Audit/DashboardAudit.ps1
+++ b/src/powershell/Validation/Audit/DashboardAudit.ps1
@@ -395,13 +395,14 @@ function Read-SourceRow {
         }
 
         if (-not $deviceProfiles.ContainsKey($deviceKey)) {
-            $groupName = if ($machine) { [string]$machine.rbacGroupName } else { $fallbackGroupName }
+            $machineProjection = Get-MachineProjection -Machine $machine
+            $groupName = if ($machineProjection) { [string]$machineProjection.RbacGroupName } else { $fallbackGroupName }
             if ([string]::IsNullOrWhiteSpace($groupName)) {
                 $groupName = if ([string]::IsNullOrWhiteSpace($fallbackGroupName)) { '(none)' } else { $fallbackGroupName }
             }
 
-            $machineTags = if ($machine -and @($machine.machineTags).Count -gt 0) {
-                @($machine.machineTags)
+            $machineTags = if ($machineProjection -and @($machineProjection.MachineTags).Count -gt 0) {
+                @($machineProjection.MachineTags)
             }
             elseif (@($fallbackMachineTags).Count -gt 0) {
                 @($fallbackMachineTags)
@@ -411,12 +412,12 @@ function Read-SourceRow {
             }
 
             $deviceProfiles[$deviceKey] = [PSCustomObject]@{
-                DeviceName = if ($machine) { [string]$machine.computerDnsName } elseif ($fallbackDeviceName) { $fallbackDeviceName } else { '(no machine data)' }
+                DeviceName = if ($machineProjection) { [string]$machineProjection.ComputerDnsName } elseif ($fallbackDeviceName) { $fallbackDeviceName } else { '(no machine data)' }
                 RbacGroupName = $groupName
-                OSPlatform = if ($machine) { [string]$machine.osPlatform } else { $fallbackPlatform }
-                OSVersion = if ($machine) { [string]$machine.osVersion } else { $fallbackOsVersion }
+                OSPlatform = if ($machineProjection) { [string]$machineProjection.OSPlatform } else { $fallbackPlatform }
+                OSVersion = if ($machineProjection) { [string]$machineProjection.OSVersion } else { $fallbackOsVersion }
                 MachineTags = $machineTags
-                MachineInfo = New-MachineInfoObject -Machine $machine
+                MachineInfo = if ($machineProjection) { $machineProjection.MachineInfo } else { $null }
             }
         }
         $deviceProfile = $deviceProfiles[$deviceKey]
@@ -1987,7 +1988,7 @@ function Get-DashboardAuditResult {
 
     $auditStopwatch = [System.Diagnostics.Stopwatch]::StartNew()
     $machineLoadStopwatch = [System.Diagnostics.Stopwatch]::StartNew()
-    $machines = Read-MachineData -Path $ResolvedExportsPath
+    $machines = Read-NormalizationMachineLookup -Path $ResolvedExportsPath
     $machineLoadStopwatch.Stop()
     $machineLoadElapsedSeconds = [math]::Round($machineLoadStopwatch.Elapsed.TotalSeconds, 2)
 

--- a/src/powershell/Validation/Audit/DashboardAudit.ps1
+++ b/src/powershell/Validation/Audit/DashboardAudit.ps1
@@ -401,6 +401,10 @@ function Read-SourceRow {
                 $groupName = if ([string]::IsNullOrWhiteSpace($fallbackGroupName)) { '(none)' } else { $fallbackGroupName }
             }
 
+            $projectedDeviceName = if ($machineProjection) { [string]$machineProjection.ComputerDnsName } else { $null }
+            $projectedOsPlatform = if ($machineProjection) { [string]$machineProjection.OSPlatform } else { $null }
+            $projectedOsVersion = if ($machineProjection) { [string]$machineProjection.OSVersion } else { $null }
+
             $machineTags = if ($machineProjection -and @($machineProjection.MachineTags).Count -gt 0) {
                 @($machineProjection.MachineTags)
             }
@@ -412,10 +416,10 @@ function Read-SourceRow {
             }
 
             $deviceProfiles[$deviceKey] = [PSCustomObject]@{
-                DeviceName = if ($machineProjection) { [string]$machineProjection.ComputerDnsName } elseif ($fallbackDeviceName) { $fallbackDeviceName } else { '(no machine data)' }
+                DeviceName = if (-not [string]::IsNullOrWhiteSpace($projectedDeviceName)) { $projectedDeviceName } elseif (-not [string]::IsNullOrWhiteSpace([string]$fallbackDeviceName)) { $fallbackDeviceName } else { '(no machine data)' }
                 RbacGroupName = $groupName
-                OSPlatform = if ($machineProjection) { [string]$machineProjection.OSPlatform } else { $fallbackPlatform }
-                OSVersion = if ($machineProjection) { [string]$machineProjection.OSVersion } else { $fallbackOsVersion }
+                OSPlatform = if (-not [string]::IsNullOrWhiteSpace($projectedOsPlatform)) { $projectedOsPlatform } else { $fallbackPlatform }
+                OSVersion = if (-not [string]::IsNullOrWhiteSpace($projectedOsVersion)) { $projectedOsVersion } else { $fallbackOsVersion }
                 MachineTags = $machineTags
                 MachineInfo = if ($machineProjection) { $machineProjection.MachineInfo } else { $null }
             }

--- a/src/powershell/Validation/Audit/LargeDatasetAudit.ps1
+++ b/src/powershell/Validation/Audit/LargeDatasetAudit.ps1
@@ -929,13 +929,14 @@ function Read-SourceCanonicalSignatureStream {
         }
 
         if (-not $deviceProfiles.ContainsKey($deviceKey)) {
-            $groupName = if ($machine) { [string]$machine.rbacGroupName } else { $fallbackGroupName }
+            $machineProjection = Get-MachineProjection -Machine $machine
+            $groupName = if ($machineProjection) { [string]$machineProjection.RbacGroupName } else { $fallbackGroupName }
             if ([string]::IsNullOrWhiteSpace($groupName)) {
                 $groupName = if ([string]::IsNullOrWhiteSpace($fallbackGroupName)) { '(none)' } else { $fallbackGroupName }
             }
 
-            $machineTags = if ($machine -and @($machine.machineTags).Count -gt 0) {
-                @($machine.machineTags)
+            $machineTags = if ($machineProjection -and @($machineProjection.MachineTags).Count -gt 0) {
+                @($machineProjection.MachineTags)
             }
             elseif (@($fallbackMachineTags).Count -gt 0) {
                 @($fallbackMachineTags)
@@ -945,12 +946,12 @@ function Read-SourceCanonicalSignatureStream {
             }
 
             $deviceProfiles[$deviceKey] = [PSCustomObject]@{
-                DeviceName = if ($machine) { [string]$machine.computerDnsName } elseif ($fallbackDeviceName) { $fallbackDeviceName } else { '(no machine data)' }
+                DeviceName = if ($machineProjection) { [string]$machineProjection.ComputerDnsName } elseif ($fallbackDeviceName) { $fallbackDeviceName } else { '(no machine data)' }
                 RbacGroupName = $groupName
-                OSPlatform = if ($machine) { [string]$machine.osPlatform } else { $fallbackPlatform }
-                OSVersion = if ($machine) { [string]$machine.osVersion } else { $fallbackOsVersion }
+                OSPlatform = if ($machineProjection) { [string]$machineProjection.OSPlatform } else { $fallbackPlatform }
+                OSVersion = if ($machineProjection) { [string]$machineProjection.OSVersion } else { $fallbackOsVersion }
                 MachineTags = $machineTags
-                MachineInfo = New-MachineInfoObject -Machine $machine
+                MachineInfo = if ($machineProjection) { $machineProjection.MachineInfo } else { $null }
             }
         }
 
@@ -1945,7 +1946,7 @@ function Get-StreamingDashboardAuditResult {
             }
             else {
                 $machineLoadStopwatch = [System.Diagnostics.Stopwatch]::StartNew()
-                $machines = Read-MachineData -Path $ResolvedExportsPath
+                $machines = Read-NormalizationMachineLookup -Path $ResolvedExportsPath
                 $machineLoadStopwatch.Stop()
                 $machineLoadElapsedSeconds = [math]::Round($machineLoadStopwatch.Elapsed.TotalSeconds, 2)
 

--- a/src/powershell/Validation/Audit/LargeDatasetAudit.ps1
+++ b/src/powershell/Validation/Audit/LargeDatasetAudit.ps1
@@ -935,6 +935,10 @@ function Read-SourceCanonicalSignatureStream {
                 $groupName = if ([string]::IsNullOrWhiteSpace($fallbackGroupName)) { '(none)' } else { $fallbackGroupName }
             }
 
+            $projectedDeviceName = if ($machineProjection) { [string]$machineProjection.ComputerDnsName } else { $null }
+            $projectedOsPlatform = if ($machineProjection) { [string]$machineProjection.OSPlatform } else { $null }
+            $projectedOsVersion = if ($machineProjection) { [string]$machineProjection.OSVersion } else { $null }
+
             $machineTags = if ($machineProjection -and @($machineProjection.MachineTags).Count -gt 0) {
                 @($machineProjection.MachineTags)
             }
@@ -946,10 +950,10 @@ function Read-SourceCanonicalSignatureStream {
             }
 
             $deviceProfiles[$deviceKey] = [PSCustomObject]@{
-                DeviceName = if ($machineProjection) { [string]$machineProjection.ComputerDnsName } elseif ($fallbackDeviceName) { $fallbackDeviceName } else { '(no machine data)' }
+                DeviceName = if (-not [string]::IsNullOrWhiteSpace($projectedDeviceName)) { $projectedDeviceName } elseif (-not [string]::IsNullOrWhiteSpace([string]$fallbackDeviceName)) { $fallbackDeviceName } else { '(no machine data)' }
                 RbacGroupName = $groupName
-                OSPlatform = if ($machineProjection) { [string]$machineProjection.OSPlatform } else { $fallbackPlatform }
-                OSVersion = if ($machineProjection) { [string]$machineProjection.OSVersion } else { $fallbackOsVersion }
+                OSPlatform = if (-not [string]::IsNullOrWhiteSpace($projectedOsPlatform)) { $projectedOsPlatform } else { $fallbackPlatform }
+                OSVersion = if (-not [string]::IsNullOrWhiteSpace($projectedOsVersion)) { $projectedOsVersion } else { $fallbackOsVersion }
                 MachineTags = $machineTags
                 MachineInfo = if ($machineProjection) { $machineProjection.MachineInfo } else { $null }
             }

--- a/templates/dashboard.css
+++ b/templates/dashboard.css
@@ -1504,6 +1504,12 @@ tbody tr:hover {
     background: var(--color-surface-alt);
 }
 
+.devices-table-container.virtualized-table-container {
+    max-height: 28rem;
+    overflow: auto;
+    overscroll-behavior: contain;
+}
+
 @media (max-width: 960px) {
     .remediation-card-header {
         flex-direction: column;

--- a/templates/dashboard.js
+++ b/templates/dashboard.js
@@ -149,6 +149,8 @@ let sortImpactAnalysisDirection = {};
 const TABLE_PAGE_SIZE = 100;
 const CARD_PAGE_SIZE = 20;
 const CARD_RENDER_BATCH_SIZE = 50;
+const DEVICE_CARD_VIRTUALIZATION_THRESHOLD = 250;
+const DEVICE_CARD_VIRTUALIZATION_ROW_HEIGHT = 44;
 const configuredPdfPageWarningThreshold = Number(dashboardConfig.pdfExportPageWarningThreshold);
 const configuredReportDataWarmupRowLimit = Number(dashboardConfig.reportDataWarmupRowLimit);
 const configuredReportDataWarmupMode = typeof dashboardConfig.reportDataWarmupMode === 'string'
@@ -302,6 +304,192 @@ let remediationsByDeviceExpanded = false;
 let remediationsByDeviceSortDirection = {};
 let expandedDevices = {};
 let lastFocusedElementBeforeModal = null;
+let forceFullDevicesByRemediationRows = false;
+
+function getDashboardGlobalScope() {
+    if (typeof window !== 'undefined' && window) {
+        return window;
+    }
+
+    return globalThis;
+}
+
+function createEmptyDashboardMetricsState() {
+    return {
+        version: 1,
+        deliveryMode: dashboardConfig.deliveryMode || 'self-contained',
+        activeReportId,
+        ready: false,
+        lastUpdatedUtc: '',
+        phases: {
+            loadDataMs: 0,
+            denormalizeMs: 0,
+            applyFiltersMs: 0,
+            initTotalMs: 0
+        },
+        reports: {},
+        counts: {
+            applyFilters: 0,
+            renders: 0
+        }
+    };
+}
+
+let dashboardMetrics = createEmptyDashboardMetricsState();
+
+function cloneDashboardMetricsSnapshot() {
+    const reports = {};
+    Object.keys(dashboardMetrics.reports).forEach(reportId => {
+        reports[reportId] = { ...dashboardMetrics.reports[reportId] };
+    });
+
+    return {
+        version: dashboardMetrics.version,
+        deliveryMode: dashboardMetrics.deliveryMode,
+        activeReportId: dashboardMetrics.activeReportId,
+        ready: dashboardMetrics.ready,
+        lastUpdatedUtc: dashboardMetrics.lastUpdatedUtc,
+        phases: { ...dashboardMetrics.phases },
+        reports,
+        counts: { ...dashboardMetrics.counts }
+    };
+}
+
+function getDashboardMetricsSnapshot() {
+    dashboardMetrics.activeReportId = getCurrentReportId();
+    dashboardMetrics.ready = Boolean(getDashboardGlobalScope()._dashboardReady);
+    dashboardMetrics.lastUpdatedUtc = new Date().toISOString();
+    return cloneDashboardMetricsSnapshot();
+}
+
+function hasDashboardElement(id) {
+    return Boolean(document.getElementById(id));
+}
+
+function getDashboardElementText(id) {
+    const element = document.getElementById(id);
+    return element ? String(element.textContent || '').trim() : '';
+}
+
+function getDashboardSelectOptions(id, fallbackEntries = []) {
+    const element = document.getElementById(id);
+    if (element && element.options) {
+        return Array.from(element.options).map(option => ({
+            value: option.value,
+            label: String(option.textContent || option.label || '').trim()
+        }));
+    }
+
+    return fallbackEntries.map(entry => ({ ...entry }));
+}
+
+function buildDashboardValidationSnapshot() {
+    return {
+        deliveryMode: dashboardConfig.deliveryMode || 'self-contained',
+        activeReportId: getCurrentReportId(),
+        ready: Boolean(getDashboardGlobalScope()._dashboardReady),
+        statusMessage: getDashboardElementText('dashboardStatus'),
+        summaryCards: {
+            critical: getDashboardElementText('criticalCount'),
+            high: getDashboardElementText('highCount'),
+            medium: getDashboardElementText('mediumCount'),
+            low: getDashboardElementText('lowCount')
+        },
+        reportSelectorOptions: getDashboardSelectOptions(
+            'reportSelector',
+            REPORT_IDS.map(reportId => ({ value: reportId, label: REPORT_LABELS[reportId] || reportId }))
+        ),
+        filterControls: {
+            date: hasDashboardElement('filterPillDate'),
+            deviceGroups: hasDashboardElement('filterPillRbacGroup'),
+            deviceTags: hasDashboardElement('filterPillDeviceTags'),
+            platform: hasDashboardElement('filterPillOSPlatform'),
+            severity: hasDashboardElement('filterPillSeverity'),
+            device: hasDashboardElement('filterPillDeviceName'),
+            clearAll: hasDashboardElement('clearAllFiltersButton')
+        },
+        reportSections: REPORT_IDS.reduce((sections, reportId) => {
+            sections[reportId] = hasDashboardElement(reportId + '-section');
+            return sections;
+        }, {}),
+        reportSurfaces: {
+            activeVulnerabilitiesTable: hasDashboardElement('remediationTable'),
+            remediationActivityTable: hasDashboardElement('remediationDetailsTable'),
+            impactAnalysisTable: hasDashboardElement('impactAnalysisTable'),
+            devicesByRemediationContainer: hasDashboardElement('devicesByRemediationContainer'),
+            remediationsByDeviceContainer: hasDashboardElement('remediationsByDeviceContainer')
+        }
+    };
+}
+
+function publishDashboardDiagnostics() {
+    const dashboardScope = getDashboardGlobalScope();
+    const metrics = getDashboardMetricsSnapshot();
+    const validation = buildDashboardValidationSnapshot();
+    dashboardScope.dashboardMetrics = metrics;
+    dashboardScope.dashboardValidation = validation;
+    return { metrics, validation };
+}
+
+function recordDashboardPhaseTiming(name, durationMs) {
+    if (!Number.isFinite(durationMs) || durationMs < 0) {
+        return;
+    }
+
+    dashboardMetrics.phases[name] = Number(durationMs.toFixed(3));
+    publishDashboardDiagnostics();
+}
+
+function recordDashboardRenderTiming(reportId, durationMs) {
+    if (!Number.isFinite(durationMs) || durationMs < 0 || !reportId) {
+        return;
+    }
+
+    const roundedDuration = Number(durationMs.toFixed(3));
+    const currentMetrics = dashboardMetrics.reports[reportId] || {
+        label: REPORT_LABELS[reportId] || reportId,
+        count: 0,
+        lastMs: 0,
+        maxMs: 0
+    };
+    currentMetrics.count += 1;
+    currentMetrics.lastMs = roundedDuration;
+    currentMetrics.maxMs = Math.max(currentMetrics.maxMs, roundedDuration);
+    dashboardMetrics.reports[reportId] = currentMetrics;
+    dashboardMetrics.counts.renders += 1;
+    publishDashboardDiagnostics();
+}
+
+function dispatchDashboardEvent(name, detail) {
+    const dashboardScope = getDashboardGlobalScope();
+    if (typeof dashboardScope.dispatchEvent !== 'function') {
+        return;
+    }
+
+    if (typeof CustomEvent === 'function') {
+        dashboardScope.dispatchEvent(new CustomEvent(name, { detail }));
+        return;
+    }
+
+    if (typeof Event === 'function') {
+        const event = new Event(name);
+        event.detail = detail;
+        dashboardScope.dispatchEvent(event);
+        return;
+    }
+
+    dashboardScope.dispatchEvent({ type: name, detail });
+}
+
+function markDashboardReady() {
+    const dashboardScope = getDashboardGlobalScope();
+    dashboardScope._dashboardReady = true;
+    const detail = publishDashboardDiagnostics();
+    dispatchDashboardEvent('dashboard-ready', detail);
+}
+
+getDashboardGlobalScope()._dashboardReady = false;
+publishDashboardDiagnostics();
 
 function createEmptyFilterState() {
     return {
@@ -983,12 +1171,14 @@ function setDashboardStatus(message, kind = 'info') {
         status.hidden = true;
         status.removeAttribute('data-status-kind');
         status.textContent = '';
+        publishDashboardDiagnostics();
         return;
     }
 
     status.hidden = false;
     status.dataset.statusKind = kind;
     status.textContent = message;
+    publishDashboardDiagnostics();
 }
 
 function clearDashboardStatus() {
@@ -1610,6 +1800,33 @@ class VirtualModalTable {
 
 // Track active virtual tables so we can clean up when modal closes
 let activeVirtualTables = [];
+let activeDevicesByRemediationVirtualTables = [];
+
+function destroyManagedVirtualTables(registry) {
+    registry.forEach(vt => vt.destroy());
+    registry.length = 0;
+}
+
+function attachManagedVirtualTables(scrollContainer, vtRowData, registry) {
+    for (const [vtId, config] of Object.entries(vtRowData)) {
+        const tbody = scrollContainer.querySelector(`tbody[data-vt-id="${vtId}"]`);
+        if (!tbody) {
+            continue;
+        }
+
+        if (config.items.length > VIRTUAL_SCROLL_THRESHOLD) {
+            registry.push(new VirtualModalTable(
+                scrollContainer,
+                tbody,
+                config.items,
+                config.rowBuilder,
+                config.rowHeight || 36
+            ));
+        } else {
+            tbody.innerHTML = config.items.map(config.rowBuilder).join('');
+        }
+    }
+}
 
 // =============================================================================
 // DATA LOADING AND DENORMALIZATION
@@ -2199,16 +2416,22 @@ async function denormalizeWithCaching() {
  * Initialize the dashboard on page load
  */
 async function init() {
+    const initStart = performance.now();
     console.time('[perf] init total');
     setDashboardStatus('Loading dashboard data...');
 
     // Load and process data
+    const loadDataStart = performance.now();
     console.time('[perf] loadData');
     await loadData();
     console.timeEnd('[perf] loadData');
+    recordDashboardPhaseTiming('loadDataMs', performance.now() - loadDataStart);
+
+    const denormalizeStart = performance.now();
     console.time('[perf] denormalize');
     await denormalizeWithCaching();
     console.timeEnd('[perf] denormalize');
+    recordDashboardPhaseTiming('denormalizeMs', performance.now() - denormalizeStart);
     await ensureChartJsLoaded();
     
     logDebug('Initializing dashboard with', vulnerabilityData.length, 'vulnerabilities');
@@ -2223,7 +2446,8 @@ async function init() {
     scheduleApplyFilters(true);
     clearDashboardStatus();
     console.timeEnd('[perf] init total');
-    window._dashboardReady = true;
+    recordDashboardPhaseTiming('initTotalMs', performance.now() - initStart);
+    markDashboardReady();
 }
 
 function renderActiveVulnerabilitiesReport() {
@@ -2251,8 +2475,11 @@ function renderRemediationsByDeviceReport() {
 
 function renderReport(reportId, force = false) {
     if (!force && !dirtyReports.has(reportId) && initializedReports.has(reportId)) {
+        publishDashboardDiagnostics();
         return;
     }
+
+    const renderStart = performance.now();
 
     switch (reportId) {
         case 'active-vulnerabilities':
@@ -2271,11 +2498,13 @@ function renderReport(reportId, force = false) {
             renderRemediationsByDeviceReport();
             break;
         default:
+            publishDashboardDiagnostics();
             return;
     }
 
     initializedReports.add(reportId);
     dirtyReports.delete(reportId);
+    recordDashboardRenderTiming(reportId, performance.now() - renderStart);
 }
 
 function renderActiveReport(force = false) {
@@ -2471,6 +2700,7 @@ function handleReportChange() {
     }
 
     updateRemediationReportModeUi(selectedReport);
+    publishDashboardDiagnostics();
     scheduleVisibleReportRender(selectedReport);
 }
 
@@ -3804,6 +4034,8 @@ function applyFilters() {
         updateRemediationReportModeUi(activeReportId);
         markAllReportsDirty();
         renderActiveReport(true);
+        dashboardMetrics.counts.applyFilters += 1;
+        recordDashboardPhaseTiming('applyFiltersMs', performance.now() - _t0);
         return;
     }
 
@@ -3857,11 +4089,15 @@ function applyFilters() {
     updateStats();
     updateRemediationReportModeUi(activeReportId);
     markAllReportsDirty();
+    dashboardMetrics.counts.applyFilters += 1;
+    const applyFiltersDurationMs = performance.now() - _t0;
+    recordDashboardPhaseTiming('applyFiltersMs', applyFiltersDurationMs);
     requestAnimationFrame(() => {
         renderActiveReport(true);
         scheduleReportDataWarmup();
+        publishDashboardDiagnostics();
     });
-    console.log(`[perf] applyFilters: ${(performance.now() - _t0).toFixed(1)}ms  (${result.length}/${len} rows passed)`);
+    console.log(`[perf] applyFilters: ${applyFiltersDurationMs.toFixed(1)}ms  (${result.length}/${len} rows passed)`);
 }
 
 // =============================================================================
@@ -3909,6 +4145,7 @@ function updateStats() {
     els.high.textContent = counts.High;
     els.medium.textContent = counts.Medium;
     els.low.textContent = counts.Low;
+    publishDashboardDiagnostics();
 }
 
 /**
@@ -3982,6 +4219,34 @@ function formatSoftwareName(vendor, product) {
     return `${vendorPart} - ${productPart}`;
 }
 
+function formatOsPlatformLabel(osPlatform) {
+    const platformText = normalizeRemediationText(osPlatform);
+    if (!platformText) {
+        return '';
+    }
+
+    const normalized = platformText
+        .replace(/_/g, ' ')
+        .replace(/([a-z])([A-Z])/g, '$1 $2')
+        .replace(/([A-Za-z])(\d+)/g, '$1 $2')
+        .replace(/(\d)([A-Za-z]+)/g, '$1 $2')
+        .replace(/\s+/g, ' ')
+        .trim();
+
+    const releaseNormalized = normalized.replace(/\bR\s+(\d)\b/g, 'R$1');
+
+    const lower = releaseNormalized.toLowerCase();
+    if (lower === 'mac os') {
+        return 'macOS';
+    }
+
+    if (lower === 'i os') {
+        return 'iOS';
+    }
+
+    return releaseNormalized;
+}
+
 function normalizeOsVersionGroupingLabel(osPlatform, osVersion) {
     const versionText = normalizeRemediationText(osVersion);
     if (!versionText) {
@@ -4009,23 +4274,50 @@ function normalizeOsVersionGroupingLabel(osPlatform, osVersion) {
     return normalizedParts.join('.');
 }
 
-function getVersionAwareSoftwareLabel(software, osPlatform, osVersion, splitByVersion) {
-    if (!splitByVersion) {
-        return software;
-    }
-
-    const versionLabel = normalizeOsVersionGroupingLabel(osPlatform, osVersion);
-    if (!versionLabel || !software || software === 'Unknown') {
-        return software;
-    }
-
-    return `${software} (${versionLabel})`;
-}
-
 function getOsFamilyComparisonKey(text) {
     return normalizeRemediationText(text)
         .toLowerCase()
         .replace(/[^a-z0-9]+/g, '');
+}
+
+function isOsFamilySoftwareLabel(software) {
+    const softwareKey = getOsFamilyComparisonKey(software);
+    return /^(windows|macos|ubuntu|debian|linux|android|ios|chromeos)/.test(softwareKey);
+}
+
+function getVersionAwareSoftwareLabel(software, osPlatform, osVersion, splitByVersion) {
+    if (!software || software === 'Unknown') {
+        return software;
+    }
+
+    if (splitByVersion) {
+        const versionLabel = normalizeOsVersionGroupingLabel(osPlatform, osVersion);
+        if (!versionLabel) {
+            return software;
+        }
+
+        return `${software} (${versionLabel})`;
+    }
+
+    if (!isOsFamilySoftwareLabel(software)) {
+        return software;
+    }
+
+    const softwareKey = getOsFamilyComparisonKey(software);
+    const platformKey = getOsFamilyComparisonKey(osPlatform);
+    if (!softwareKey || !platformKey) {
+        return software;
+    }
+
+    const matchesPlatform = softwareKey === platformKey
+        || softwareKey.startsWith(platformKey)
+        || platformKey.startsWith(softwareKey);
+    if (matchesPlatform) {
+        return software;
+    }
+
+    const platformLabel = formatOsPlatformLabel(osPlatform);
+    return platformLabel ? `${software} [${platformLabel}]` : software;
 }
 
 function shouldSplitRemediationByOsVersion(software, osPlatform) {
@@ -4066,16 +4358,11 @@ function getVersionAwareImpactDisplayName(descriptor, software, osPlatform, osVe
     }
 
     const baseName = getScopedRemediationDisplayTitle(descriptor);
-    if (!splitByVersion) {
-        versionAwareImpactDisplayNameCache.set(cacheKey, baseName);
-        return baseName;
-    }
-
-    const baseSoftwareLabel = formatSoftwarePart(software)
+    const baseSoftwareLabel = normalizeRemediationText(software)
         || normalizeRemediationText(descriptor?.softwareLabel)
         || normalizeRemediationText(descriptor?.scopeLabel)
         || 'Unknown';
-    const versionedSoftwareLabel = getVersionAwareSoftwareLabel(baseSoftwareLabel, osPlatform, osVersion, true);
+    const versionedSoftwareLabel = getVersionAwareSoftwareLabel(baseSoftwareLabel, osPlatform, osVersion, splitByVersion);
 
     if (!versionedSoftwareLabel || versionedSoftwareLabel === baseSoftwareLabel) {
         versionAwareImpactDisplayNameCache.set(cacheKey, baseName);
@@ -4878,7 +5165,11 @@ function getRemediationAdvisoryFamilyMergeKey(target, fallbackKey = '') {
     }
 
     const datePart = normalizeRemediationText(target?.date);
-    const mergeKey = `${recommendationReference}|${advisoryTitle}`;
+    const displayScope = normalizeRemediationText(target?.software)
+        || normalizeRemediationText(target?.name);
+    const mergeKey = displayScope
+        ? `${recommendationReference}|${advisoryTitle}|${displayScope}`
+        : `${recommendationReference}|${advisoryTitle}`;
     return datePart ? `${datePart}|${mergeKey}` : mergeKey;
 }
 
@@ -4994,7 +5285,12 @@ function mergeImpactRemediationBuckets(target, source) {
     mergeDescriptorObservationMaps(target.descriptorObservationMap, source.descriptorObservationMap);
     mergeRemediationUpdateEntryMaps(target.updateEntryMap, source.updateEntryMap);
     source.devices.forEach(device => target.devices.add(device));
-    target.vulnerabilities.push(...source.vulnerabilities);
+    if (source.cveIds instanceof Set) {
+        source.cveIds.forEach(cveId => target.cveIds.add(cveId));
+    }
+    if (Array.isArray(source.vulnerabilities) && Array.isArray(target.vulnerabilities)) {
+        target.vulnerabilities.push(...source.vulnerabilities);
+    }
     if (shouldPreferRemediationDescriptor(source.remediationDescriptor, target.remediationDescriptor)) {
         target.remediationDescriptor = source.remediationDescriptor;
     }
@@ -5939,7 +6235,7 @@ function getRemediationTableData() {
         const splitByVersion = shouldSplitRemediationByOsVersion(software, v.OSPlatform)
             && (versionBucketsByBaseKey.get(baseKey)?.size || 0) > 1;
         const softwareLabel = getVersionAwareSoftwareLabel(software, v.OSPlatform, v.OSVersion, splitByVersion);
-        const key = splitByVersion ? `${baseKey}|${softwareLabel}` : baseKey;
+        const key = softwareLabel !== software ? `${baseKey}|${softwareLabel}` : baseKey;
 
         if (!remediationMap[key]) {
             remediationMap[key] = {
@@ -6139,7 +6435,12 @@ function getImpactAnalysisData() {
     const remediationMap = {};
     const activeRows = getActiveRowsForCurrentSelection();
     const remediationDescriptors = new Array(activeRows.length);
+    const remediationBaseKeys = new Array(activeRows.length);
+    const remediationFormattedSoftware = new Array(activeRows.length);
+    const remediationCanSplitByOsVersion = new Array(activeRows.length);
+    const remediationRawKeys = new Array(activeRows.length);
     const versionBucketsByBaseKey = new Map();
+    const rawKeyToMergedKey = new Map();
 
     for (let i = 0, len = activeRows.length; i < len; i++) {
         const v = activeRows[i];
@@ -6147,11 +6448,18 @@ function getImpactAnalysisData() {
         const formattedSoftware = formatSoftwarePart(v.SoftwareName);
         const baseKey = remediation.key;
         const canSplitByOsVersion = shouldSplitRemediationByOsVersion(formattedSoftware, v.OSPlatform);
-        const versionBucket = normalizeOsVersionGroupingLabel(v.OSPlatform, v.OSVersion);
 
         remediationDescriptors[i] = remediation;
+        remediationBaseKeys[i] = baseKey;
+        remediationFormattedSoftware[i] = formattedSoftware;
+        remediationCanSplitByOsVersion[i] = canSplitByOsVersion;
 
-        if (!canSplitByOsVersion || !versionBucket) {
+        if (!canSplitByOsVersion) {
+            continue;
+        }
+
+        const versionBucket = normalizeOsVersionGroupingLabel(v.OSPlatform, v.OSVersion);
+        if (!versionBucket) {
             continue;
         }
 
@@ -6166,12 +6474,14 @@ function getImpactAnalysisData() {
 
     activeRows.forEach((v, index) => {
         const remediation = remediationDescriptors[index];
-        const formattedSoftware = formatSoftwarePart(v.SoftwareName);
-        const baseKey = remediation.key;
-        const splitByVersion = shouldSplitRemediationByOsVersion(formattedSoftware, v.OSPlatform)
+        const formattedSoftware = remediationFormattedSoftware[index];
+        const baseKey = remediationBaseKeys[index];
+        const splitByVersion = remediationCanSplitByOsVersion[index]
             && (versionBucketsByBaseKey.get(baseKey)?.size || 0) > 1;
+        const baseImpactName = getScopedRemediationDisplayTitle(remediation);
         const impactName = getVersionAwareImpactDisplayName(remediation, formattedSoftware, v.OSPlatform, v.OSVersion, splitByVersion);
-        const key = splitByVersion ? `${baseKey}|${impactName}` : baseKey;
+        const key = impactName !== baseImpactName ? `${baseKey}|${impactName}` : baseKey;
+        remediationRawKeys[index] = key;
 
         if (!remediationMap[key]) {
             remediationMap[key] = {
@@ -6180,30 +6490,36 @@ function getImpactAnalysisData() {
                 name: impactName,
                 updateEntryMap: new Map(),
                 devices: new Set(),
-                vulnerabilities: []
+                cveIds: new Set()
             };
         }
 
         observeRemediationDescriptor(remediationMap[key], remediation);
         addRemediationUpdateEntry(remediationMap[key].updateEntryMap, remediation);
         remediationMap[key].devices.add(getDeviceIdentityKey(v));
-        remediationMap[key].vulnerabilities.push(v);
+        remediationMap[key].cveIds.add(v.CveId);
+    });
+
+    Object.entries(remediationMap).forEach(([key, bucket]) => {
+        rawKeyToMergedKey.set(key, getRemediationAdvisoryFamilyMergeKey(bucket, key));
     });
 
     const mergedRemediationMap = mergeRemediationObjectBuckets(remediationMap, mergeImpactRemediationBuckets);
 
-    const top25 = Object.values(mergedRemediationMap)
-        .map(data => ({
+    const top25 = Object.entries(mergedRemediationMap)
+        .map(([key, data]) => ({
+            key,
             remediationDescriptor: getDominantRemediationDescriptor(data) || data.remediationDescriptor,
             name: data.name,
             updateEntries: finalizeRemediationUpdateEntries(data.updateEntryMap),
-            impact: data.devices.size * new Set(data.vulnerabilities.map(v => v.CveId)).size,
-            vulnerabilities: data.vulnerabilities
+            impact: data.devices.size * data.cveIds.size,
+            vulnerabilities: []
         }))
         .map(data => {
             const name = data.name || getScopedRemediationDisplayTitle(data.remediationDescriptor);
             const updateDisplay = buildSeparatedRemediationUpdateDisplay(name, data.remediationDescriptor, data.updateEntries);
             return {
+                key: data.key,
                 name: name,
                 nameHtml: buildRemediationTitleCellHtml(name),
                 updateEntries: data.updateEntries,
@@ -6215,6 +6531,17 @@ function getImpactAnalysisData() {
         })
         .sort((a, b) => b.impact - a.impact)
         .slice(0, 25);
+
+    const top25ByKey = new Map(top25.map(item => [item.key, item]));
+    for (let index = 0, len = activeRows.length; index < len; index++) {
+        const v = activeRows[index];
+        const rawKey = remediationRawKeys[index];
+        const mergedKey = rawKeyToMergedKey.get(rawKey) || rawKey;
+        const top25Entry = top25ByKey.get(mergedKey);
+        if (top25Entry) {
+            top25Entry.vulnerabilities.push(v);
+        }
+    }
 
     const top25VulnIds = new Set();
     top25.forEach(rem => {
@@ -7550,6 +7877,7 @@ function initCveTooltips() {
 function renderDevicesByRemediationTablePage() {
     const container = document.getElementById('devicesByRemediationContainer');
     container.innerHTML = '';
+    destroyManagedVirtualTables(activeDevicesByRemediationVirtualTables);
     
     // Initialize tooltip system once
     if (!document.getElementById('cve-global-tooltip')) {
@@ -7572,10 +7900,29 @@ function renderDevicesByRemediationTablePage() {
     updateDevicesByRemediationScrollInfo();
 }
 
+function buildDevicesByRemediationDeviceRow(device) {
+    const tagsDisplay = Array.isArray(device.MachineTags) && device.MachineTags.length > 0
+        ? device.MachineTags.join(', ')
+        : '(No Tags)';
+
+    return '<tr>' +
+        '<td>' + escapeHtml(device.DeviceName || 'Unknown') + '</td>' +
+        '<td>' + escapeHtml(device.IpAddress || '-') + '</td>' +
+        '<td>' + escapeHtml(device.RbacGroupName || '-') + '</td>' +
+        '<td>' + escapeHtml(tagsDisplay) + '</td>' +
+        '</tr>';
+}
+
+function shouldVirtualizeDevicesByRemediationCard(sortedDevices) {
+    return !forceFullDevicesByRemediationRows
+        && Array.isArray(sortedDevices)
+        && sortedDevices.length > DEVICE_CARD_VIRTUALIZATION_THRESHOLD;
+}
+
 /**
  * Append a single remediation card to the container
  */
-function appendDevicesByRemediationCard(container, data, index) {
+function appendDevicesByRemediationCard(container, data, index, pendingVirtualTables) {
     const card = document.createElement('div');
     card.className = 'remediation-card';
     
@@ -7701,22 +8048,14 @@ function appendDevicesByRemediationCard(container, data, index) {
     const sortedDevices = Array.from(data.devices.values()).sort((a, b) => 
         a.DeviceName.localeCompare(b.DeviceName)
     );
-    
-    // Build device rows
-    const deviceRows = sortedDevices.map(device => {
-        const tagsDisplay = device.MachineTags.length > 0 
-            ? device.MachineTags.join(', ') 
-            : '(No Tags)';
-        
-        return `
-            <tr>
-                <td>${device.DeviceName}</td>
-                <td>${device.IpAddress}</td>
-                <td>${device.RbacGroupName}</td>
-                <td>${tagsDisplay}</td>
-            </tr>
-        `;
-    }).join('');
+    const shouldVirtualizeDeviceRows = shouldVirtualizeDevicesByRemediationCard(sortedDevices);
+    const deviceTableId = `devices-by-remediation-${index}`;
+    const deviceRows = shouldVirtualizeDeviceRows
+        ? ''
+        : sortedDevices.map(buildDevicesByRemediationDeviceRow).join('');
+    const virtualizationNote = shouldVirtualizeDeviceRows
+        ? `<div class="remediation-density-note">Showing a virtualized device table for ${data.deviceCount.toLocaleString()} devices. Scroll inside the table to inspect the full list without inflating the page DOM.</div>`
+        : '';
     
     card.innerHTML = `
         <div class="remediation-card-header">
@@ -7735,7 +8074,8 @@ function appendDevicesByRemediationCard(container, data, index) {
         <div class="devices-header-row">
             <h4>Vulnerable Devices</h4>
         </div>
-        <div class="devices-table-container">
+        ${virtualizationNote}
+        <div class="devices-table-container${shouldVirtualizeDeviceRows ? ' virtualized-table-container' : ''}">
             <table class="devices-table">
                 <thead>
                     <tr>
@@ -7745,22 +8085,46 @@ function appendDevicesByRemediationCard(container, data, index) {
                         <th>Tags</th>
                     </tr>
                 </thead>
-                <tbody>
+                <tbody${shouldVirtualizeDeviceRows ? ` data-vt-id="${deviceTableId}"` : ''}>
                     ${deviceRows}
                 </tbody>
             </table>
         </div>
     `;
+
+    if (shouldVirtualizeDeviceRows) {
+        pendingVirtualTables.push({
+            card,
+            tableId: deviceTableId,
+            devices: sortedDevices
+        });
+    }
     
     container.appendChild(card);
 }
 
 function appendDevicesByRemediationCards(container, startIdx, endIdx) {
     const fragment = document.createDocumentFragment();
+    const pendingVirtualTables = [];
     for (let i = startIdx; i < endIdx; i++) {
-        appendDevicesByRemediationCard(fragment, devicesByRemediationAllData[i], i + 1);
+        appendDevicesByRemediationCard(fragment, devicesByRemediationAllData[i], i + 1, pendingVirtualTables);
     }
     container.appendChild(fragment);
+
+    pendingVirtualTables.forEach(({ card, tableId, devices }) => {
+        const tableContainer = card.querySelector('.virtualized-table-container');
+        if (!tableContainer) {
+            return;
+        }
+
+        attachManagedVirtualTables(tableContainer, {
+            [tableId]: {
+                items: devices,
+                rowBuilder: buildDevicesByRemediationDeviceRow,
+                rowHeight: DEVICE_CARD_VIRTUALIZATION_ROW_HEIGHT
+            }
+        }, activeDevicesByRemediationVirtualTables);
+    });
 }
 
 /**
@@ -8534,6 +8898,8 @@ function groupDevicesByCveSignature(details) {
  * Threshold: tables with more rows than this use virtual scrolling
  */
 const VIRTUAL_SCROLL_THRESHOLD = 50;
+const DENSE_MODAL_DETAIL_THRESHOLD = 15000;
+const DENSE_MODAL_DEVICE_THRESHOLD = 2500;
 
 /**
  * Build a detail-row HTML string for showDetails CVE tables
@@ -8578,6 +8944,119 @@ function buildRemediationRow(v, includeEvidenceColumn) {
         '</tr>';
 }
 
+function buildModalSummaryCounts(details, summarySource) {
+    return {
+        totalDetails: details.length,
+        totalDevices: summarySource && summarySource.devices instanceof Set
+            ? summarySource.devices.size
+            : new Set(details.map(d => getDeviceIdentityKey(d))).size,
+        totalCves: summarySource && summarySource.vulnerabilities instanceof Set
+            ? summarySource.vulnerabilities.size
+            : new Set(details.map(d => d.CveId)).size
+    };
+}
+
+function shouldUseDenseDetailsModalLayout(summaryCounts) {
+    return summaryCounts.totalDetails > DENSE_MODAL_DETAIL_THRESHOLD
+        || summaryCounts.totalDevices > DENSE_MODAL_DEVICE_THRESHOLD;
+}
+
+function formatModalDeviceId(deviceId) {
+    if (!deviceId) {
+        return '-';
+    }
+
+    return deviceId.length > 12 ? deviceId.substring(0, 12) + '...' : deviceId;
+}
+
+function buildDenseModalDeviceRows(details) {
+    const deviceMap = new Map();
+
+    for (let i = 0; i < details.length; i++) {
+        const detail = details[i];
+        const key = getDeviceIdentityKey(detail);
+        let device = deviceMap.get(key);
+
+        if (!device) {
+            device = {
+                DeviceName: detail.DeviceName || 'Unknown',
+                DeviceId: detail.DeviceId || '',
+                MachineInfo: detail.MachineInfo || null,
+                cveIds: new Set(),
+                lastSeen: getLastSeenDate(detail)
+            };
+            deviceMap.set(key, device);
+        }
+
+        device.cveIds.add(detail.CveId);
+        const candidateLastSeen = getLastSeenDate(detail);
+        if (candidateLastSeen && (!device.lastSeen || candidateLastSeen > device.lastSeen)) {
+            device.lastSeen = candidateLastSeen;
+        }
+    }
+
+    return Array.from(deviceMap.values()).sort((a, b) => {
+        if (b.cveIds.size !== a.cveIds.size) {
+            return b.cveIds.size - a.cveIds.size;
+        }
+
+        return a.DeviceName.localeCompare(b.DeviceName);
+    });
+}
+
+function buildDenseModalDeviceRow(device) {
+    const ipAddress = device.MachineInfo && device.MachineInfo.ip ? device.MachineInfo.ip : '-';
+
+    return '<tr>' +
+        '<td>' + escapeHtml(device.DeviceName) + '</td>' +
+        '<td title="' + escapeHtml(device.DeviceId || '') + '">' + escapeHtml(formatModalDeviceId(device.DeviceId)) + '</td>' +
+        '<td>' + device.cveIds.size + '</td>' +
+        '<td>' + escapeHtml(ipAddress) + '</td>' +
+        '<td class="modal-date-col">' + formatDateYMD(device.lastSeen) + '</td>' +
+        '</tr>';
+}
+
+function buildDenseDetailRow(v, includeEvidenceColumn) {
+    const severityClass = v.VulnerabilitySeverityLevel.toLowerCase();
+    const epssDisplay = v.EpssScore != null ? v.EpssScore.toFixed(5) : '-';
+    const publishedDisplay = formatDateYMD(v.PublishedDate);
+    const firstSeenDisplay = getEnvironmentFirstSeenDate(v);
+
+    return '<tr>' +
+        '<td>' + escapeHtml(v.DeviceName || 'Unknown') + '</td>' +
+        '<td title="' + escapeHtml(v.DeviceId || '') + '">' + escapeHtml(formatModalDeviceId(v.DeviceId)) + '</td>' +
+        buildCveLinkHtml(v) +
+        '<td>' + escapeHtml(v.SoftwareVersion) + '</td>' +
+        '<td><span class="badge ' + severityClass + '">' + v.VulnerabilitySeverityLevel + '</span></td>' +
+        '<td>' + v.CvssScore + '</td>' +
+        '<td>' + epssDisplay + '</td>' +
+        '<td>' + formatExploitLevel(v.ExploitabilityLevel) + '</td>' +
+        (includeEvidenceColumn ? buildEvidenceHtml(v) : '') +
+        '<td class="modal-date-col">' + publishedDisplay + '</td>' +
+        '<td class="modal-date-col">' + firstSeenDisplay + '</td>' +
+        '</tr>';
+}
+
+    function buildDenseRemediationDetailRow(v, includeEvidenceColumn) {
+        const severityClass = v.VulnerabilitySeverityLevel.toLowerCase();
+        const epssDisplay = v.EpssScore != null ? v.EpssScore.toFixed(5) : '-';
+        const publishedDisplay = formatDateYMD(v.PublishedDate);
+        const firstSeenDisplay = getEnvironmentFirstSeenDate(v);
+
+        return '<tr>' +
+        '<td>' + escapeHtml(v.DeviceName || 'Unknown') + '</td>' +
+        '<td title="' + escapeHtml(v.DeviceId || '') + '">' + escapeHtml(formatModalDeviceId(v.DeviceId)) + '</td>' +
+        buildCveLinkHtml(v) +
+        '<td>' + escapeHtml(v.SoftwareVersion) + '</td>' +
+        '<td><span class="badge ' + severityClass + '">' + v.VulnerabilitySeverityLevel + '</span></td>' +
+        '<td>' + v.CvssScore + '</td>' +
+        '<td>' + epssDisplay + '</td>' +
+        (includeEvidenceColumn ? buildEvidenceHtml(v) : '') +
+        '<td class="modal-date-col">' + publishedDisplay + '</td>' +
+        '<td class="modal-date-col">' + firstSeenDisplay + '</td>' +
+        '</tr>';
+    }
+
 /**
  * Check whether any vulnerability in a list has evidence paths
  * @param {Array} vulnerabilities - Array of vulnerability objects
@@ -8599,28 +9078,234 @@ function hasAnyEvidence(vulnerabilities) {
  * that has a data-vt-rows attribute storing row data.
  */
 function attachVirtualTables(scrollContainer, vtRowData) {
-    activeVirtualTables.forEach(vt => vt.destroy());
-    activeVirtualTables = [];
-
-    for (const [vtId, config] of Object.entries(vtRowData)) {
-        const tbody = scrollContainer.querySelector(`tbody[data-vt-id="${vtId}"]`);
-        if (!tbody) continue;
-
-        if (config.items.length > VIRTUAL_SCROLL_THRESHOLD) {
-            activeVirtualTables.push(new VirtualModalTable(scrollContainer, tbody, config.items, config.rowBuilder));
-        } else if (tbody) {
-            tbody.innerHTML = config.items.map(config.rowBuilder).join('');
-        }
-    }
+    destroyManagedVirtualTables(activeVirtualTables);
+    attachManagedVirtualTables(scrollContainer, vtRowData, activeVirtualTables);
 }
 
-function buildModalGroupCache(details) {
+function buildModalGroupCache(details, summaryCounts) {
+    const summary = summaryCounts || buildModalSummaryCounts(details);
+
     return {
+        ...summary,
+        layoutMode: 'grouped',
         groups: groupDevicesByCveSignature(details),
         includeEvidenceColumn: hasAnyEvidence(details),
-        totalDevices: new Set(details.map(d => getDeviceIdentityKey(d))).size,
-        totalCves: new Set(details.map(d => d.CveId)).size
+        totalDevices: summary.totalDevices,
+        totalCves: summary.totalCves
     };
+}
+
+function buildDenseDetailsModalCache(details, summaryCounts) {
+    return {
+        ...summaryCounts,
+        layoutMode: 'dense',
+        includeEvidenceColumn: hasAnyEvidence(details),
+        deviceRows: buildDenseModalDeviceRows(details)
+    };
+}
+
+function getDetailsModalCache(remediationData) {
+    if (remediationData._modalCache) {
+        return remediationData._modalCache;
+    }
+
+    const summaryCounts = buildModalSummaryCounts(remediationData.details, remediationData);
+    remediationData._modalCache = shouldUseDenseDetailsModalLayout(summaryCounts)
+        ? buildDenseDetailsModalCache(remediationData.details, summaryCounts)
+        : buildModalGroupCache(remediationData.details, summaryCounts);
+
+    return remediationData._modalCache;
+}
+
+function buildGroupedDetailsModalSections(modalCache, updateEntries) {
+    const { groups, includeEvidenceColumn, totalDevices, totalCves } = modalCache;
+    const parts = [];
+    const vtRowData = {};
+
+    parts.push('<h3>Affected Devices and Vulnerabilities</h3>');
+
+    const updateLinksHtml = buildRemediationModalUpdateLinksHtml(updateEntries);
+    if (updateLinksHtml) {
+        parts.push(updateLinksHtml);
+    }
+
+    parts.push('<p class="modal-summary-text">' +
+        totalDevices + ' device' + (totalDevices !== 1 ? 's' : '') + ', ' +
+        totalCves + ' CVE' + (totalCves !== 1 ? 's' : '') + '</p>');
+
+    for (let gi = 0; gi < groups.length; gi++) {
+        const group = groups[gi];
+        const vtId = 'det_' + gi;
+
+        parts.push('<div class="device-bubbles-container">');
+        group.devices.sort((a, b) => a.DeviceName.localeCompare(b.DeviceName));
+        for (let di = 0; di < group.devices.length; di++) {
+            parts.push(buildDeviceBubbleHtml(group.devices[di]));
+        }
+        parts.push('</div>');
+
+        parts.push('<div class="modal-table-container"><table class="detail-table"><thead><tr>',
+            '<th>CVE ID</th><th>Version</th><th>Severity</th><th>CVSS</th><th>EPSS</th><th>Exploitability</th>' +
+            (includeEvidenceColumn ? '<th>Evidence</th>' : '') +
+            '<th class="modal-date-col">Published</th><th class="modal-date-col">Environment First Seen</th>',
+            '</tr></thead><tbody data-vt-id="', vtId, '"></tbody></table></div>');
+
+        vtRowData[vtId] = {
+            items: group.vulns,
+            rowBuilder: vuln => buildDetailRow(vuln, includeEvidenceColumn)
+        };
+
+        if (gi < groups.length - 1) {
+            parts.push('<hr class="modal-section-divider">');
+        }
+    }
+
+    return {
+        layoutMode: 'grouped',
+        parts,
+        vtRowData
+    };
+}
+
+function buildDenseDetailsModalSections(details, modalCache, updateEntries) {
+    const { includeEvidenceColumn, totalDevices, totalCves, deviceRows } = modalCache;
+    const parts = [];
+    const vtRowData = {};
+
+    parts.push('<h3>Affected Devices and Vulnerabilities</h3>');
+
+    const updateLinksHtml = buildRemediationModalUpdateLinksHtml(updateEntries);
+    if (updateLinksHtml) {
+        parts.push(updateLinksHtml);
+    }
+
+    parts.push('<p class="modal-summary-text">' +
+        totalDevices + ' device' + (totalDevices !== 1 ? 's' : '') + ', ' +
+        totalCves + ' CVE' + (totalCves !== 1 ? 's' : '') + '</p>');
+    parts.push('<p class="modal-summary-text">Large result set detected. Showing a virtualized flat view to keep this modal responsive.</p>');
+
+    parts.push('<h3>Affected Devices</h3>');
+    parts.push('<div class="modal-table-container"><table class="detail-table"><thead><tr>',
+        '<th>Device Name</th><th>Device ID</th><th>CVE Count</th><th>IP</th><th class="modal-date-col">Last Seen</th>',
+        '</tr></thead><tbody data-vt-id="det_dense_devices"></tbody></table></div>');
+
+    vtRowData.det_dense_devices = {
+        items: deviceRows,
+        rowBuilder: buildDenseModalDeviceRow
+    };
+
+    parts.push('<h3>Vulnerability Details</h3>');
+    parts.push('<div class="modal-table-container"><table class="detail-table"><thead><tr>',
+        '<th>Device Name</th><th>Device ID</th><th>CVE ID</th><th>Version</th><th>Severity</th><th>CVSS</th><th>EPSS</th><th>Exploitability</th>' +
+        (includeEvidenceColumn ? '<th>Evidence</th>' : '') +
+        '<th class="modal-date-col">Published</th><th class="modal-date-col">Environment First Seen</th>',
+        '</tr></thead><tbody data-vt-id="det_dense_details"></tbody></table></div>');
+
+    vtRowData.det_dense_details = {
+        items: details,
+        rowBuilder: vuln => buildDenseDetailRow(vuln, includeEvidenceColumn)
+    };
+
+    return {
+        layoutMode: 'dense',
+        parts,
+        vtRowData
+    };
+}
+
+function buildDetailsModalSections(remediationData) {
+    const modalCache = getDetailsModalCache(remediationData);
+    const updateEntries = remediationData.updateEntries && remediationData.updateEntries.length > 0
+        ? remediationData.updateEntries
+        : buildRemediationUpdateEntriesFromDetails(remediationData.details);
+
+    return modalCache.layoutMode === 'dense'
+        ? buildDenseDetailsModalSections(remediationData.details, modalCache, updateEntries)
+        : buildGroupedDetailsModalSections(modalCache, updateEntries);
+}
+
+function buildGroupedRemediationDetailsModalSections(remediationData, modalCache) {
+    const { groups, includeEvidenceColumn } = modalCache;
+    const parts = ['<br>', '<h3>Devices Patched</h3>'];
+    const vtRowData = {};
+
+    for (let gi = 0; gi < groups.length; gi++) {
+        const group = groups[gi];
+        const vtId = 'rem_' + gi;
+
+        parts.push('<div class="device-bubbles-container">');
+        group.devices.sort((a, b) => a.DeviceName.localeCompare(b.DeviceName));
+        for (let di = 0; di < group.devices.length; di++) {
+            parts.push(buildDeviceBubbleHtml(group.devices[di]));
+        }
+        parts.push('</div>');
+
+        parts.push('<div class="modal-table-container"><table class="detail-table"><thead><tr>',
+            '<th>CVE ID</th><th>Version</th><th>Severity</th><th>CVSS</th><th>EPSS</th>' +
+            (includeEvidenceColumn ? '<th>Evidence</th>' : '') +
+            '<th class="modal-date-col">Published</th><th class="modal-date-col">Environment First Seen</th>',
+            '</tr></thead><tbody data-vt-id="', vtId, '"></tbody></table></div>');
+
+        vtRowData[vtId] = {
+            items: group.vulns,
+            rowBuilder: vuln => buildRemediationRow(vuln, includeEvidenceColumn)
+        };
+
+        if (gi < groups.length - 1) {
+            parts.push('<hr class="modal-section-divider">');
+        }
+    }
+
+    return {
+        layoutMode: 'grouped',
+        parts,
+        vtRowData
+    };
+}
+
+function buildDenseRemediationDetailsModalSections(remediationData, modalCache) {
+    const { includeEvidenceColumn, deviceRows } = modalCache;
+    const parts = [
+        '<br>',
+        '<h3>Devices Patched</h3>',
+        '<p class="modal-summary-text">Large result set detected. Showing a virtualized flat view to keep this modal responsive.</p>'
+    ];
+    const vtRowData = {};
+
+    parts.push('<div class="modal-table-container"><table class="detail-table"><thead><tr>',
+        '<th>Device Name</th><th>Device ID</th><th>CVE Count</th><th>IP</th><th class="modal-date-col">Last Seen</th>',
+        '</tr></thead><tbody data-vt-id="rem_dense_devices"></tbody></table></div>');
+
+    vtRowData.rem_dense_devices = {
+        items: deviceRows,
+        rowBuilder: buildDenseModalDeviceRow
+    };
+
+    parts.push('<h3>Patched Vulnerabilities</h3>');
+    parts.push('<div class="modal-table-container"><table class="detail-table"><thead><tr>',
+        '<th>Device Name</th><th>Device ID</th><th>CVE ID</th><th>Version</th><th>Severity</th><th>CVSS</th><th>EPSS</th>' +
+        (includeEvidenceColumn ? '<th>Evidence</th>' : '') +
+        '<th class="modal-date-col">Published</th><th class="modal-date-col">Environment First Seen</th>',
+        '</tr></thead><tbody data-vt-id="rem_dense_details"></tbody></table></div>');
+
+    vtRowData.rem_dense_details = {
+        items: remediationData.details,
+        rowBuilder: vuln => buildDenseRemediationDetailRow(vuln, includeEvidenceColumn)
+    };
+
+    return {
+        layoutMode: 'dense',
+        parts,
+        vtRowData
+    };
+}
+
+function buildRemediationDetailsModalSections(remediationData) {
+    const modalCache = getDetailsModalCache(remediationData);
+
+    return modalCache.layoutMode === 'dense'
+        ? buildDenseRemediationDetailsModalSections(remediationData, modalCache)
+        : buildGroupedRemediationDetailsModalSections(remediationData, modalCache);
 }
 
 function focusModalCloseButton() {
@@ -8648,7 +9333,6 @@ function showDetails(remediationData) {
     const modal = document.getElementById('detailModal');
     const modalTitle = document.getElementById('modalTitle');
     const modalBody = document.getElementById('modalBody');
-    const details = remediationData.details;
     const remediation = remediationData.modalTitle
         || remediationData.remediation
         || [remediationData.vendor, remediationData.software].filter(Boolean).join(' ')
@@ -8668,54 +9352,7 @@ function showDetails(remediationData) {
 
     // Defer heavy work so the modal + loading indicator render first
     requestAnimationFrame(() => {
-        const modalCache = remediationData._modalCache || buildModalGroupCache(details);
-        remediationData._modalCache = modalCache;
-        const { groups, includeEvidenceColumn, totalDevices, totalCves } = modalCache;
-        const updateEntries = remediationData.updateEntries && remediationData.updateEntries.length > 0
-            ? remediationData.updateEntries
-            : buildRemediationUpdateEntriesFromDetails(details);
-
-        const parts = [];
-        const vtRowData = {};
-
-        parts.push('<h3>Affected Devices and Vulnerabilities</h3>');
-
-        const updateLinksHtml = buildRemediationModalUpdateLinksHtml(updateEntries);
-        if (updateLinksHtml) {
-            parts.push(updateLinksHtml);
-        }
-
-        parts.push('<p class="modal-summary-text">' +
-            totalDevices + ' device' + (totalDevices !== 1 ? 's' : '') + ', ' +
-            totalCves + ' CVE' + (totalCves !== 1 ? 's' : '') + '</p>');
-
-        for (let gi = 0; gi < groups.length; gi++) {
-            const group = groups[gi];
-            const vtId = 'det_' + gi;
-
-            // Device bubbles
-            parts.push('<div class="device-bubbles-container">');
-            group.devices.sort((a, b) => a.DeviceName.localeCompare(b.DeviceName));
-            for (let di = 0; di < group.devices.length; di++) {
-                parts.push(buildDeviceBubbleHtml(group.devices[di]));
-            }
-            parts.push('</div>');
-
-            // CVE table with empty tbody (rows added via virtual scroll)
-            parts.push('<div class="modal-table-container"><table class="detail-table"><thead><tr>',
-                '<th>CVE ID</th><th>Version</th><th>Severity</th><th>CVSS</th><th>EPSS</th><th>Exploitability</th>' +
-                (includeEvidenceColumn ? '<th>Evidence</th>' : '') +
-                '<th class="modal-date-col">Published</th><th class="modal-date-col">Environment First Seen</th>',
-                '</tr></thead><tbody data-vt-id="', vtId, '"></tbody></table></div>');
-
-            vtRowData[vtId] = {
-                items: group.vulns,
-                rowBuilder: vuln => buildDetailRow(vuln, includeEvidenceColumn)
-            };
-
-            if (gi < groups.length - 1) parts.push('<hr class="modal-section-divider">');
-        }
-
+        const { parts, vtRowData } = buildDetailsModalSections(remediationData);
         modalBody.innerHTML = parts.join('');
         const scrollContainer = modalBody.closest('.modal-content');
         attachVirtualTables(scrollContainer, vtRowData);
@@ -8744,10 +9381,7 @@ function showRemediationDetails(data) {
     }
 
     requestAnimationFrame(() => {
-        const modalCache = data._modalCache || buildModalGroupCache(data.details);
-        data._modalCache = modalCache;
-        const { groups, includeEvidenceColumn } = modalCache;
-        const vtRowData = {};
+        const modalSections = buildRemediationDetailsModalSections(data);
         const updateEntries = data.updateEntries && data.updateEntries.length > 0
             ? data.updateEntries
             : buildRemediationUpdateEntriesFromDetails(data.details);
@@ -8765,39 +9399,11 @@ function showRemediationDetails(data) {
             parts.push(updateLinksHtml);
         }
 
-        parts.push('<br>',
-            '<h3>Devices Patched</h3>');
-
-        for (let gi = 0; gi < groups.length; gi++) {
-            const group = groups[gi];
-            const vtId = 'rem_' + gi;
-
-            // Device bubbles
-            parts.push('<div class="device-bubbles-container">');
-            group.devices.sort((a, b) => a.DeviceName.localeCompare(b.DeviceName));
-            for (let di = 0; di < group.devices.length; di++) {
-                parts.push(buildDeviceBubbleHtml(group.devices[di]));
-            }
-            parts.push('</div>');
-
-            // CVE table with empty tbody
-            parts.push('<div class="modal-table-container"><table class="detail-table"><thead><tr>',
-                '<th>CVE ID</th><th>Version</th><th>Severity</th><th>CVSS</th><th>EPSS</th>' +
-                (includeEvidenceColumn ? '<th>Evidence</th>' : '') +
-                '<th class="modal-date-col">Published</th><th class="modal-date-col">Environment First Seen</th>',
-                '</tr></thead><tbody data-vt-id="', vtId, '"></tbody></table></div>');
-
-            vtRowData[vtId] = {
-                items: group.vulns,
-                rowBuilder: vuln => buildRemediationRow(vuln, includeEvidenceColumn)
-            };
-
-            if (gi < groups.length - 1) parts.push('<hr class="modal-section-divider">');
-        }
+        parts.push(...modalSections.parts);
 
         modalBody.innerHTML = parts.join('');
         const scrollContainer = modalBody.closest('.modal-content');
-        attachVirtualTables(scrollContainer, vtRowData);
+        attachVirtualTables(scrollContainer, modalSections.vtRowData);
     });
 }
 
@@ -8872,8 +9478,7 @@ function showImpactAnalysisDetails(item) {
  * Close the modal and clean up virtual tables
  */
 function closeModal() {
-    activeVirtualTables.forEach(vt => vt.destroy());
-    activeVirtualTables = [];
+    destroyManagedVirtualTables(activeVirtualTables);
     hideGlobalTooltip();
     const modal = document.getElementById('detailModal');
     modal.classList.remove('active');
@@ -9011,39 +9616,43 @@ function loadPdfLibraries() {
  * @returns {boolean} The previous expansion state
  */
 function expandReportForPdf(selectedReport) {
-    let wasExpanded = false;
+    const previousState = {
+        wasExpanded: false,
+        forceFullDevicesByRemediationRows
+    };
     
     switch (selectedReport) {
         case 'active-vulnerabilities':
-            wasExpanded = remediationExpanded;
+            previousState.wasExpanded = remediationExpanded;
             if (!remediationExpanded) {
                 remediationExpanded = true;
                 renderRemediationTablePage();
             }
             break;
         case 'remediation-activity':
-            wasExpanded = remediationDetailsExpanded;
+            previousState.wasExpanded = remediationDetailsExpanded;
             if (!remediationDetailsExpanded) {
                 remediationDetailsExpanded = true;
                 renderRemediationDetailsTablePage();
             }
             break;
         case 'impact-analysis':
-            wasExpanded = impactAnalysisExpanded;
+            previousState.wasExpanded = impactAnalysisExpanded;
             if (!impactAnalysisExpanded) {
                 impactAnalysisExpanded = true;
                 renderImpactAnalysisTablePage();
             }
             break;
         case 'devices-by-remediation':
-            wasExpanded = devicesByRemediationExpanded;
+            previousState.wasExpanded = devicesByRemediationExpanded;
+            forceFullDevicesByRemediationRows = true;
             if (!devicesByRemediationExpanded) {
                 devicesByRemediationExpanded = true;
-                renderDevicesByRemediationTablePage();
             }
+            renderDevicesByRemediationTablePage();
             break;
         case 'remediations-by-device':
-            wasExpanded = remediationsByDeviceExpanded;
+            previousState.wasExpanded = remediationsByDeviceExpanded;
             if (!remediationsByDeviceExpanded) {
                 remediationsByDeviceExpanded = true;
                 renderRemediationsByDeviceTablePage();
@@ -9051,7 +9660,7 @@ function expandReportForPdf(selectedReport) {
             break;
     }
     
-    return wasExpanded;
+    return previousState;
 }
 
 /**
@@ -9059,27 +9668,37 @@ function expandReportForPdf(selectedReport) {
  * @param {string} selectedReport - The report type identifier
  * @param {boolean} wasExpanded - The previous expansion state
  */
-function restoreReportState(selectedReport, wasExpanded) {
-    if (wasExpanded) return;
+function restoreReportState(selectedReport, previousState) {
+    const state = typeof previousState === 'object' && previousState !== null
+        ? previousState
+        : {
+            wasExpanded: Boolean(previousState),
+            forceFullDevicesByRemediationRows
+        };
     
     switch (selectedReport) {
         case 'active-vulnerabilities':
+            if (state.wasExpanded) return;
             remediationExpanded = false;
             renderRemediationTablePage();
             break;
         case 'remediation-activity':
+            if (state.wasExpanded) return;
             remediationDetailsExpanded = false;
             renderRemediationDetailsTablePage();
             break;
         case 'impact-analysis':
+            if (state.wasExpanded) return;
             impactAnalysisExpanded = false;
             renderImpactAnalysisTablePage();
             break;
         case 'devices-by-remediation':
-            devicesByRemediationExpanded = false;
+            forceFullDevicesByRemediationRows = state.forceFullDevicesByRemediationRows;
+            devicesByRemediationExpanded = state.wasExpanded;
             renderDevicesByRemediationTablePage();
             break;
         case 'remediations-by-device':
+            if (state.wasExpanded) return;
             remediationsByDeviceExpanded = false;
             renderRemediationsByDeviceTablePage();
             break;

--- a/tests/Assert-DashboardModalResponsiveness.js
+++ b/tests/Assert-DashboardModalResponsiveness.js
@@ -1,0 +1,111 @@
+﻿const assert = require('assert');
+const { loadDashboardHarness } = require('./helpers/dashboard-test-harness');
+
+function createDetail(index, overrides = {}) {
+    const suffix = String(index).padStart(4, '0');
+
+    return {
+        DeviceId: `device-${suffix}`,
+        DeviceName: `device-${suffix}.contoso.com`,
+        CveId: `CVE-2026-${suffix}`,
+        SoftwareVersion: `10.0.${index}`,
+        VulnerabilitySeverityLevel: 'High',
+        CvssScore: 7.1,
+        EpssScore: 0.00042,
+        ExploitabilityLevel: 'ExploitIsNotPubliclyKnown',
+        PublishedDate: '2026-04-14',
+        FirstSeenTimestamp: '2026-04-15',
+        LastSeenTimestamp: '2026-04-16',
+        MachineInfo: {
+            ip: `10.0.0.${(index % 250) + 1}`,
+            ls: '2026-04-16'
+        },
+        ...overrides
+    };
+}
+
+function main() {
+    const dashboard = loadDashboardHarness(`
+module.exports = {
+    buildDetailsModalSections,
+    buildRemediationDetailsModalSections
+};
+`);
+
+    const groupedDetails = [
+        createDetail(1, { DeviceId: 'device-a', DeviceName: 'device-a.contoso.com', CveId: 'CVE-2026-1001' }),
+        createDetail(2, { DeviceId: 'device-a', DeviceName: 'device-a.contoso.com', CveId: 'CVE-2026-1002' }),
+        createDetail(3, { DeviceId: 'device-b', DeviceName: 'device-b.contoso.com', CveId: 'CVE-2026-1001' })
+    ];
+
+    const groupedResult = dashboard.buildDetailsModalSections({
+        modalTitle: 'Small grouped remediation',
+        details: groupedDetails,
+        devices: new Set(groupedDetails.map(detail => detail.DeviceId)),
+        vulnerabilities: new Set(groupedDetails.map(detail => detail.CveId)),
+        updateEntries: []
+    });
+
+    assert.strictEqual(groupedResult.layoutMode, 'grouped');
+    assert.ok(Object.keys(groupedResult.vtRowData).length >= 1);
+
+    const mediumDetails = Array.from({ length: 600 }, (_, index) => createDetail(index + 1));
+    const mediumResult = dashboard.buildDetailsModalSections({
+        modalTitle: 'Medium remediation set',
+        details: mediumDetails,
+        devices: new Set(mediumDetails.map(detail => detail.DeviceId)),
+        vulnerabilities: new Set(mediumDetails.map(detail => detail.CveId)),
+        updateEntries: []
+    });
+
+    assert.strictEqual(
+        mediumResult.layoutMode,
+        'grouped',
+        'Expected moderate remediation modal sizes to retain the grouped layout instead of defaulting to dense mode.'
+    );
+
+    const denseDetails = Array.from({ length: 2600 }, (_, index) => createDetail(index + 1));
+    const denseResult = dashboard.buildDetailsModalSections({
+        modalTitle: 'Windows 11: April 2026 Security Updates',
+        details: denseDetails,
+        devices: new Set(denseDetails.map(detail => detail.DeviceId)),
+        vulnerabilities: new Set(denseDetails.map(detail => detail.CveId)),
+        updateEntries: []
+    });
+
+    assert.strictEqual(denseResult.layoutMode, 'dense');
+    assert.deepStrictEqual(Object.keys(denseResult.vtRowData).sort(), ['det_dense_details', 'det_dense_devices']);
+    assert.strictEqual(denseResult.vtRowData.det_dense_devices.items.length, 2600);
+    assert.strictEqual(denseResult.vtRowData.det_dense_details.items.length, 2600);
+    assert.ok(denseResult.parts.join('').includes('virtualized flat view'));
+
+    const sampleDeviceRow = denseResult.vtRowData.det_dense_devices.rowBuilder(denseResult.vtRowData.det_dense_devices.items[0]);
+    assert.ok(sampleDeviceRow.includes('device-0001.contoso.com'));
+
+    const sampleDetailRow = denseResult.vtRowData.det_dense_details.rowBuilder(denseResult.vtRowData.det_dense_details.items[0]);
+    assert.ok(sampleDetailRow.includes('device-0001.contoso.com'));
+    assert.ok(sampleDetailRow.includes('CVE-2026-0001'));
+
+    const denseRemediationResult = dashboard.buildRemediationDetailsModalSections({
+        date: '2026-04-16',
+        remediation: 'Windows 11: April 2026 Security Updates',
+        details: denseDetails,
+        devices: new Set(denseDetails.map(detail => detail.DeviceId)),
+        vulnerabilities: new Set(denseDetails.map(detail => detail.CveId)),
+        updateEntries: []
+    });
+
+    assert.strictEqual(denseRemediationResult.layoutMode, 'dense');
+    assert.deepStrictEqual(Object.keys(denseRemediationResult.vtRowData).sort(), ['rem_dense_details', 'rem_dense_devices']);
+    assert.strictEqual(denseRemediationResult.vtRowData.rem_dense_devices.items.length, 2600);
+    assert.strictEqual(denseRemediationResult.vtRowData.rem_dense_details.items.length, 2600);
+    assert.ok(denseRemediationResult.parts.join('').includes('virtualized flat view'));
+
+    const sampleRemediationRow = denseRemediationResult.vtRowData.rem_dense_details.rowBuilder(denseRemediationResult.vtRowData.rem_dense_details.items[0]);
+    assert.ok(sampleRemediationRow.includes('device-0001.contoso.com'));
+    assert.ok(sampleRemediationRow.includes('CVE-2026-0001'));
+
+    console.log('Dashboard modal responsiveness assertions passed.');
+}
+
+main();

--- a/tests/Assert-DashboardRemediationViews.js
+++ b/tests/Assert-DashboardRemediationViews.js
@@ -728,6 +728,116 @@ module.exports = {
         'Expected impact analysis Patch Ref content to retain collapsed KB references.'
     );
 
+    const osFamilyDisambiguationRows = [
+        createTestRow({
+            DeviceId: 'windows-client',
+            DeviceName: 'windows-client.contoso.com',
+            SoftwareVendor: 'microsoft',
+            SoftwareName: 'windows_11',
+            OSPlatform: 'Windows11',
+            OSVersion: '10.0.26100.1',
+            RecommendationReference: 'va-_-microsoft-_-windows_11',
+            CveId: 'CVE-2026-4100',
+            RecommendedSecurityUpdate: 'April 2026 Security Updates',
+            RecommendedSecurityUpdateId: '',
+            RecommendedSecurityUpdateUrl: '',
+            CveBatchTitle: 'Microsoft April 2026 Security Updates',
+            FirstSeenTimestamp: '2025-11-21',
+            LastSeenTimestamp: '2025-12-01',
+            MachineInfo: {
+                ls: '2025-12-01',
+                ip: '10.0.0.70'
+            }
+        }),
+        createTestRow({
+            DeviceId: 'windows-client-legacy',
+            DeviceName: 'windows-client-legacy.contoso.com',
+            SoftwareVendor: 'microsoft',
+            SoftwareName: 'windows_11',
+            OSPlatform: 'Windows11',
+            OSVersion: '10.0.22631.1',
+            RecommendationReference: 'va-_-microsoft-_-windows_11',
+            CveId: 'CVE-2026-4103',
+            RecommendedSecurityUpdate: 'April 2026 Security Updates',
+            RecommendedSecurityUpdateId: '',
+            RecommendedSecurityUpdateUrl: '',
+            CveBatchTitle: 'Microsoft April 2026 Security Updates',
+            FirstSeenTimestamp: '2025-11-24',
+            LastSeenTimestamp: '2025-12-01',
+            MachineInfo: {
+                ls: '2025-12-01',
+                ip: '10.0.0.73'
+            }
+        }),
+        createTestRow({
+            DeviceId: 'windows-server',
+            DeviceName: 'windows-server.contoso.com',
+            SoftwareVendor: 'microsoft',
+            SoftwareName: 'windows_11',
+            OSPlatform: 'WindowsServer2022',
+            OSVersion: '10.0.20348.1',
+            RecommendationReference: 'va-_-microsoft-_-windows_11',
+            CveId: 'CVE-2026-4101',
+            RecommendedSecurityUpdate: 'April 2026 Security Updates',
+            RecommendedSecurityUpdateId: '',
+            RecommendedSecurityUpdateUrl: '',
+            CveBatchTitle: 'Microsoft April 2026 Security Updates',
+            FirstSeenTimestamp: '2025-11-22',
+            LastSeenTimestamp: '2025-12-01',
+            MachineInfo: {
+                ls: '2025-12-01',
+                ip: '10.0.0.71'
+            }
+        }),
+        createTestRow({
+            DeviceId: 'windows-ubuntu',
+            DeviceName: 'windows-ubuntu.contoso.com',
+            SoftwareVendor: 'microsoft',
+            SoftwareName: 'windows_11',
+            OSPlatform: 'Ubuntu',
+            OSVersion: '24.04.1',
+            RecommendationReference: 'va-_-microsoft-_-windows_11',
+            CveId: 'CVE-2026-4102',
+            RecommendedSecurityUpdate: 'April 2026 Security Updates',
+            RecommendedSecurityUpdateId: '',
+            RecommendedSecurityUpdateUrl: '',
+            CveBatchTitle: 'Microsoft April 2026 Security Updates',
+            FirstSeenTimestamp: '2025-11-23',
+            LastSeenTimestamp: '2025-12-01',
+            MachineInfo: {
+                ls: '2025-12-01',
+                ip: '10.0.0.72'
+            }
+        })
+    ];
+
+    dashboard.applyDerivedVulnerabilityFields(osFamilyDisambiguationRows);
+    dashboard.setDashboardState(historicalRangeState, osFamilyDisambiguationRows, '2025-12-01');
+
+    const osFamilyRows = dashboard.getRemediationTableData();
+    assert.strictEqual(
+        osFamilyRows.map(row => row.software).sort().join('|'),
+        [
+            'Windows 11 (10.0.22631)',
+            'Windows 11 (10.0.26100)',
+            'Windows 11 [Ubuntu]',
+            'Windows 11 [Windows Server 2022]'
+        ].sort().join('|'),
+        'Expected OS-family remediation rows to disambiguate mismatched device platforms instead of collapsing them into one plain software label.'
+    );
+
+    const osFamilyImpact = dashboard.getImpactAnalysisData();
+    assert.strictEqual(
+        osFamilyImpact.top25.map(row => row.name).sort().join('|'),
+        [
+            'Windows 11 (10.0.22631): April 2026 Security Updates',
+            'Windows 11 (10.0.26100): April 2026 Security Updates',
+            'Windows 11 [Ubuntu]: April 2026 Security Updates',
+            'Windows 11 [Windows Server 2022]: April 2026 Security Updates'
+        ].sort().join('|'),
+        'Expected impact analysis to keep the same OS-family disambiguation used by the active remediation table.'
+    );
+
     const appleDescriptor = dashboard.buildRemediationDescriptor(createTestRow({
         SoftwareVendor: 'apple',
         SoftwareName: 'mac_os',

--- a/tests/Assert-DashboardTelemetry.js
+++ b/tests/Assert-DashboardTelemetry.js
@@ -1,0 +1,80 @@
+﻿const assert = require('assert');
+const { loadDashboardHarness } = require('./helpers/dashboard-test-harness');
+
+function main() {
+    let currentNow = 0;
+    const dashboard = loadDashboardHarness(`
+module.exports = {
+    document,
+    window,
+    buildDashboardValidationSnapshot,
+    getDashboardMetricsSnapshot,
+    publishDashboardDiagnostics,
+    recordDashboardPhaseTiming,
+    recordDashboardRenderTiming,
+    markDashboardReady,
+    setActiveReportIdForTest(value) {
+        activeReportId = value;
+    }
+};
+`, {
+        performance: {
+            now() {
+                currentNow += 10;
+                return currentNow;
+            }
+        }
+    });
+
+    dashboard.window.dispatchEvent = event => {
+        dashboard.window.__lastEvent = event;
+    };
+
+    const selector = dashboard.document.getElementById('reportSelector');
+    selector.value = 'impact-analysis';
+    selector.options = {
+        0: { value: 'active-vulnerabilities', textContent: 'Active Vulnerabilities' },
+        1: { value: 'remediation-activity', textContent: 'Remediation Activity' },
+        2: { value: 'impact-analysis', textContent: 'Impact Analysis' },
+        length: 3
+    };
+
+    dashboard.document.getElementById('criticalCount').textContent = '12';
+    dashboard.document.getElementById('highCount').textContent = '34';
+    dashboard.document.getElementById('mediumCount').textContent = '56';
+    dashboard.document.getElementById('lowCount').textContent = '78';
+
+    dashboard.setActiveReportIdForTest('impact-analysis');
+    dashboard.recordDashboardPhaseTiming('loadDataMs', 123.4567);
+    dashboard.recordDashboardPhaseTiming('denormalizeMs', 456.7891);
+    dashboard.recordDashboardPhaseTiming('applyFiltersMs', 12.3456);
+    dashboard.recordDashboardRenderTiming('impact-analysis', 78.9012);
+
+    const published = dashboard.publishDashboardDiagnostics();
+    assert.strictEqual(published.metrics.deliveryMode, 'self-contained');
+    assert.strictEqual(published.metrics.activeReportId, 'impact-analysis');
+    assert.strictEqual(published.metrics.phases.loadDataMs, 123.457);
+    assert.strictEqual(published.metrics.phases.denormalizeMs, 456.789);
+    assert.strictEqual(published.metrics.phases.applyFiltersMs, 12.346);
+    assert.strictEqual(published.metrics.reports['impact-analysis'].count, 1);
+    assert.strictEqual(published.metrics.reports['impact-analysis'].lastMs, 78.901);
+    assert.strictEqual(published.validation.activeReportId, 'impact-analysis');
+    assert.strictEqual(published.validation.summaryCards.critical, '12');
+    assert.strictEqual(published.validation.summaryCards.high, '34');
+    assert.strictEqual(published.validation.summaryCards.medium, '56');
+    assert.strictEqual(published.validation.summaryCards.low, '78');
+    assert.strictEqual(published.validation.reportSelectorOptions.length, 3);
+    assert.strictEqual(published.validation.reportSelectorOptions[2].value, 'impact-analysis');
+
+    dashboard.markDashboardReady();
+
+    assert.strictEqual(dashboard.window._dashboardReady, true);
+    assert.ok(dashboard.window.dashboardMetrics);
+    assert.ok(dashboard.window.dashboardValidation);
+    assert.strictEqual(dashboard.window.dashboardMetrics.ready, true);
+    assert.strictEqual(dashboard.window.__lastEvent.type, 'dashboard-ready');
+    assert.strictEqual(dashboard.window.__lastEvent.detail.metrics.ready, true);
+    assert.strictEqual(dashboard.window.__lastEvent.detail.validation.activeReportId, 'impact-analysis');
+}
+
+main();

--- a/tests/Invoke-LargeDatasetValidation.ps1
+++ b/tests/Invoke-LargeDatasetValidation.ps1
@@ -57,6 +57,10 @@ param(
     [switch]$Validate,
 
     [Parameter(Mandatory = $false)]
+    [ValidateSet('semantic', 'artifacts')]
+    [string]$ValidationMode = 'semantic',
+
+    [Parameter(Mandatory = $false)]
     [string]$DashboardOutputPath,
 
     [Parameter(Mandatory = $false)]
@@ -81,6 +85,11 @@ $ErrorActionPreference = 'Stop'
 
 if (-not $Validate -and -not [string]::IsNullOrWhiteSpace($ValidationOutputPath)) {
     throw 'ValidationOutputPath requires -Validate.'
+}
+
+$resolvedValidationMode = if ($Validate) { $ValidationMode } else { 'none' }
+if ($resolvedValidationMode -eq 'artifacts' -and -not [string]::IsNullOrWhiteSpace($ValidationOutputPath)) {
+    throw 'ValidationOutputPath is only supported with -ValidationMode semantic.'
 }
 
 function Get-StreamingCount {
@@ -129,6 +138,59 @@ function Get-ValidationAuditSummary {
         comparisonStorage = if ($null -ne $semanticParity -and $semanticParity.PSObject.Properties['ComparisonStorage']) { [string]$semanticParity.ComparisonStorage } else { $null }
         comparisonPayloadSource = if ($null -ne $semanticParity -and $semanticParity.PSObject.Properties['ComparisonPayloadSource']) { [string]$semanticParity.ComparisonPayloadSource } else { $null }
         phaseTimings = if ($Audit.PSObject.Properties['PhaseTimings']) { $Audit.PhaseTimings } elseif ($null -ne $semanticParity -and $semanticParity.PSObject.Properties['PhaseTimings']) { $semanticParity.PhaseTimings } else { $null }
+    }
+}
+
+function Add-PathSuffixBeforeExtensionLocal {
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Path,
+
+        [Parameter(Mandatory = $true)]
+        [string]$Suffix
+    )
+
+    $extension = [System.IO.Path]::GetExtension($Path)
+    if ([string]::IsNullOrEmpty($extension)) {
+        return ($Path + $Suffix)
+    }
+
+    return ($Path.Substring(0, $Path.Length - $extension.Length) + $Suffix + $extension)
+}
+
+function Invoke-GeneratedArtifactValidation {
+    [CmdletBinding()]
+    [OutputType([pscustomobject])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$SelfContainedPath,
+
+        [Parameter(Mandatory = $true)]
+        [string]$HostedPath
+    )
+
+    $validatorScriptPath = Join-Path $PSScriptRoot 'Validate-DashboardGeneratedArtifacts.js'
+    if (-not (Test-Path -LiteralPath $validatorScriptPath -PathType Leaf)) {
+        throw "Artifact validator '$validatorScriptPath' was not found."
+    }
+
+    $nodeCommand = Get-Command -Name 'node' -ErrorAction Stop
+    & $nodeCommand.Source $validatorScriptPath $SelfContainedPath $HostedPath
+
+    $validatorExitCode = [int]$global:LASTEXITCODE
+    if ($validatorExitCode -ne 0) {
+        throw "Generated artifact validation failed with exit code $validatorExitCode."
+    }
+
+    return [PSCustomObject]@{
+        mode = 'generated-artifact-parity'
+        validatorScriptPath = [System.IO.Path]::GetFullPath($validatorScriptPath)
+        selfContainedPath = [System.IO.Path]::GetFullPath($SelfContainedPath)
+        hostedPath = [System.IO.Path]::GetFullPath($HostedPath)
+        hostedAssetsPath = Join-Path (Split-Path -Path (Resolve-Path -LiteralPath $HostedPath).Path -Parent) (([System.IO.Path]::GetFileNameWithoutExtension($HostedPath)) + '.assets')
+        passed = $true
     }
 }
 
@@ -275,6 +337,10 @@ function Write-StressValidationReport {
 
         [Parameter(Mandatory = $false)]
         [AllowEmptyString()]
+        [string]$HostedDashboardOutputPath,
+
+        [Parameter(Mandatory = $false)]
+        [AllowEmptyString()]
         [string]$ResolvedDiagnosticPhaseLogPath,
 
         [Parameter(Mandatory = $false)]
@@ -318,12 +384,20 @@ function Write-StressValidationReport {
 
         [Parameter(Mandatory = $false)]
         [AllowNull()]
-        $DiagnosticTimingSummary
+        $DiagnosticTimingSummary,
+
+        [Parameter(Mandatory = $true)]
+        [string]$ResolvedValidationMode,
+
+        [Parameter(Mandatory = $false)]
+        [AllowNull()]
+        $ArtifactValidationSummary
     )
 
     $resolvedDashboardOutputPath = [System.IO.Path]::GetFullPath($DashboardOutputPath)
     $dashboardExists = Test-Path -LiteralPath $DashboardOutputPath -PathType Leaf
     $dashboardBytes = if ($dashboardExists) { (Get-Item -LiteralPath $DashboardOutputPath).Length } else { $null }
+    $resolvedHostedDashboardOutputPath = if ([string]::IsNullOrWhiteSpace($HostedDashboardOutputPath)) { $null } else { [System.IO.Path]::GetFullPath($HostedDashboardOutputPath) }
 
     $report = [PSCustomObject]@{
         preset = $Preset
@@ -332,6 +406,7 @@ function Write-StressValidationReport {
         completedOn = (Get-Date).ToString('o')
         syntheticPath = $SyntheticPath
         dashboardOutputPath = $resolvedDashboardOutputPath
+        hostedDashboardOutputPath = $resolvedHostedDashboardOutputPath
         diagnosticPhaseLogPath = if ([string]::IsNullOrWhiteSpace($ResolvedDiagnosticPhaseLogPath)) { $null } else { [System.IO.Path]::GetFullPath($ResolvedDiagnosticPhaseLogPath) }
         elapsedSeconds = [math]::Round($ElapsedSeconds, 2)
         generationTiming = if ($null -ne $DiagnosticTimingSummary) {
@@ -358,11 +433,13 @@ function Write-StressValidationReport {
         manifest = $Manifest
         validation = [PSCustomObject]@{
             validate = $Validate.IsPresent
+            validationMode = $ResolvedValidationMode
             heartbeatSeconds = $ValidationHeartbeatSeconds
             partitionCompareParallelism = $ValidationPartitionCompareParallelism
             skipObservedWindowMerge = $SkipObservedWindowMerge
             auditPath = if ([string]::IsNullOrWhiteSpace($ResolvedValidationAuditPath)) { $null } else { [System.IO.Path]::GetFullPath($ResolvedValidationAuditPath) }
             auditSummary = Get-ValidationAuditSummary -Audit $Audit
+            artifactSummary = $ArtifactValidationSummary
         }
         error = if ($null -ne $FailureRecord) {
             [PSCustomObject]@{
@@ -432,10 +509,17 @@ else {
     Join-Path ([System.IO.Path]::GetTempPath()) ('stress-dashboard-' + [guid]::NewGuid().ToString('N') + '.html')
 }
 
+$hostedDashboardOutput = if ($resolvedValidationMode -eq 'artifacts') {
+    Add-PathSuffixBeforeExtensionLocal -Path $dashboardOutput -Suffix '.Hosted'
+}
+else {
+    $null
+}
+
 $resolvedValidationOutputPath = if (-not [string]::IsNullOrWhiteSpace($ValidationOutputPath)) {
     [System.IO.Path]::GetFullPath($ValidationOutputPath)
 }
-elseif ($Validate) {
+elseif ($resolvedValidationMode -eq 'semantic') {
     Join-Path $resolvedSyntheticPath 'dashboard-audit.json'
 }
 else {
@@ -477,11 +561,15 @@ $generateArgs = @{
 if ($skipObservedWindowMerge) {
     $generateArgs.SkipObservedWindowMerge = $true
 }
-if ($Validate) {
+if ($resolvedValidationMode -eq 'semantic') {
     $generateArgs.Validate = $true
     if (-not [string]::IsNullOrWhiteSpace($resolvedValidationOutputPath)) {
         $generateArgs.ValidationOutputPath = $resolvedValidationOutputPath
     }
+}
+elseif ($resolvedValidationMode -eq 'artifacts') {
+    $generateArgs.DualPackage = $true
+    $generateArgs.HostedOutputPath = $hostedDashboardOutput
 }
 if (-not [string]::IsNullOrWhiteSpace($resolvedDiagnosticPhaseLogPath)) {
     $generateArgs.DiagnosticPhaseLogPath = $resolvedDiagnosticPhaseLogPath
@@ -494,6 +582,15 @@ if (Test-Path -LiteralPath $reportPath -PathType Leaf) {
 
 if (Test-Path -LiteralPath $dashboardOutput -PathType Leaf) {
     Remove-Item -LiteralPath $dashboardOutput -Force
+}
+if (-not [string]::IsNullOrWhiteSpace($hostedDashboardOutput) -and (Test-Path -LiteralPath $hostedDashboardOutput -PathType Leaf)) {
+    Remove-Item -LiteralPath $hostedDashboardOutput -Force
+}
+if (-not [string]::IsNullOrWhiteSpace($hostedDashboardOutput)) {
+    $hostedAssetsPath = Join-Path (Split-Path -Path $hostedDashboardOutput -Parent) (([System.IO.Path]::GetFileNameWithoutExtension($hostedDashboardOutput)) + '.assets')
+    if (Test-Path -LiteralPath $hostedAssetsPath -PathType Container) {
+        Remove-Item -LiteralPath $hostedAssetsPath -Recurse -Force -ErrorAction SilentlyContinue
+    }
 }
 if (-not [string]::IsNullOrWhiteSpace($resolvedDiagnosticPhaseLogPath) -and (Test-Path -LiteralPath $resolvedDiagnosticPhaseLogPath -PathType Leaf)) {
     Remove-Item -LiteralPath $resolvedDiagnosticPhaseLogPath -Force
@@ -510,6 +607,7 @@ $status = 'success'
 $dashboardExitCode = $null
 $failureRecord = $null
 $audit = $null
+$artifactValidationSummary = $null
 $diagnosticTimingSummary = $null
 try {
     $global:LASTEXITCODE = 0
@@ -524,12 +622,19 @@ try {
         throw "Dashboard output '$dashboardOutput' was not created."
     }
 
-    if (-not [string]::IsNullOrWhiteSpace($resolvedValidationOutputPath)) {
+    if ($resolvedValidationMode -eq 'semantic' -and -not [string]::IsNullOrWhiteSpace($resolvedValidationOutputPath)) {
         if (-not (Test-Path -LiteralPath $resolvedValidationOutputPath -PathType Leaf)) {
             throw "Validation audit '$resolvedValidationOutputPath' was not created."
         }
 
         $audit = Get-Content -Path $resolvedValidationOutputPath -Raw | ConvertFrom-Json -Depth 100
+    }
+    elseif ($resolvedValidationMode -eq 'artifacts') {
+        if (-not (Test-Path -LiteralPath $hostedDashboardOutput -PathType Leaf)) {
+            throw "Hosted dashboard output '$hostedDashboardOutput' was not created."
+        }
+
+        $artifactValidationSummary = Invoke-GeneratedArtifactValidation -SelfContainedPath $dashboardOutput -HostedPath $hostedDashboardOutput
     }
 }
 catch {
@@ -546,6 +651,7 @@ finally {
         -Preset $Preset `
         -SyntheticPath $resolvedSyntheticPath `
         -DashboardOutputPath $dashboardOutput `
+        -HostedDashboardOutputPath $hostedDashboardOutput `
         -ResolvedDiagnosticPhaseLogPath $resolvedDiagnosticPhaseLogPath `
         -ResolvedValidationAuditPath $resolvedValidationOutputPath `
         -ElapsedSeconds $stopwatch.Elapsed.TotalSeconds `
@@ -558,7 +664,9 @@ finally {
         -DashboardExitCode $dashboardExitCode `
         -FailureRecord $failureRecord `
         -Audit $audit `
-        -DiagnosticTimingSummary $diagnosticTimingSummary
+        -DiagnosticTimingSummary $diagnosticTimingSummary `
+        -ResolvedValidationMode $resolvedValidationMode `
+        -ArtifactValidationSummary $artifactValidationSummary
 }
 
 $dashboardItem = Get-Item -LiteralPath $dashboardOutput
@@ -567,11 +675,18 @@ Write-Output ''
 Write-Output 'Stress validation completed.'
 Write-Output ("  Synthetic path: {0}" -f $resolvedSyntheticPath)
 Write-Output ("  Dashboard output: {0}" -f ([System.IO.Path]::GetFullPath($dashboardOutput)))
+if (-not [string]::IsNullOrWhiteSpace($hostedDashboardOutput)) {
+    Write-Output ("  Hosted dashboard output: {0}" -f ([System.IO.Path]::GetFullPath($hostedDashboardOutput)))
+}
 if (-not [string]::IsNullOrWhiteSpace($resolvedDiagnosticPhaseLogPath)) {
     Write-Output ("  Diagnostic phase log: {0}" -f $resolvedDiagnosticPhaseLogPath)
 }
-if (-not [string]::IsNullOrWhiteSpace($resolvedValidationOutputPath)) {
+Write-Output ("  Validation mode: {0}" -f $resolvedValidationMode)
+if ($resolvedValidationMode -eq 'semantic' -and -not [string]::IsNullOrWhiteSpace($resolvedValidationOutputPath)) {
     Write-Output ("  Validation audit: {0}" -f $resolvedValidationOutputPath)
+}
+elseif ($resolvedValidationMode -eq 'artifacts') {
+    Write-Output '  Artifact validation: passed.'
 }
 Write-Output ("  Elapsed: {0} seconds" -f ([math]::Round($stopwatch.Elapsed.TotalSeconds, 2)))
 Write-Output ("  Devices: {0}" -f $machineCount)

--- a/tests/README.md
+++ b/tests/README.md
@@ -60,17 +60,25 @@ Defaults:
 - target vulnerability rows: `1,500,000`
 - output path: `.\exports-synthetic`
 
-Run a full local dashboard generation against that synthetic export set with:
+Run an iterative local dashboard generation against that synthetic export set with:
 
 ```powershell
-pwsh -NoProfile -File .\tests\Invoke-LargeDatasetValidation.ps1 -Validate
+pwsh -NoProfile -File .\tests\Invoke-LargeDatasetValidation.ps1 -Validate -ValidationMode artifacts
 ```
 
 That command:
 - regenerates the synthetic exports
 - runs `Generate-VulnerabilityDashboard.ps1` against them
+- validates the generated self-contained and hosted dashboard artifacts
 - writes `synthetic-manifest.json` and `stress-validation-report.json` under `exports-synthetic/`
-- writes `dashboard-audit.json` under `exports-synthetic/` when `-Validate` is set
+
+Reserve the semantic replay for milestone or final local sign-off:
+
+```powershell
+pwsh -NoProfile -File .\tests\Invoke-LargeDatasetValidation.ps1 -Validate -ValidationMode semantic
+```
+
+That semantic mode additionally writes `dashboard-audit.json` under `exports-synthetic/`.
 
 Supported presets:
 - `DeviceCardinalityFirst`
@@ -141,8 +149,10 @@ pwsh -NoProfile -File .\tests\Generate-SyntheticLargeExports.ps1 -OutputPath .\.
 
 pwsh -NoProfile -File .\tests\New-SyntheticLiveExport.ps1 -SourcePath .\.local\large-datasets\synthetic-raw -OutputPath .\.local\large-datasets\synthetic-raw-live -SkipContentStoreSidecars -Force
 
-pwsh -NoProfile -File .\tests\Invoke-LargeDatasetValidation.ps1 -SkipSyntheticGeneration -SyntheticOutputPath .\.local\large-datasets\synthetic-raw-live -Validate
+pwsh -NoProfile -File .\tests\Invoke-LargeDatasetValidation.ps1 -SkipSyntheticGeneration -SyntheticOutputPath .\.local\large-datasets\synthetic-raw-live -Validate -ValidationMode artifacts
 ```
+
+Switch that final command to `-ValidationMode semantic` only when you need the full streaming semantic replay before sign-off.
 
 Standalone legacy vulnerability snapshot materialization from that raw live dataset:
 

--- a/tests/Run-SharedHelperRegression.ps1
+++ b/tests/Run-SharedHelperRegression.ps1
@@ -1996,6 +1996,73 @@ function Test-ReadNormalizationMachineLookupMatchesCompressedMachineLookup {
     }
 }
 
+function Test-LegacyMachineTupleFallbackPreservesProjectedRowMetadata {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '', Justification = 'Regression test name intentionally describes legacy tuple fallback behavior.')]
+    [CmdletBinding()]
+    param()
+
+    $legacyMachineTuple = [object[]]@(
+        '10.0.0.30',
+        '203.0.113.30',
+        'Active',
+        'Medium',
+        'High',
+        'Normal',
+        'Intune',
+        $true,
+        '2026-04-22T00:00:00Z',
+        '2026-04-01T00:00:00Z'
+    )
+
+    $projection = Get-MachineProjection -Machine $legacyMachineTuple
+    Assert-True ($null -eq $projection.ComputerDnsName) 'Expected legacy tuples without expanded metadata to preserve a null ComputerDnsName projection.'
+    Assert-True ($null -eq $projection.OSPlatform) 'Expected legacy tuples without expanded metadata to preserve a null OSPlatform projection.'
+    Assert-True ($null -eq $projection.OSVersion) 'Expected legacy tuples without expanded metadata to preserve a null OSVersion projection.'
+
+    $context = Get-NormalizationContext
+    $context.Machines['device-legacy'] = $legacyMachineTuple
+
+    $deviceIndex = Add-NormalizedDevice `
+        -DeviceId 'device-legacy' `
+        -DeviceName 'legacy-device.contoso.com' `
+        -GroupName 'Pilot' `
+        -OsPlatform 'Windows11' `
+        -OsVersion '10.0.26100' `
+        -MachineTags @('Pilot') `
+        -Context $context
+
+    $deviceLookup = $context.Lookups.devices[$deviceIndex]
+
+    Assert-True ($deviceLookup.n -eq 'legacy-device.contoso.com') 'Expected Add-NormalizedDevice to fall back to the row DeviceName when a legacy tuple has no ComputerDnsName.'
+    Assert-True ($context.Lookups.groups[$deviceLookup.g] -eq 'Pilot') 'Expected Add-NormalizedDevice to fall back to the row GroupName when a legacy tuple has no RBAC group.'
+    Assert-True ($context.Lookups.platforms[$deviceLookup.o] -eq 'Windows11') 'Expected Add-NormalizedDevice to fall back to the row OSPlatform when a legacy tuple has no platform metadata.'
+    Assert-True ($deviceLookup.ov -eq '10.0.26100') 'Expected Add-NormalizedDevice to fall back to the row OSVersion when a legacy tuple has no OSVersion metadata.'
+    Assert-True ($context.Lookups.tags[$deviceLookup.t[0]] -eq 'Pilot') 'Expected Add-NormalizedDevice to fall back to row machine tags when a legacy tuple has no tag metadata.'
+    Assert-True ($deviceLookup.m.ip -eq '10.0.0.30') 'Expected Add-NormalizedDevice to preserve machine info pulled from the legacy tuple.'
+}
+
+function Test-SourceCveEnrichmentReadsExploitAvailabilityFromObjectRecord {
+    [CmdletBinding()]
+    param()
+
+    $vendorSet = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+    [void]$vendorSet.Add((Get-VendorMatchKey -Vendor 'Contoso'))
+
+    $advancedHunting = @{
+        'CVE-2026-7777' = [PSCustomObject]@{
+            PublishedDate = '2026-04-14'
+            VulnerabilityDescription = 'Example vulnerability description.'
+            EpssScore = 0.0042
+            AffectedSoftware = @('Contoso:Legacy Agent')
+            IsExploitAvailable = $true
+        }
+    }
+
+    $enrichment = Get-SourceCveEnrichment -CveId 'CVE-2026-7777' -AdvancedHunting $advancedHunting -NvdCveData $null -VendorSet $vendorSet
+
+    Assert-True ($enrichment.IsExploitAvailable -eq $true) 'Expected exploit availability to be preserved for PSCustomObject-based Advanced Hunting records.'
+}
+
 function Test-WriteBase64FileContentMatchesReferenceOutput {
     [CmdletBinding()]
     param()
@@ -2955,6 +3022,10 @@ Test-AdvancedHuntingBundleStringArrayFiltersSparseInputs
 Write-Output '  Advanced Hunting bundle sparse string-array checks passed.'
 Test-ReadNormalizationMachineLookupMatchesCompressedMachineLookup
 Write-Output '  Machine tuple reader checks passed.'
+Test-LegacyMachineTupleFallbackPreservesProjectedRowMetadata
+Write-Output '  Legacy tuple fallback checks passed.'
+Test-SourceCveEnrichmentReadsExploitAvailabilityFromObjectRecord
+Write-Output '  Source enrichment exploit-availability checks passed.'
 Test-VulnPropertyHelpersSupportSupportedRowShapes
 Write-Output '  Vulnerability property helper shape checks passed.'
 Test-VulnContentStoreRoundTrip

--- a/tests/Run-SharedHelperRegression.ps1
+++ b/tests/Run-SharedHelperRegression.ps1
@@ -1964,16 +1964,29 @@ function Test-ReadNormalizationMachineLookupMatchesCompressedMachineLookup {
 
         Assert-True ($tupleMachines.Count -eq $compressedMachines.Count) 'Expected tuple-mode machine loading to preserve the same machine count as the compressed machine lookup path.'
         Assert-True ($tupleMachines.ContainsKey('device-live')) 'Expected tuple-mode machine loading to preserve populated machines.'
-        Assert-True (-not $tupleMachines.ContainsKey('device-sparse')) 'Expected tuple-mode machine loading to drop machines whose normalization tuple is entirely empty.'
+        Assert-True ($tupleMachines.ContainsKey('device-sparse')) 'Expected tuple-mode machine loading to retain sparse machines when extended normalization metadata is present.'
         Assert-True (-not $tupleMachines.ContainsKey('device-removed')) 'Expected tuple-mode machine loading to drop removed machines from the current lookup.'
 
         $expectedTuple = [object[]]$compressedMachines['device-live']
         $actualTuple = [object[]]$tupleMachines['device-live']
         Assert-True ($actualTuple -is [System.Array]) 'Expected tuple-mode machine loading to materialize array-backed normalization tuples.'
-        Assert-True ($actualTuple.Length -eq 10) 'Expected tuple-mode machine loading to preserve the 10-slot normalization tuple shape.'
+        Assert-True ($actualTuple.Length -eq $expectedTuple.Length) 'Expected tuple-mode machine loading to preserve the normalization tuple shape.'
+
+        $expectedSparseTuple = [object[]]$compressedMachines['device-sparse']
+        $actualSparseTuple = [object[]]$tupleMachines['device-sparse']
+        Assert-True ($actualSparseTuple -is [System.Array]) 'Expected tuple-mode machine loading to materialize sparse machines as array-backed normalization tuples.'
+        Assert-True ($actualSparseTuple.Length -eq $expectedSparseTuple.Length) 'Expected tuple-mode machine loading to preserve the sparse normalization tuple shape.'
 
         for ($tupleIndex = 0; $tupleIndex -lt $expectedTuple.Length; $tupleIndex++) {
-            Assert-True ($actualTuple[$tupleIndex] -eq $expectedTuple[$tupleIndex]) "Expected tuple-mode machine loading to preserve tuple slot $tupleIndex."
+            $expectedTupleValue = ConvertTo-Json -InputObject $expectedTuple[$tupleIndex] -Compress -Depth 20
+            $actualTupleValue = ConvertTo-Json -InputObject $actualTuple[$tupleIndex] -Compress -Depth 20
+            Assert-True ($actualTupleValue -eq $expectedTupleValue) "Expected tuple-mode machine loading to preserve tuple slot $tupleIndex."
+        }
+
+        for ($tupleIndex = 0; $tupleIndex -lt $expectedSparseTuple.Length; $tupleIndex++) {
+            $expectedSparseTupleValue = ConvertTo-Json -InputObject $expectedSparseTuple[$tupleIndex] -Compress -Depth 20
+            $actualSparseTupleValue = ConvertTo-Json -InputObject $actualSparseTuple[$tupleIndex] -Compress -Depth 20
+            Assert-True ($actualSparseTupleValue -eq $expectedSparseTupleValue) "Expected tuple-mode machine loading to preserve sparse tuple slot $tupleIndex."
         }
     }
     finally {

--- a/tests/Validate-DashboardGeneratedArtifacts.js
+++ b/tests/Validate-DashboardGeneratedArtifacts.js
@@ -1,0 +1,171 @@
+﻿const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+
+const reportOptions = [
+    ['active-vulnerabilities', 'Active Vulnerabilities'],
+    ['remediation-activity', 'Remediation Activity'],
+    ['impact-analysis', 'Impact Analysis'],
+    ['devices-by-remediation', 'Devices by Remediation'],
+    ['remediations-by-device', 'Remediations by Device']
+];
+
+const requiredElementIds = [
+    'dashboardMain',
+    'reportSelector',
+    'exportPdfButton',
+    'dashboardStatus',
+    'statsSummary',
+    'criticalCount',
+    'highCount',
+    'mediumCount',
+    'lowCount',
+    'filterToolbar',
+    'filterPillDate',
+    'filterPillRbacGroup',
+    'filterPillDeviceTags',
+    'filterPillOSPlatform',
+    'filterPillSeverity',
+    'filterPillDeviceName',
+    'clearAllFiltersButton',
+    'active-vulnerabilities-section',
+    'remediation-activity-section',
+    'impact-analysis-section',
+    'devices-by-remediation-section',
+    'remediations-by-device-section',
+    'remediationTable',
+    'remediationDetailsTable',
+    'impactAnalysisTable',
+    'devicesByRemediationContainer',
+    'remediationsByDeviceContainer',
+    'dashboardConfig',
+    'dataFormat',
+    'lookupsData',
+    'vulnsData'
+];
+
+const activeVulnerabilityColumnLabels = [
+    'Vendor',
+    'Software',
+    'Remediation',
+    'Update Details',
+    'Assets',
+    'Vulnerabilities',
+    'Exploits',
+    'Kits'
+];
+
+const hostedAssets = [
+    'dashboard.css',
+    'dashboard.js',
+    'pako.js',
+    'chart.js',
+    'pdf-export.bundle.js',
+    'payload.json.gz'
+];
+
+function assertFileExists(filePath, message) {
+    assert(fs.existsSync(filePath), message);
+}
+
+function readUtf8(filePath) {
+    assertFileExists(filePath, `Expected file to exist: ${filePath}`);
+    return fs.readFileSync(filePath, 'utf8');
+}
+
+function escapeRegex(value) {
+    return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function assertContains(text, expected, message) {
+    assert(text.includes(expected), message);
+}
+
+function assertMatches(text, expression, message) {
+    assert(expression.test(text), message);
+}
+
+function validateCommonHtml(html, label) {
+    const unresolvedPlaceholders = html.match(/__[A-Z0-9_]+__/g) || [];
+    assert.strictEqual(
+        unresolvedPlaceholders.length,
+        0,
+        `${label}: unresolved placeholders found: ${unresolvedPlaceholders.join(', ')}`
+    );
+
+    requiredElementIds.forEach(id => {
+        assertMatches(html, new RegExp(`id="${escapeRegex(id)}"`), `${label}: missing required element id '${id}'.`);
+    });
+
+    reportOptions.forEach(([value, optionLabel]) => {
+        assertMatches(
+            html,
+            new RegExp(`<option[^>]*value="${escapeRegex(value)}"[^>]*>${escapeRegex(optionLabel)}</option>`),
+            `${label}: missing report option '${optionLabel}'.`
+        );
+    });
+
+    activeVulnerabilityColumnLabels.forEach(columnLabel => {
+        assertContains(html, columnLabel, `${label}: missing Active Vulnerabilities column label '${columnLabel}'.`);
+    });
+
+    ['Critical', 'High', 'Medium', 'Low', 'Report:', 'Export to PDF', 'Dashboard filters'].forEach(text => {
+        assertContains(html, text, `${label}: missing required text '${text}'.`);
+    });
+}
+
+function validateSelfContained(selfContainedPath) {
+    const html = readUtf8(selfContainedPath);
+    validateCommonHtml(html, 'self-contained');
+    assertContains(html, '"deliveryMode":"self-contained"', 'self-contained: delivery mode marker is missing or incorrect.');
+    assertContains(html, '<style>', 'self-contained: expected embedded CSS block.');
+    assertContains(html, '<script id="chartJsLib" type="application/gzip-base64">', 'self-contained: missing embedded Chart.js payload.');
+    assertContains(html, '<script id="pdfExportBundleLib" type="application/gzip-base64">', 'self-contained: missing embedded PDF export payload.');
+    assert(!html.includes('.assets/dashboard.js'), 'self-contained: should not reference hosted dashboard asset paths.');
+}
+
+function validateHosted(hostedPath) {
+    const html = readUtf8(hostedPath);
+    validateCommonHtml(html, 'hosted');
+    assertContains(html, '"deliveryMode":"split-assets"', 'hosted: delivery mode marker is missing or incorrect.');
+
+    const hostedDirectoryName = `${path.basename(hostedPath, path.extname(hostedPath))}.assets`;
+    const hostedDirectoryPath = path.join(path.dirname(hostedPath), hostedDirectoryName);
+    assertFileExists(hostedDirectoryPath, `hosted: expected asset directory '${hostedDirectoryPath}' to exist.`);
+
+    hostedAssets.forEach(assetName => {
+        const assetPath = path.join(hostedDirectoryPath, assetName);
+        assertFileExists(assetPath, `hosted: expected asset '${assetName}' to exist.`);
+        assertContains(html, `${hostedDirectoryName}/${assetName}`, `hosted: expected HTML to reference '${assetName}'.`);
+    });
+
+    assertContains(
+        html,
+        `<link rel="stylesheet" href="${hostedDirectoryName}/dashboard.css">`,
+        'hosted: expected external stylesheet reference.'
+    );
+    assertContains(
+        html,
+        `<script src="${hostedDirectoryName}/pako.js"></script>`,
+        'hosted: expected external pako reference.'
+    );
+    assertContains(
+        html,
+        `<script src="${hostedDirectoryName}/dashboard.js"></script>`,
+        'hosted: expected external dashboard script reference.'
+    );
+    assert(!html.includes('<style>'), 'hosted: should not contain embedded stylesheet markup.');
+}
+
+function main() {
+    const [, , selfContainedPath, hostedPath] = process.argv;
+    if (!selfContainedPath || !hostedPath) {
+        console.error('Usage: node tests/Validate-DashboardGeneratedArtifacts.js <self-contained-html> <hosted-html>');
+        process.exit(1);
+    }
+
+    validateSelfContained(path.resolve(selfContainedPath));
+    validateHosted(path.resolve(hostedPath));
+}
+
+main();


### PR DESCRIPTION
## Summary
- optimize dashboard runtime behavior with telemetry, modal density guards, devices-by-remediation virtualization, and clearer remediation labeling for cross-platform OS-family rows
- extend shared machine projection and tuple handling so local generation, audits, and the Azure pipeline use the same expanded machine metadata
- add broader validation coverage for generated artifacts, dashboard telemetry, modal responsiveness, large-dataset workflows, and document the optimization work

## Validation
- `node .\\tests\\Assert-DashboardRemediationViews.js`
- `node .\\tests\\Validate-DashboardGeneratedArtifacts.js .\\.local\\live-dashboard\\2026-04-25-merge-ready\\VulnerabilityDashboard.html .\\.local\\live-dashboard\\2026-04-25-merge-ready\\VulnerabilityDashboard.Hosted.html`
- `pwsh -NoProfile -File .\\build\\Invoke-RegressionValidation.ps1`
- regenerated the dual-package dashboard from `.\\.local\\large-datasets\\synthetic-50k-1_5m`
- inspected the regenerated self-contained dashboard in Edge and verified the Windows 11 label disambiguation plus devices-by-remediation virtualization output
