### PR TITLE
Retry empty MDE bulk export blobs

### DIFF
--- a/azure/Invoke-DashboardPipeline.ps1
+++ b/azure/Invoke-DashboardPipeline.ps1
@@ -6891,6 +6891,10 @@ function Invoke-MdeBulkVulnerabilitySnapshotDownload {
         [string]$ExportUrl
     )
 
+    $emptyDownloadMaxAttempts = 4
+    $emptyDownloadInitialDelayMs = 2000
+    $emptyDownloadBackoffMultiplier = 2.0
+
     $resolvedExportUrl = Get-MdeBulkVulnerabilityExportRequestUri -ExportUrl $ExportUrl
     $response = Invoke-RestMethodWithRetry -Uri $resolvedExportUrl -Headers $Headers -Method Get -MaxRetries 4 -InitialDelayMs 5000 -TimeoutSec 600 -RetryTransientTransportFailures
     $exportFiles = @($response.exportFiles)
@@ -6924,30 +6928,57 @@ function Invoke-MdeBulkVulnerabilitySnapshotDownload {
 
         $outputFile = Join-Path $OutputPath ("VulnExport_{0}_{1}_part_{2}.json.gz" -f $groupId, $date, $partIndex)
         $stagingOutputFile = Get-VulnSnapshotStagingPath -OutputFile $outputFile
-        if (Test-Path -LiteralPath $stagingOutputFile -PathType Leaf) {
-            Remove-Item -LiteralPath $stagingOutputFile -Force -ErrorAction SilentlyContinue
-        }
+        $downloadAttempt = 0
+        $emptyDownloadDelayMs = $emptyDownloadInitialDelayMs
 
-        try {
-            Invoke-WebRequestWithRetry -Uri $fileUrl -OutFile $stagingOutputFile -MaxRetries 6 -InitialDelayMs 2000 -TimeoutSec 1800 -RetryTransientTransportFailures
-
-            $stagingFile = Get-Item -LiteralPath $stagingOutputFile -Force -ErrorAction Stop
-            if ($stagingFile.Length -le 0) {
-                throw "Downloaded file is empty: $(Get-SanitizedUriForLog -Uri $fileUrl)"
-            }
-
-            if (Test-Path -LiteralPath $outputFile -PathType Leaf) {
-                Remove-Item -LiteralPath $outputFile -Force -ErrorAction SilentlyContinue
-            }
-
-            [System.IO.File]::Move($stagingOutputFile, $outputFile)
-        }
-        catch {
+        while ($true) {
             if (Test-Path -LiteralPath $stagingOutputFile -PathType Leaf) {
                 Remove-Item -LiteralPath $stagingOutputFile -Force -ErrorAction SilentlyContinue
             }
 
-            throw
+            try {
+                $downloadAttempt++
+                Invoke-WebRequestWithRetry -Uri $fileUrl -OutFile $stagingOutputFile -MaxRetries 6 -InitialDelayMs 2000 -TimeoutSec 1800 -RetryTransientTransportFailures
+                $stagingFile = Get-Item -LiteralPath $stagingOutputFile -Force -ErrorAction Stop
+            }
+            catch {
+                if (Test-Path -LiteralPath $stagingOutputFile -PathType Leaf) {
+                    Remove-Item -LiteralPath $stagingOutputFile -Force -ErrorAction SilentlyContinue
+                }
+
+                throw
+            }
+
+            if ($stagingFile.Length -gt 0) {
+                try {
+                    if (Test-Path -LiteralPath $outputFile -PathType Leaf) {
+                        Remove-Item -LiteralPath $outputFile -Force -ErrorAction SilentlyContinue
+                    }
+
+                    [System.IO.File]::Move($stagingOutputFile, $outputFile)
+                }
+                catch {
+                    if (Test-Path -LiteralPath $stagingOutputFile -PathType Leaf) {
+                        Remove-Item -LiteralPath $stagingOutputFile -Force -ErrorAction SilentlyContinue
+                    }
+
+                    throw
+                }
+
+                break
+            }
+
+            if (Test-Path -LiteralPath $stagingOutputFile -PathType Leaf) {
+                Remove-Item -LiteralPath $stagingOutputFile -Force -ErrorAction SilentlyContinue
+            }
+
+            if ($downloadAttempt -ge $emptyDownloadMaxAttempts) {
+                throw "Downloaded file is empty: $(Get-SanitizedUriForLog -Uri $fileUrl)"
+            }
+
+            Write-Warning ("Downloaded file was empty for {0} (attempt {1}/{2}). Retrying in {3}s..." -f (Get-SanitizedUriForLog -Uri $fileUrl), $downloadAttempt, $emptyDownloadMaxAttempts, [math]::Round($emptyDownloadDelayMs / 1000, 1))
+            Start-Sleep -Milliseconds $emptyDownloadDelayMs
+            $emptyDownloadDelayMs = [int]($emptyDownloadDelayMs * $emptyDownloadBackoffMultiplier)
         }
 
         $downloadedFiles.Add($outputFile)

--- a/src/powershell/Shared/DefenderApi/MdeExport.ps1
+++ b/src/powershell/Shared/DefenderApi/MdeExport.ps1
@@ -212,6 +212,10 @@ function Invoke-MdeBulkVulnerabilitySnapshotDownload {
         [string]$ExportUrl
     )
 
+    $emptyDownloadMaxAttempts = 4
+    $emptyDownloadInitialDelayMs = 2000
+    $emptyDownloadBackoffMultiplier = 2.0
+
     $resolvedExportUrl = Get-MdeBulkVulnerabilityExportRequestUri -ExportUrl $ExportUrl
     $response = Invoke-RestMethodWithRetry -Uri $resolvedExportUrl -Headers $Headers -Method Get -MaxRetries 4 -InitialDelayMs 5000 -TimeoutSec 600 -RetryTransientTransportFailures
     $exportFiles = @($response.exportFiles)
@@ -245,30 +249,57 @@ function Invoke-MdeBulkVulnerabilitySnapshotDownload {
 
         $outputFile = Join-Path $OutputPath ("VulnExport_{0}_{1}_part_{2}.json.gz" -f $groupId, $date, $partIndex)
         $stagingOutputFile = Get-VulnSnapshotStagingPath -OutputFile $outputFile
-        if (Test-Path -LiteralPath $stagingOutputFile -PathType Leaf) {
-            Remove-Item -LiteralPath $stagingOutputFile -Force -ErrorAction SilentlyContinue
-        }
+        $downloadAttempt = 0
+        $emptyDownloadDelayMs = $emptyDownloadInitialDelayMs
 
-        try {
-            Invoke-WebRequestWithRetry -Uri $fileUrl -OutFile $stagingOutputFile -MaxRetries 6 -InitialDelayMs 2000 -TimeoutSec 1800 -RetryTransientTransportFailures
-
-            $stagingFile = Get-Item -LiteralPath $stagingOutputFile -Force -ErrorAction Stop
-            if ($stagingFile.Length -le 0) {
-                throw "Downloaded file is empty: $(Get-SanitizedUriForLog -Uri $fileUrl)"
-            }
-
-            if (Test-Path -LiteralPath $outputFile -PathType Leaf) {
-                Remove-Item -LiteralPath $outputFile -Force -ErrorAction SilentlyContinue
-            }
-
-            [System.IO.File]::Move($stagingOutputFile, $outputFile)
-        }
-        catch {
+        while ($true) {
             if (Test-Path -LiteralPath $stagingOutputFile -PathType Leaf) {
                 Remove-Item -LiteralPath $stagingOutputFile -Force -ErrorAction SilentlyContinue
             }
 
-            throw
+            try {
+                $downloadAttempt++
+                Invoke-WebRequestWithRetry -Uri $fileUrl -OutFile $stagingOutputFile -MaxRetries 6 -InitialDelayMs 2000 -TimeoutSec 1800 -RetryTransientTransportFailures
+                $stagingFile = Get-Item -LiteralPath $stagingOutputFile -Force -ErrorAction Stop
+            }
+            catch {
+                if (Test-Path -LiteralPath $stagingOutputFile -PathType Leaf) {
+                    Remove-Item -LiteralPath $stagingOutputFile -Force -ErrorAction SilentlyContinue
+                }
+
+                throw
+            }
+
+            if ($stagingFile.Length -gt 0) {
+                try {
+                    if (Test-Path -LiteralPath $outputFile -PathType Leaf) {
+                        Remove-Item -LiteralPath $outputFile -Force -ErrorAction SilentlyContinue
+                    }
+
+                    [System.IO.File]::Move($stagingOutputFile, $outputFile)
+                }
+                catch {
+                    if (Test-Path -LiteralPath $stagingOutputFile -PathType Leaf) {
+                        Remove-Item -LiteralPath $stagingOutputFile -Force -ErrorAction SilentlyContinue
+                    }
+
+                    throw
+                }
+
+                break
+            }
+
+            if (Test-Path -LiteralPath $stagingOutputFile -PathType Leaf) {
+                Remove-Item -LiteralPath $stagingOutputFile -Force -ErrorAction SilentlyContinue
+            }
+
+            if ($downloadAttempt -ge $emptyDownloadMaxAttempts) {
+                throw "Downloaded file is empty: $(Get-SanitizedUriForLog -Uri $fileUrl)"
+            }
+
+            Write-Warning ("Downloaded file was empty for {0} (attempt {1}/{2}). Retrying in {3}s..." -f (Get-SanitizedUriForLog -Uri $fileUrl), $downloadAttempt, $emptyDownloadMaxAttempts, [math]::Round($emptyDownloadDelayMs / 1000, 1))
+            Start-Sleep -Milliseconds $emptyDownloadDelayMs
+            $emptyDownloadDelayMs = [int]($emptyDownloadDelayMs * $emptyDownloadBackoffMultiplier)
         }
 
         $downloadedFiles.Add($outputFile)

--- a/tests/Run-SharedHelperRegression.ps1
+++ b/tests/Run-SharedHelperRegression.ps1
@@ -731,6 +731,270 @@ function Test-BulkVulnerabilitySnapshotDownloadStagingBehavior {
     }
 }
 
+function Test-BulkVulnerabilitySnapshotDownloadRetriesEmptyBlob {
+    [CmdletBinding()]
+    param()
+
+    $tempRoot = Join-Path ([System.IO.Path]::GetTempPath()) ('bulk-download-empty-blob-' + [guid]::NewGuid().ToString('N'))
+    [void](New-Item -Path $tempRoot -ItemType Directory -Force)
+
+    $originalRestMethod = (Get-Command -Name Invoke-RestMethodWithRetry -CommandType Function).ScriptBlock
+    $originalWebRequest = (Get-Command -Name Invoke-WebRequestWithRetry -CommandType Function).ScriptBlock
+
+    try {
+        $script:EmptyBlobDownloadAttempts = 0
+        $script:EmptyBlobRetrySleeps = [System.Collections.Generic.List[int]]::new()
+
+        Set-Item -Path Function:Invoke-RestMethodWithRetry -Value {
+            param(
+                [string]$Uri,
+                [string]$Method,
+                [hashtable]$Headers,
+                [object]$Body,
+                [string]$ContentType,
+                [int]$MaxRetries,
+                [int]$InitialDelayMs,
+                [double]$BackoffMultiplier,
+                [int]$TimeoutSec,
+                [switch]$RetryTransientTransportFailures
+            )
+
+            $null = $Uri, $Method, $Headers, $Body, $ContentType, $MaxRetries, $InitialDelayMs, $BackoffMultiplier, $TimeoutSec, $RetryTransientTransportFailures
+
+            return [PSCustomObject]@{
+                exportFiles = @('https://example.invalid/flat-va/2026-01-01/org/json/_RbacGroupId=1/part-000.c000.json.gz?sig=secret')
+            }
+        }
+
+        Set-Item -Path Function:Start-Sleep -Value {
+            param(
+                [int]$Milliseconds
+            )
+
+            $script:EmptyBlobRetrySleeps.Add($Milliseconds)
+        }
+
+        Set-Item -Path Function:Invoke-WebRequestWithRetry -Value {
+            param(
+                [string]$Uri,
+                [string]$Method,
+                [hashtable]$Headers,
+                [string]$OutFile,
+                [string]$InFile,
+                [string]$ContentType,
+                [int]$MaxRetries,
+                [int]$InitialDelayMs,
+                [double]$BackoffMultiplier,
+                [int]$TimeoutSec,
+                [switch]$RetryTransientTransportFailures
+            )
+
+            $null = $Uri, $Method, $Headers, $InFile, $ContentType, $MaxRetries, $InitialDelayMs, $BackoffMultiplier, $TimeoutSec, $RetryTransientTransportFailures
+
+            $script:EmptyBlobDownloadAttempts++
+            if ($script:EmptyBlobDownloadAttempts -eq 1) {
+                [System.IO.File]::WriteAllText($OutFile, '', [System.Text.UTF8Encoding]::new($false))
+                return
+            }
+
+            [System.IO.File]::WriteAllText($OutFile, 'payload', [System.Text.UTF8Encoding]::new($false))
+        }
+
+        $result = Invoke-MdeBulkVulnerabilitySnapshotDownload -Headers @{} -OutputPath $tempRoot -ExportUrl 'https://example.invalid/api/machines/SoftwareVulnerabilitiesExport'
+        $finalPath = Join-Path $tempRoot 'VulnExport_1_2026-01-01_part_0.json.gz'
+        $stagingPath = Join-Path $tempRoot '.VulnExport_1_2026-01-01_part_0.json.gz.partial'
+
+        Assert-True ($script:EmptyBlobDownloadAttempts -eq 2) 'Expected zero-byte bulk snapshot downloads to be retried.'
+        Assert-True ($script:EmptyBlobRetrySleeps.Count -eq 1 -and $script:EmptyBlobRetrySleeps[0] -eq 2000) 'Expected the first empty bulk snapshot retry to wait for the configured initial delay.'
+        Assert-True ((Test-Path -LiteralPath $finalPath -PathType Leaf)) 'Expected a retried empty bulk snapshot download to eventually finalize the export file.'
+        Assert-True (-not (Test-Path -LiteralPath $stagingPath -PathType Leaf)) 'Expected empty bulk snapshot retries to clean up their partial files before retrying.'
+        Assert-True ($result.DownloadedFiles.Count -eq 1 -and $result.DownloadedFiles[0] -eq $finalPath) 'Expected the downloader to report the finalized export path after retrying an empty blob.'
+    }
+    finally {
+        Set-Item -Path Function:Invoke-RestMethodWithRetry -Value $originalRestMethod
+        Set-Item -Path Function:Invoke-WebRequestWithRetry -Value $originalWebRequest
+        Remove-Item -Path Function:Start-Sleep -ErrorAction SilentlyContinue
+        Remove-Variable -Name EmptyBlobDownloadAttempts -Scope Script -ErrorAction SilentlyContinue
+        Remove-Variable -Name EmptyBlobRetrySleeps -Scope Script -ErrorAction SilentlyContinue
+
+        if (Test-Path -LiteralPath $tempRoot) {
+            Remove-Item -LiteralPath $tempRoot -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+}
+
+function Test-BulkVulnerabilitySnapshotDownloadEmptyBlobExhaustionBehavior {
+    [CmdletBinding()]
+    param()
+
+    $tempRoot = Join-Path ([System.IO.Path]::GetTempPath()) ('bulk-download-empty-blob-exhaustion-' + [guid]::NewGuid().ToString('N'))
+    [void](New-Item -Path $tempRoot -ItemType Directory -Force)
+
+    $originalRestMethod = (Get-Command -Name Invoke-RestMethodWithRetry -CommandType Function).ScriptBlock
+    $originalWebRequest = (Get-Command -Name Invoke-WebRequestWithRetry -CommandType Function).ScriptBlock
+
+    try {
+        $script:EmptyBlobExhaustionDownloadAttempts = 0
+        $script:EmptyBlobExhaustionSleeps = [System.Collections.Generic.List[int]]::new()
+
+        Set-Item -Path Function:Invoke-RestMethodWithRetry -Value {
+            param(
+                [string]$Uri,
+                [string]$Method,
+                [hashtable]$Headers,
+                [object]$Body,
+                [string]$ContentType,
+                [int]$MaxRetries,
+                [int]$InitialDelayMs,
+                [double]$BackoffMultiplier,
+                [int]$TimeoutSec,
+                [switch]$RetryTransientTransportFailures
+            )
+
+            $null = $Uri, $Method, $Headers, $Body, $ContentType, $MaxRetries, $InitialDelayMs, $BackoffMultiplier, $TimeoutSec, $RetryTransientTransportFailures
+
+            return [PSCustomObject]@{
+                exportFiles = @('https://example.invalid/flat-va/2026-01-01/org/json/_RbacGroupId=1/part-000.c000.json.gz?sig=secret')
+            }
+        }
+
+        Set-Item -Path Function:Start-Sleep -Value {
+            param(
+                [int]$Milliseconds
+            )
+
+            $script:EmptyBlobExhaustionSleeps.Add($Milliseconds)
+        }
+
+        Set-Item -Path Function:Invoke-WebRequestWithRetry -Value {
+            param(
+                [string]$Uri,
+                [string]$Method,
+                [hashtable]$Headers,
+                [string]$OutFile,
+                [string]$InFile,
+                [string]$ContentType,
+                [int]$MaxRetries,
+                [int]$InitialDelayMs,
+                [double]$BackoffMultiplier,
+                [int]$TimeoutSec,
+                [switch]$RetryTransientTransportFailures
+            )
+
+            $null = $Uri, $Method, $Headers, $InFile, $ContentType, $MaxRetries, $InitialDelayMs, $BackoffMultiplier, $TimeoutSec, $RetryTransientTransportFailures
+
+            $script:EmptyBlobExhaustionDownloadAttempts++
+            [System.IO.File]::WriteAllText($OutFile, '', [System.Text.UTF8Encoding]::new($false))
+        }
+
+        $downloadFailure = $null
+        try {
+            $null = Invoke-MdeBulkVulnerabilitySnapshotDownload -Headers @{} -OutputPath $tempRoot -ExportUrl 'https://example.invalid/api/machines/SoftwareVulnerabilitiesExport'
+        }
+        catch {
+            $downloadFailure = $_
+        }
+
+        $finalPath = Join-Path $tempRoot 'VulnExport_1_2026-01-01_part_0.json.gz'
+        $stagingPath = Join-Path $tempRoot '.VulnExport_1_2026-01-01_part_0.json.gz.partial'
+
+        Assert-True ($null -ne $downloadFailure) 'Expected persistently empty bulk snapshot downloads to fail after exhausting retries.'
+        Assert-True ($script:EmptyBlobExhaustionDownloadAttempts -eq 4) 'Expected empty bulk snapshot downloads to stop after four attempts.'
+        Assert-True (($script:EmptyBlobExhaustionSleeps -join ',') -eq '2000,4000,8000') 'Expected empty bulk snapshot retries to use exponential backoff before the final failure.'
+        Assert-True ([string]$downloadFailure.Exception.Message -eq 'Downloaded file is empty: https://example.invalid/flat-va/2026-01-01/org/json/_RbacGroupId=1/part-000.c000.json.gz') 'Expected the empty bulk snapshot failure to surface the sanitized blob URL.'
+        Assert-True (-not (Test-Path -LiteralPath $stagingPath -PathType Leaf)) 'Expected empty bulk snapshot retry exhaustion to clean up the staged partial file.'
+        Assert-True (-not (Test-Path -LiteralPath $finalPath -PathType Leaf)) 'Expected empty bulk snapshot retry exhaustion to avoid finalizing an output file.'
+    }
+    finally {
+        Set-Item -Path Function:Invoke-RestMethodWithRetry -Value $originalRestMethod
+        Set-Item -Path Function:Invoke-WebRequestWithRetry -Value $originalWebRequest
+        Remove-Item -Path Function:Start-Sleep -ErrorAction SilentlyContinue
+        Remove-Variable -Name EmptyBlobExhaustionDownloadAttempts -Scope Script -ErrorAction SilentlyContinue
+        Remove-Variable -Name EmptyBlobExhaustionSleeps -Scope Script -ErrorAction SilentlyContinue
+
+        if (Test-Path -LiteralPath $tempRoot) {
+            Remove-Item -LiteralPath $tempRoot -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+}
+
+function Test-BulkVulnerabilitySnapshotDownloadMoveFailureCleanupBehavior {
+    [CmdletBinding()]
+    param()
+
+    $tempRoot = Join-Path ([System.IO.Path]::GetTempPath()) ('bulk-download-move-failure-' + [guid]::NewGuid().ToString('N'))
+    [void](New-Item -Path $tempRoot -ItemType Directory -Force)
+
+    $originalRestMethod = (Get-Command -Name Invoke-RestMethodWithRetry -CommandType Function).ScriptBlock
+    $originalWebRequest = (Get-Command -Name Invoke-WebRequestWithRetry -CommandType Function).ScriptBlock
+
+    try {
+        Set-Item -Path Function:Invoke-RestMethodWithRetry -Value {
+            param(
+                [string]$Uri,
+                [string]$Method,
+                [hashtable]$Headers,
+                [object]$Body,
+                [string]$ContentType,
+                [int]$MaxRetries,
+                [int]$InitialDelayMs,
+                [double]$BackoffMultiplier,
+                [int]$TimeoutSec,
+                [switch]$RetryTransientTransportFailures
+            )
+
+            $null = $Uri, $Method, $Headers, $Body, $ContentType, $MaxRetries, $InitialDelayMs, $BackoffMultiplier, $TimeoutSec, $RetryTransientTransportFailures
+
+            return [PSCustomObject]@{
+                exportFiles = @('https://example.invalid/flat-va/2026-01-01/org/json/_RbacGroupId=1/part-000.c000.json.gz?sig=secret')
+            }
+        }
+
+        Set-Item -Path Function:Invoke-WebRequestWithRetry -Value {
+            param(
+                [string]$Uri,
+                [string]$Method,
+                [hashtable]$Headers,
+                [string]$OutFile,
+                [string]$InFile,
+                [string]$ContentType,
+                [int]$MaxRetries,
+                [int]$InitialDelayMs,
+                [double]$BackoffMultiplier,
+                [int]$TimeoutSec,
+                [switch]$RetryTransientTransportFailures
+            )
+
+            $null = $Uri, $Method, $Headers, $InFile, $ContentType, $MaxRetries, $InitialDelayMs, $BackoffMultiplier, $TimeoutSec, $RetryTransientTransportFailures
+            [System.IO.File]::WriteAllText($OutFile, 'payload', [System.Text.UTF8Encoding]::new($false))
+        }
+
+        $finalPath = Join-Path $tempRoot 'VulnExport_1_2026-01-01_part_0.json.gz'
+        $stagingPath = Join-Path $tempRoot '.VulnExport_1_2026-01-01_part_0.json.gz.partial'
+        [void](New-Item -Path $finalPath -ItemType Directory -Force)
+
+        $moveFailure = $null
+        try {
+            $null = Invoke-MdeBulkVulnerabilitySnapshotDownload -Headers @{} -OutputPath $tempRoot -ExportUrl 'https://example.invalid/api/machines/SoftwareVulnerabilitiesExport'
+        }
+        catch {
+            $moveFailure = $_
+        }
+
+        Assert-True ($null -ne $moveFailure) 'Expected a conflicting move target to surface a failure.'
+        Assert-True ((Test-Path -LiteralPath $finalPath -PathType Container)) 'Expected the conflicting destination directory to remain in place.'
+        Assert-True (-not (Test-Path -LiteralPath $stagingPath -PathType Leaf)) 'Expected move failures to clean up the staged partial file.'
+    }
+    finally {
+        Set-Item -Path Function:Invoke-RestMethodWithRetry -Value $originalRestMethod
+        Set-Item -Path Function:Invoke-WebRequestWithRetry -Value $originalWebRequest
+
+        if (Test-Path -LiteralPath $tempRoot) {
+            Remove-Item -LiteralPath $tempRoot -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+}
+
 function Test-BulkVulnerabilitySnapshotDownloadCleanupBehavior {
     [CmdletBinding()]
     param()
@@ -2944,6 +3208,12 @@ Test-BulkVulnerabilitySnapshotDownloadMultipartNameUniqueness
 Write-Output '  Multipart vulnerability download naming checks passed.'
 Test-BulkVulnerabilitySnapshotDownloadStagingBehavior
 Write-Output '  Multipart vulnerability download staging checks passed.'
+Test-BulkVulnerabilitySnapshotDownloadRetriesEmptyBlob
+Write-Output '  Multipart vulnerability empty-blob retry checks passed.'
+Test-BulkVulnerabilitySnapshotDownloadEmptyBlobExhaustionBehavior
+Write-Output '  Multipart vulnerability empty-blob retry exhaustion checks passed.'
+Test-BulkVulnerabilitySnapshotDownloadMoveFailureCleanupBehavior
+Write-Output '  Multipart vulnerability move-failure cleanup checks passed.'
 Test-BulkVulnerabilitySnapshotDownloadCleanupBehavior
 Write-Output '  Multipart vulnerability failed-download cleanup checks passed.'
 Test-VulnCurrentFileRejectsDuplicateId


### PR DESCRIPTION
## Summary
Retry zero-byte MDE bulk export blob downloads instead of failing on the first successful-but-empty response.

## What changed
- Keep multipart RBAC-scoped export filenames unique by group/date/part
- Retry empty staged blob downloads up to 4 attempts with exponential backoff
- Clean up staged partial files on retry exhaustion and on final move failures
- Add regression coverage for:
  - empty blob then success
  - empty blob retry exhaustion
  - staged file cleanup when final move fails

## Validation
- `pwsh -NoProfile -File .\tests\Run-SharedHelperRegression.ps1`
- regenerated Azure artifacts and parsed:
  - `azure/Invoke-DashboardPipeline.ps1`
  - `azure/function-app/ExportAndGenerate/run.ps1`

## Context
The original customer issue was data loss from reusing filenames across RBAC device groups. After that naming fix, the next observed failure was a zero-byte downloaded blob from the MDE export URLs. This PR addresses that empty-blob path without changing the transport retry helper behavior.