### PR TITLE
Harden dashboard pipeline validation

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,19 @@
+## Summary
+
+-
+
+## Validation
+
+- [ ] Deterministic preflight: `pwsh -NoProfile -File .\build\Invoke-RegressionValidation.ps1`
+- [ ] Live export dry run, when API export or shipped dashboard behavior changed: `pwsh -NoProfile -File .\build\Invoke-LiveDashboardDryRun.ps1 -UseExistingAzContext`
+- [ ] Large-dataset artifact gate, when normalization, payload, validation, or packaging changed: `pwsh -NoProfile -File .\tests\Invoke-LargeDatasetValidation.ps1 -SkipSyntheticGeneration -SyntheticOutputPath .\.local\large-datasets\synthetic-50k-1_5m -Validate -ValidationMode artifacts`
+- [ ] Large-dataset semantic sign-off, when semantics, validation, or perf-sensitive behavior changed: `pwsh -NoProfile -File .\tests\Invoke-LargeDatasetValidation.ps1 -SkipSyntheticGeneration -SyntheticOutputPath .\.local\large-datasets\synthetic-50k-1_5m -Validate -ValidationMode semantic`
+- [ ] Azure deployment validation, when Azure deployment, packaging, Automation, Function App, or release packaging changed: `pwsh -NoProfile -File .\build\Invoke-AzureDeploymentValidation.ps1 <local parameters>`
+- [ ] Hosted dashboard runtime smoke, when split-assets delivery changed: `pwsh -NoProfile -File .\tests\Invoke-HostedDashboardRuntimeSmoke.ps1 -DashboardPath <hosted-html>`
+- [ ] Not applicable: explain skipped gates below.
+
+## Gate Notes
+
+- Dataset(s):
+- Artifact path(s):
+- Skipped gates and reason:

--- a/.github/workflows/validate-dashboard.yml
+++ b/.github/workflows/validate-dashboard.yml
@@ -7,11 +7,14 @@ concurrency:
 on:
   pull_request:
     paths:
-      - '*.ps1'
       - '**/*.ps1'
+      - 'azure/**'
+      - 'build/manifests/**'
       - 'build/PSScriptAnalyzerSettings.psd1'
       - 'build/Validate-DashboardReports.ps1'
+      - 'src/**'
       - 'templates/**'
+      - 'tests/**'
       - 'exports/**'
       - 'VulnerabilityDashboard.html'
       - '.github/workflows/validate-dashboard.yml'
@@ -22,11 +25,14 @@ on:
     branches:
       - main
     paths:
-      - '*.ps1'
       - '**/*.ps1'
+      - 'azure/**'
+      - 'build/manifests/**'
       - 'build/PSScriptAnalyzerSettings.psd1'
       - 'build/Validate-DashboardReports.ps1'
+      - 'src/**'
       - 'templates/**'
+      - 'tests/**'
       - 'exports/**'
       - 'VulnerabilityDashboard.html'
       - '.github/workflows/validate-dashboard.yml'

--- a/Generate-VulnerabilityDashboard.ps1
+++ b/Generate-VulnerabilityDashboard.ps1
@@ -620,6 +620,8 @@ try {
         $payloadCacheEntry = Get-NormalizedPayloadCacheEntry -BasePath $DirectoryPath -SkipObservedWindowMerge:$effectiveSkipObservedWindowMerge
         $payloadManifest = $null
         $payloadManifestPath = $null
+        $payloadSourceMode = 'unknown'
+        $sourceMetadata = $null
         $normalizedQuality = $null
         $vulnCount = 0
         $deviceCount = 0
@@ -649,6 +651,7 @@ try {
 
                 Copy-Item -LiteralPath $resolvedNormalizedPayloadInputPath -Destination $tempPayloadPath -Force
                 Write-Host ("  Using provided normalized payload ({0})..." -f [System.IO.Path]::GetFileName($resolvedNormalizedPayloadInputPath)) -ForegroundColor Gray
+                $payloadSourceMode = 'package-only-input'
             }
             else {
                 if (-not $payloadCacheEntry) {
@@ -659,12 +662,10 @@ try {
                 $payloadManifestPath = $payloadCacheEntry.ManifestPath
                 Copy-Item -LiteralPath $payloadCacheEntry.PayloadPath -Destination $tempPayloadPath -Force
                 Write-Host ("  Reusing cached normalized payload ({0})..." -f $payloadCacheEntry.Fingerprint.Substring(0, 12)) -ForegroundColor Gray
+                $payloadSourceMode = 'package-only-cache'
             }
 
-            $payloadManifestRecord = ConvertTo-NormalizedPayloadManifestRecord -Manifest $payloadManifest
-            if (-not $payloadManifestRecord.Contains('PayloadSha256') -or [string]::IsNullOrWhiteSpace([string]$payloadManifestRecord.PayloadSha256)) {
-                $payloadManifestRecord.PayloadSha256 = Get-FileSha256Hex -Path $tempPayloadPath
-            }
+            $payloadManifestRecord = Confirm-NormalizedPayloadManifestPayloadSha -Manifest $payloadManifest -PayloadPath $tempPayloadPath -ThrowOnMismatch
             if (-not $payloadManifestRecord.Contains('SkipObservedWindowMerge')) {
                 $payloadManifestRecord.SkipObservedWindowMerge = ($effectiveSkipObservedWindowMerge -eq $true)
             }
@@ -678,26 +679,51 @@ try {
             Write-Host "  Cached payload: ${compressedSize}KB" -ForegroundColor Green
             $localPhaseTimings.Add((Complete-LocalDiagnosticPhase -PhaseContext $phaseContext)) | Out-Null
         }
-        elseif ($payloadCacheEntry) {
-            $phaseContext = Get-LocalDiagnosticPhaseContext -Name 'Prepare normalized payload'
-            Write-Host "`nPreparing data for embedding..." -ForegroundColor Cyan
-            Write-Host ("  Reusing cached normalized payload ({0})..." -f $payloadCacheEntry.Fingerprint.Substring(0, 12)) -ForegroundColor Gray
-            Copy-Item -LiteralPath $payloadCacheEntry.PayloadPath -Destination $tempPayloadPath -Force
-            $payloadManifestRecord = ConvertTo-NormalizedPayloadManifestRecord -Manifest $payloadCacheEntry.Manifest
-            if (-not $payloadManifestRecord.Contains('PayloadSha256') -or [string]::IsNullOrWhiteSpace([string]$payloadManifestRecord.PayloadSha256)) {
-                $payloadManifestRecord.PayloadSha256 = Get-FileSha256Hex -Path $payloadCacheEntry.PayloadPath
-            }
-            $payloadManifest = [PSCustomObject]$payloadManifestRecord
-            $payloadManifestPath = $payloadCacheEntry.ManifestPath
-            $vulnCount = [int]$payloadManifest.VulnCount
-            $deviceCount = [int]$payloadManifest.DeviceCount
-            $cveCount = [int]$payloadManifest.CveCount
-            $normalizedQuality = $payloadManifest.Quality
-            $compressedSize = [math]::Round((Get-Item $tempPayloadPath).Length / 1KB, 1)
-            Write-Host "  Cached payload: ${compressedSize}KB" -ForegroundColor Green
-            $localPhaseTimings.Add((Complete-LocalDiagnosticPhase -PhaseContext $phaseContext)) | Out-Null
-        }
         else {
+            if ($payloadCacheEntry) {
+                $phaseContext = Get-LocalDiagnosticPhaseContext -Name 'Prepare normalized payload'
+                Write-Host "`nPreparing data for embedding..." -ForegroundColor Cyan
+                Write-Host ("  Reusing cached normalized payload ({0})..." -f $payloadCacheEntry.Fingerprint.Substring(0, 12)) -ForegroundColor Gray
+                $payloadManifestRecord = $null
+                $cacheReuseFailure = $null
+                try {
+                    Copy-Item -LiteralPath $payloadCacheEntry.PayloadPath -Destination $tempPayloadPath -Force
+                    $payloadManifestRecord = Confirm-NormalizedPayloadManifestPayloadSha -Manifest $payloadCacheEntry.Manifest -PayloadPath $tempPayloadPath
+                }
+                catch {
+                    $cacheReuseFailure = $_
+                }
+
+                if ($null -eq $payloadManifestRecord) {
+                    if ($null -ne $cacheReuseFailure) {
+                        Write-Warning ("  Cached normalized payload reuse failed after cache validation; regenerating. {0}" -f $cacheReuseFailure.Exception.Message)
+                    }
+                    else {
+                        Write-Warning '  Cached normalized payload failed payload hash validation after copy; regenerating.'
+                    }
+
+                    Remove-Item -LiteralPath $tempPayloadPath -Force -ErrorAction SilentlyContinue
+                    $payloadCacheEntry = $null
+                    $payloadManifestPath = $null
+                }
+                else {
+                    $payloadManifest = [PSCustomObject]$payloadManifestRecord
+                    $payloadManifestPath = $payloadCacheEntry.ManifestPath
+                    $payloadSourceMode = 'normalized-payload-cache'
+                    $vulnCount = [int]$payloadManifest.VulnCount
+                    $deviceCount = [int]$payloadManifest.DeviceCount
+                    $cveCount = [int]$payloadManifest.CveCount
+                    $normalizedQuality = $payloadManifest.Quality
+                    $compressedSize = [math]::Round((Get-Item $tempPayloadPath).Length / 1KB, 1)
+                    Write-Host "  Cached payload: ${compressedSize}KB" -ForegroundColor Green
+                }
+
+                $localPhaseTimings.Add((Complete-LocalDiagnosticPhase -PhaseContext $phaseContext)) | Out-Null
+            }
+
+        }
+
+        if ((-not $PackageOnly) -and ($null -eq $payloadManifest)) {
             $phaseContext = Get-LocalDiagnosticPhaseContext -Name 'Load source data'
             $machines = Read-NormalizationMachineLookup -Path $DirectoryPath
             $advancedHuntingBundle = Read-AdvancedHuntingBundle -Path $DirectoryPath -IncludeDeviceUsers -IncludeInventoryData
@@ -705,6 +731,15 @@ try {
             $advancedHuntingDeviceUsers = [hashtable]$advancedHuntingBundle.DeviceUsers
             $advancedHuntingInventoryData = [hashtable]$advancedHuntingBundle.InventoryData
             $nvdCveData = Read-NvdCveData -Path $DirectoryPath
+            $sourceMetadata = Get-DashboardSourceSummary `
+                -BasePath $DirectoryPath `
+                -MachineCount $machines.Count `
+                -AdvancedHuntingCveCount $advancedHuntingData.Count `
+                -AdvancedHuntingDeviceUserCount $advancedHuntingDeviceUsers.Count `
+                -AdvancedHuntingInventoryTupleCount $advancedHuntingInventoryData.Count `
+                -NvdCveCount $nvdCveData.Count `
+                -NormalizationMode 'live-normalization' `
+                -SkipObservedWindowMerge:$effectiveSkipObservedWindowMerge
             $localPhaseTimings.Add((Complete-LocalDiagnosticPhase -PhaseContext $phaseContext)) | Out-Null
 
             $phaseContext = Get-LocalDiagnosticPhaseContext -Name 'Normalize source data'
@@ -823,11 +858,12 @@ try {
             }
             Invoke-FullGarbageCollection
 
-            $cacheEntry = Publish-NormalizedPayloadCache -BasePath $DirectoryPath -PayloadPath $tempPayloadPath -VulnCount $vulnCount -DeviceCount $deviceCount -CveCount $cveCount -Quality $normalizedQuality -SkipObservedWindowMerge:$effectiveSkipObservedWindowMerge
+            $cacheEntry = Publish-NormalizedPayloadCache -BasePath $DirectoryPath -PayloadPath $tempPayloadPath -VulnCount $vulnCount -DeviceCount $deviceCount -CveCount $cveCount -Quality $normalizedQuality -SourceMetadata $sourceMetadata -SkipObservedWindowMerge:$effectiveSkipObservedWindowMerge
             if ($cacheEntry) {
                 Write-Host ("  Cached normalized payload as {0}" -f $cacheEntry.Fingerprint.Substring(0, 12)) -ForegroundColor Gray
                 $payloadManifest = $cacheEntry.Manifest
                 $payloadManifestPath = $cacheEntry.ManifestPath
+                $payloadSourceMode = 'live-normalization'
             }
             else {
                 $payloadManifest = [PSCustomObject]@{
@@ -839,9 +875,11 @@ try {
                     DeviceCount = $deviceCount
                     CveCount = $cveCount
                     Quality = $normalizedQuality
+                    SourceMetadata = $sourceMetadata
                     SkipObservedWindowMerge = ($effectiveSkipObservedWindowMerge -eq $true)
                     SemanticValidationAttestation = $null
                 }
+                $payloadSourceMode = 'live-normalization'
             }
 
             $compressedSize = [math]::Round((Get-Item $tempPayloadPath).Length / 1KB, 1)
@@ -949,6 +987,17 @@ try {
         }
         if (-not $payloadManifestRecord.Contains('SkipObservedWindowMerge')) {
             $payloadManifestRecord.SkipObservedWindowMerge = ($effectiveSkipObservedWindowMerge -eq $true)
+        }
+        if (-not $payloadManifestRecord.Contains('SourceMetadata') -or $null -eq $payloadManifestRecord.SourceMetadata) {
+            $payloadManifestRecord.SourceMetadata = Get-DashboardSourceSummary `
+                -BasePath $DirectoryPath `
+                -MachineCount $deviceCount `
+                -AdvancedHuntingCveCount 0 `
+                -AdvancedHuntingDeviceUserCount 0 `
+                -AdvancedHuntingInventoryTupleCount 0 `
+                -NvdCveCount 0 `
+                -NormalizationMode $payloadSourceMode `
+                -SkipObservedWindowMerge:$effectiveSkipObservedWindowMerge
         }
         $payloadManifest = [PSCustomObject]$payloadManifestRecord
 

--- a/azure/Invoke-DashboardPipeline.ps1
+++ b/azure/Invoke-DashboardPipeline.ps1
@@ -9574,9 +9574,16 @@ function Save-JSLibraryFile {
         $safeName = ($Name -replace '[^A-Za-z0-9._-]', '-')
         $cachePath = Join-Path $cacheDirectory ("{0}-{1}{2}" -f $safeName, $urlHash, $extension)
         if (Test-Path -LiteralPath $cachePath -PathType Leaf) {
-            Copy-Item -LiteralPath $cachePath -Destination $OutputPath -Force
-            Write-Information "Reusing cached $Name library" -InformationAction Continue
-            return $OutputPath
+            $cachedLibrary = Get-Item -LiteralPath $cachePath
+            if ($cachedLibrary.Length -le 0) {
+                Write-Warning "Cached $Name library was empty; refreshing."
+                Remove-Item -LiteralPath $cachePath -Force -ErrorAction SilentlyContinue
+            }
+            else {
+                Copy-Item -LiteralPath $cachePath -Destination $OutputPath -Force
+                Write-Information "Reusing cached $Name library" -InformationAction Continue
+                return $OutputPath
+            }
         }
     }
 
@@ -9584,6 +9591,11 @@ function Save-JSLibraryFile {
 
     try {
         Invoke-WebRequest -Uri $Url -OutFile $OutputPath -TimeoutSec 30
+        $downloadedLibrary = Get-Item -LiteralPath $OutputPath -ErrorAction Stop
+        if ($downloadedLibrary.Length -le 0) {
+            throw "$Name library download produced an empty file."
+        }
+
         if ($cachePath) {
             Copy-Item -LiteralPath $OutputPath -Destination $cachePath -Force
         }
@@ -9591,6 +9603,10 @@ function Save-JSLibraryFile {
         return $OutputPath
     }
     catch {
+        if (Test-Path -LiteralPath $OutputPath -PathType Leaf) {
+            Remove-Item -LiteralPath $OutputPath -Force -ErrorAction SilentlyContinue
+        }
+
         $errorMessage = "Failed to download $Name from $Url`: $_"
         if ($Critical) {
             Write-Error $errorMessage
@@ -11785,7 +11801,6 @@ function Get-FileSetFingerprint {
         $fileIdentity = if ($FileIdentityProperty -eq 'Name') { $file.Name } else { $file.FullName }
         [void]$builder.Append($fileIdentity).Append('|')
         [void]$builder.Append($file.Length).Append('|')
-        [void]$builder.Append($file.LastWriteTimeUtc.Ticks).Append('|')
         [void]$builder.AppendLine($hash)
     }
 
@@ -12259,6 +12274,91 @@ function Get-NvdCveFingerprintSourceFileSet {
     return [System.IO.FileInfo[]]@((Get-Item -LiteralPath $currentPath))
 }
 
+function Get-DashboardSourceFileSummary {
+    [CmdletBinding()]
+    [OutputType([pscustomobject])]
+    param(
+        [Parameter(Mandatory = $false)]
+        [AllowNull()]
+        [System.IO.FileInfo[]]$Files
+    )
+
+    $sourceFiles = @($Files | Where-Object { $null -ne $_ } | Sort-Object FullName)
+    $latestFile = @($sourceFiles | Sort-Object LastWriteTimeUtc -Descending | Select-Object -First 1)
+    $latestLastWriteTimeUtc = if ($latestFile.Count -gt 0) { $latestFile[0].LastWriteTimeUtc.ToUniversalTime() } else { $null }
+    $ageSeconds = if ($null -ne $latestLastWriteTimeUtc) {
+        [math]::Max(0, [int][math]::Round(((Get-Date).ToUniversalTime() - $latestLastWriteTimeUtc).TotalSeconds, 0))
+    }
+    else {
+        $null
+    }
+
+    return [PSCustomObject]@{
+        Present = ($sourceFiles.Count -gt 0)
+        FileCount = [int]$sourceFiles.Count
+        LatestLastWriteTimeUtc = if ($null -ne $latestLastWriteTimeUtc) { $latestLastWriteTimeUtc.ToString('o') } else { $null }
+        AgeSeconds = $ageSeconds
+        Files = @($sourceFiles | ForEach-Object {
+                [PSCustomObject]@{
+                    Name = $_.Name
+                    Length = [long]$_.Length
+                    LastWriteTimeUtc = $_.LastWriteTimeUtc.ToUniversalTime().ToString('o')
+                }
+            })
+    }
+}
+
+function Get-DashboardSourceSummary {
+    [CmdletBinding()]
+    [OutputType([pscustomobject])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$BasePath,
+
+        [Parameter(Mandatory = $false)]
+        [int]$MachineCount = 0,
+
+        [Parameter(Mandatory = $false)]
+        [int]$AdvancedHuntingCveCount = 0,
+
+        [Parameter(Mandatory = $false)]
+        [int]$AdvancedHuntingDeviceUserCount = 0,
+
+        [Parameter(Mandatory = $false)]
+        [int]$AdvancedHuntingInventoryTupleCount = 0,
+
+        [Parameter(Mandatory = $false)]
+        [int]$NvdCveCount = 0,
+
+        [Parameter(Mandatory = $false)]
+        [string]$NormalizationMode = 'unknown',
+
+        [Parameter(Mandatory = $false)]
+        [switch]$SkipObservedWindowMerge
+    )
+
+    return [PSCustomObject]@{
+        Version = 'dashboard-source-metadata-v1'
+        GeneratedOnUtc = (Get-Date).ToUniversalTime().ToString('o')
+        NormalizationMode = $NormalizationMode
+        SkipObservedWindowMerge = ($SkipObservedWindowMerge -eq $true)
+        MachineData = [PSCustomObject]@{
+            RecordCount = [int]$MachineCount
+            Source = Get-DashboardSourceFileSummary -Files (Get-MachineFingerprintSourceFileSet -BasePath $BasePath)
+        }
+        AdvancedHunting = [PSCustomObject]@{
+            CveCount = [int]$AdvancedHuntingCveCount
+            DeviceUserCount = [int]$AdvancedHuntingDeviceUserCount
+            InventoryTupleCount = [int]$AdvancedHuntingInventoryTupleCount
+            Source = Get-DashboardSourceFileSummary -Files (Get-AdvancedHuntingFingerprintSourceFileSet -BasePath $BasePath)
+        }
+        NvdCve = [PSCustomObject]@{
+            RecordCount = [int]$NvdCveCount
+            Source = Get-DashboardSourceFileSummary -Files (Get-NvdCveFingerprintSourceFileSet -BasePath $BasePath)
+        }
+    }
+}
+
 function Get-VulnerabilityPayloadFingerprintSourceFileSet {
     [CmdletBinding()]
     [OutputType([System.IO.FileInfo[]])]
@@ -12717,11 +12817,53 @@ function ConvertTo-NormalizedPayloadManifestRecord {
     )
 
     $record = [ordered]@{}
-    foreach ($property in $Manifest.PSObject.Properties) {
-        $record[$property.Name] = $property.Value
+    if ($Manifest -is [System.Collections.IDictionary]) {
+        foreach ($key in $Manifest.Keys) {
+            $record[[string]$key] = $Manifest[$key]
+        }
+    }
+    else {
+        foreach ($property in $Manifest.PSObject.Properties) {
+            $record[$property.Name] = $property.Value
+        }
     }
 
     return $record
+}
+
+function Confirm-NormalizedPayloadManifestPayloadSha {
+    [CmdletBinding()]
+    [OutputType([hashtable])]
+    param(
+        [Parameter(Mandatory = $true)]
+        $Manifest,
+
+        [Parameter(Mandatory = $true)]
+        [string]$PayloadPath,
+
+        [Parameter(Mandatory = $false)]
+        [switch]$ThrowOnMismatch
+    )
+
+    $manifestRecord = ConvertTo-NormalizedPayloadManifestRecord -Manifest $Manifest
+    $actualPayloadSha256 = Get-FileSha256Hex -Path $PayloadPath
+    $manifestPayloadSha256 = if ($manifestRecord.Contains('PayloadSha256')) { [string]$manifestRecord.PayloadSha256 } else { '' }
+
+    if (
+        -not [string]::IsNullOrWhiteSpace($manifestPayloadSha256) -and
+        -not [System.StringComparer]::OrdinalIgnoreCase.Equals($manifestPayloadSha256, $actualPayloadSha256)
+    ) {
+        $message = "Normalized payload hash mismatch for '$PayloadPath'. Manifest has '$manifestPayloadSha256' but file is '$actualPayloadSha256'."
+        if ($ThrowOnMismatch) {
+            throw $message
+        }
+
+        Write-Warning $message
+        return $null
+    }
+
+    $manifestRecord.PayloadSha256 = $actualPayloadSha256
+    return $manifestRecord
 }
 
 function Export-NormalizedPayloadArtifacts {
@@ -12909,6 +13051,7 @@ function Write-DashboardValidationSidecar {
         DeviceCount = [int]$PayloadManifest.DeviceCount
         CveCount = [int]$PayloadManifest.CveCount
         Quality = $PayloadManifest.Quality
+        SourceMetadata = if ($PayloadManifest.PSObject.Properties['SourceMetadata']) { $PayloadManifest.SourceMetadata } else { $null }
         SkipObservedWindowMerge = [bool]($PayloadManifest.PSObject.Properties['SkipObservedWindowMerge'] -and $PayloadManifest.SkipObservedWindowMerge)
         DashboardPayloadSha256 = $DashboardPayloadSha256
         DashboardPayloadRowCount = $DashboardPayloadRowCount
@@ -13001,10 +13144,17 @@ function Get-NormalizedPayloadCacheEntry {
         return $null
     }
 
-    $manifest = Get-Content -LiteralPath $manifestPath -Raw | ConvertFrom-Json -Depth 20
+    $manifest = Read-NormalizedPayloadManifest -Path $manifestPath
     if ([string]$manifest.Fingerprint -ne $fingerprint) {
         return $null
     }
+
+    $manifestRecord = Confirm-NormalizedPayloadManifestPayloadSha -Manifest $manifest -PayloadPath $payloadPath
+    if ($null -eq $manifestRecord) {
+        return $null
+    }
+
+    $manifest = [PSCustomObject]$manifestRecord
 
     Clear-StaleNormalizedPayloadCache -BasePath $BasePath -KeepPaths @($payloadPath, $manifestPath)
     return [PSCustomObject]@{
@@ -13038,6 +13188,9 @@ function Publish-NormalizedPayloadCache {
         [object]$Quality,
 
         [Parameter(Mandatory = $false)]
+        [object]$SourceMetadata,
+
+        [Parameter(Mandatory = $false)]
         [switch]$SkipObservedWindowMerge
     )
 
@@ -13061,6 +13214,7 @@ function Publish-NormalizedPayloadCache {
         DeviceCount = $DeviceCount
         CveCount = $CveCount
         Quality = $Quality
+        SourceMetadata = $SourceMetadata
         SkipObservedWindowMerge = ($SkipObservedWindowMerge -eq $true)
         SemanticValidationAttestation = $null
     }
@@ -17386,6 +17540,15 @@ try {
         $advancedHuntingBundle = Read-AdvancedHuntingBundle -Path $tempExports -IncludeDeviceUsers
         $advancedHuntingData = [hashtable]$advancedHuntingBundle.AdvancedHuntingData
         $advancedHuntingDeviceUsers = [hashtable]$advancedHuntingBundle.DeviceUsers
+        $sourceMetadata = Get-DashboardSourceSummary `
+            -BasePath $tempExports `
+            -MachineCount $machines.Count `
+            -AdvancedHuntingCveCount $advancedHuntingData.Count `
+            -AdvancedHuntingDeviceUserCount $advancedHuntingDeviceUsers.Count `
+            -AdvancedHuntingInventoryTupleCount 0 `
+            -NvdCveCount 0 `
+            -NormalizationMode 'azure-runbook-normalization' `
+            -SkipObservedWindowMerge:$skipObservedWindowMerge
         $advancedHuntingBundle = $null
         Invoke-FullGarbageCollection
         Write-MemoryUsage -Label "Post-AdvancedHuntingBundle"
@@ -17433,7 +17596,7 @@ try {
         }
         Invoke-FullGarbageCollection
 
-        $cacheEntry = Publish-NormalizedPayloadCache -BasePath $tempExports -PayloadPath $tempPayloadPath -VulnCount $vulnCount -DeviceCount $deviceCount -CveCount $cveCount -Quality $normalizedQuality -SkipObservedWindowMerge:$skipObservedWindowMerge
+        $cacheEntry = Publish-NormalizedPayloadCache -BasePath $tempExports -PayloadPath $tempPayloadPath -VulnCount $vulnCount -DeviceCount $deviceCount -CveCount $cveCount -Quality $normalizedQuality -SourceMetadata $sourceMetadata -SkipObservedWindowMerge:$skipObservedWindowMerge
         if ($cacheEntry) {
             Write-Output ("  Cached normalized payload as {0}" -f $cacheEntry.Fingerprint.Substring(0, 12))
         }

--- a/build/azure/runbook-source.ps1
+++ b/build/azure/runbook-source.ps1
@@ -1304,6 +1304,15 @@ try {
         $advancedHuntingBundle = Read-AdvancedHuntingBundle -Path $tempExports -IncludeDeviceUsers
         $advancedHuntingData = [hashtable]$advancedHuntingBundle.AdvancedHuntingData
         $advancedHuntingDeviceUsers = [hashtable]$advancedHuntingBundle.DeviceUsers
+        $sourceMetadata = Get-DashboardSourceSummary `
+            -BasePath $tempExports `
+            -MachineCount $machines.Count `
+            -AdvancedHuntingCveCount $advancedHuntingData.Count `
+            -AdvancedHuntingDeviceUserCount $advancedHuntingDeviceUsers.Count `
+            -AdvancedHuntingInventoryTupleCount 0 `
+            -NvdCveCount 0 `
+            -NormalizationMode 'azure-runbook-normalization' `
+            -SkipObservedWindowMerge:$skipObservedWindowMerge
         $advancedHuntingBundle = $null
         Invoke-FullGarbageCollection
         Write-MemoryUsage -Label "Post-AdvancedHuntingBundle"
@@ -1351,7 +1360,7 @@ try {
         }
         Invoke-FullGarbageCollection
 
-        $cacheEntry = Publish-NormalizedPayloadCache -BasePath $tempExports -PayloadPath $tempPayloadPath -VulnCount $vulnCount -DeviceCount $deviceCount -CveCount $cveCount -Quality $normalizedQuality -SkipObservedWindowMerge:$skipObservedWindowMerge
+        $cacheEntry = Publish-NormalizedPayloadCache -BasePath $tempExports -PayloadPath $tempPayloadPath -VulnCount $vulnCount -DeviceCount $deviceCount -CveCount $cveCount -Quality $normalizedQuality -SourceMetadata $sourceMetadata -SkipObservedWindowMerge:$skipObservedWindowMerge
         if ($cacheEntry) {
             Write-Output ("  Cached normalized payload as {0}" -f $cacheEntry.Fingerprint.Substring(0, 12))
         }

--- a/docs/pipeline-architecture-review.md
+++ b/docs/pipeline-architecture-review.md
@@ -1,0 +1,90 @@
+# Pipeline Architecture Review
+
+This review covers the Defender reporting data path from API export through dashboard generation. It is based on the tracked source and maintainer docs, with generated outputs and local history treated as non-authoritative.
+
+## Pipeline Map
+
+1. API export
+   - [Invoke-VulnerabilityExport.ps1](../Invoke-VulnerabilityExport.ps1) authenticates to Defender for Endpoint, downloads bulk vulnerability snapshots, refreshes machine data, optionally refreshes Advanced Hunting enrichment, and writes canonical gzip stores under `exports/`.
+   - The shared export helpers live in [MdeExport.ps1](../src/powershell/Shared/DefenderApi/MdeExport.ps1), with store layout helpers in [Core.ps1](../src/powershell/Shared/Core/Core.ps1), [VulnerabilityStore.ps1](../src/powershell/Shared/Stores/VulnerabilityStore.ps1), [VulnerabilitySnapshotImport.ps1](../src/powershell/Shared/Stores/VulnerabilitySnapshotImport.ps1), and [MachineStore.ps1](../src/powershell/Shared/Stores/MachineStore.ps1).
+
+2. Normalization
+   - [Generate-VulnerabilityDashboard.ps1](../Generate-VulnerabilityDashboard.ps1) reads canonical stores, optionally refreshes machine data, loads Advanced Hunting and NVD enrichment, and calls `ConvertTo-NormalizedData` from [DashboardGeneration.ps1](../src/powershell/Shared/Dashboard/DashboardGeneration.ps1).
+   - Normalization can run from content-store sidecars or raw current/history rows. It can also reuse normalized column caches and normalized payload caches under `.dashboard-cache/`.
+
+3. Payload preparation
+   - The generator writes a compressed payload with lookup tables plus vulnerability rows or columns. `-NormalizeOnly` can materialize this payload and its manifest; `-PackageOnly` can package a previously materialized payload.
+   - Cache identity comes from `Get-DashboardPayloadCacheFingerprint`, which depends on vulnerability, machine, Advanced Hunting, NVD, and normalization-mode inputs.
+
+4. Dashboard packaging
+   - `Write-DashboardArtifactBundle` combines templates, payload, pako, Chart.js, and the PDF export bundle into either a self-contained HTML file or a hosted split-assets directory.
+   - `-DualPackage` writes both delivery modes from the same normalized payload.
+
+5. Validation and delivery
+   - `Invoke-DashboardValidation` and the audit helpers validate payload/source parity, enrichment, report semantics, and legacy fixture behavior.
+   - Azure Automation and Function App entrypoints are built from [runbook-source.ps1](../build/azure/runbook-source.ps1) plus the manifest-driven helper bundle.
+
+## Findings
+
+### Addressed on This Branch
+
+1. Cache fingerprints include file timestamps after computing content hashes.
+   - `Get-FileSetFingerprint` already computes SHA-256 for every source file, but it also includes `LastWriteTimeUtc.Ticks` in the fingerprint material.
+   - Result: identical export content with a different timestamp misses the normalized payload, observed-window, and related caches. This is inefficient and especially expensive for large datasets because cache lookup already paid the cost of content hashing.
+   - Branch result: file-set fingerprints are now content-addressed by file identity, length, and SHA-256. A regression proves timestamp-only changes do not invalidate cache identity while content changes still do.
+
+2. Normalized payload cache entries are trusted without verifying the cached payload bytes against the manifest hash.
+   - `Get-NormalizedPayloadCacheEntry` checks the cache fingerprint and manifest fingerprint, but it does not verify that `PayloadSha256` still matches the payload file.
+   - Result: a partial or corrupted cached payload can be reused until a later phase happens to detect it.
+   - Branch result: cached payload bytes are validated against manifest `PayloadSha256` before returning a cache hit. Normal generation treats mismatches as cache misses and rechecks after copy; `-PackageOnly` fails fast when a provided manifest hash does not match the provided payload.
+
+3. JavaScript library cache reuse accepts zero-byte files.
+   - `Save-JSLibraryFile` reuses any cached library path that exists.
+   - Result: a failed or interrupted previous download can poison later self-contained and hosted dashboard packages.
+   - Branch result: empty cached library files are rejected and refreshed, and new downloads are verified as non-empty before caching or packaging.
+
+4. Operator-visible data freshness and enrichment metadata is thin.
+   - Machine export failures during dashboard generation are warning-only and reuse existing machine data. Advanced Hunting enrichment is optional and may be intentionally absent.
+   - Result: operators need better metadata to distinguish intentional offline generation from degraded freshness or enrichment.
+   - Branch result: payload manifests, validation sidecars, and audit outputs now carry source summaries for machine data, Advanced Hunting, NVD, normalization mode, and source file freshness. Strict freshness/enrichment policy remains a compatibility-preserving follow-up.
+
+### Deferred Follow-Ups
+
+1. Add a strict freshness mode for machine data.
+   - Candidate: `-RequireFreshMachineData` or `-AllowStaleMachineData` with a configurable maximum age and validation-sidecar metadata.
+
+2. Add explicit Advanced Hunting expectation controls.
+   - Candidate: `-RequireAdvancedHunting` plus policy around the source count metadata now emitted in manifests, sidecars, and audits.
+
+3. Expand JavaScript fixture coverage for `columns-v1` payloads.
+   - Validation helper coverage already canonicalizes rows and columns, but the browser-side assertion scripts should exercise column payloads too.
+
+4. Add machine-history continuity diagnostics.
+   - Candidate: warn when quarterly history files have unexpected gaps, overlaps, or out-of-order observed dates.
+
+## Implementation Plan
+
+1. Harden cache identity and cache hit validation.
+   - Remove timestamp material from `Get-FileSetFingerprint`.
+   - Add normalized payload manifest hash confirmation and use it in cache lookup plus package-only manifest handling.
+
+2. Harden dashboard library caching.
+   - Refresh empty cached library files.
+   - Treat empty fresh downloads as failed downloads before cache publish.
+
+3. Add focused regression coverage.
+   - Fingerprint stability for timestamp-only changes.
+   - Normalized payload cache miss on payload/manifest hash mismatch.
+   - Library cache refresh when an empty cached file exists.
+
+4. Rebuild generated helper artifacts.
+   - Run the shared helper build because [DashboardGeneration.ps1](../src/powershell/Shared/Dashboard/DashboardGeneration.ps1) changes feed [shared-helpers.ps1](../build/generated/shared-helpers.ps1), Azure runbook, and Function App artifacts.
+
+5. Validate.
+   - Run the focused shared-helper regression test first.
+   - Run the deterministic preflight before final review.
+
+## Review Notes
+
+- The export phase already uses staged partial vulnerability downloads and transactional machine store publishing, so this branch does not replace those mechanisms.
+- The validation attestation fast path is intentionally payload-oriented. Dashboard runtime behavior remains covered by the Node dashboard assertion suite and browser inspection gates rather than by semantic payload replay.

--- a/docs/test-coverage-validation-review.md
+++ b/docs/test-coverage-validation-review.md
@@ -1,0 +1,197 @@
+# Test Coverage and Validation Review
+
+This review focuses on the export, normalization, payload preparation, packaging, validation, Azure runtime, and performance validation surfaces. It intentionally leaves dashboard template, layout, and visual HTML review to a separate process.
+
+## Executive Summary
+
+The project already has a solid validation spine: a deterministic preflight, helper regression tests, generated artifact rebuild checks, dashboard JavaScript assertions, fixture smoke generation, live dry-run tooling, large synthetic validation lanes, benchmark harnesses, and Azure deployment validation scripts.
+
+The biggest cache-integrity issue found during the pipeline review has been addressed on this branch: normalized payload cache hits now validate payload bytes against the manifest hash, package-only payloads fail fast on mismatch, normal cached reuse falls back to live normalization if a cache entry changes after lookup, and zero-byte JavaScript library cache files are refreshed instead of reused.
+
+The main remaining risks are process and breadth gaps rather than a missing core validator:
+
+1. Heavy live, large-dataset, and Azure acceptance gates are manual by design, with PR checklist attestation added on this branch.
+2. Operator-facing freshness and enrichment metadata now exists in payload manifests, validation sidecars, and audits, but strict policy controls are still deferred.
+3. Browser-level runtime smoke coverage for hosted output is available as an optional local Edge smoke, outside the default CI preflight.
+4. Negative validation fixtures cover the highest-risk payload/package failures, with more attestation and baseline cases still available for future expansion.
+
+## Current Coverage
+
+### Deterministic Preflight
+
+Entrypoint: `build/Invoke-RegressionValidation.ps1`
+
+Covered today:
+
+- Build manifest coverage for generated shared and validation helpers.
+- Shared helper generation.
+- Validation helper generation.
+- Azure Automation runbook generation.
+- Azure Function App entrypoint generation.
+- PowerShell parser validation across source scripts and generated Azure runtime scripts.
+- PSScriptAnalyzer warnings and errors across non-generated scripts.
+- `tests/Run-SharedHelperRegression.ps1` focused helper and pipeline regression checks.
+- `tests/Assert-Dashboard*.js` dashboard runtime logic assertions in the Node harness.
+- Legacy migration fixture dashboard generation in both self-contained and hosted modes.
+- Generated dashboard artifact structure checks through `tests/Validate-DashboardGeneratedArtifacts.js`.
+
+Recent branch improvement:
+
+- `.github/workflows/validate-dashboard.yml` now triggers this gate for changes under `tests/**`, `build/manifests/**`, `src/**`, and `azure/**`, in addition to the existing PowerShell, template, export, dashboard, and workflow paths. These inputs were already part of the gate's real dependency surface, but not all of them previously triggered the PR workflow.
+- `tests/Run-SharedHelperRegression.ps1` now includes negative checks for hosted output with a missing payload asset and package-only payload/manifest mismatch.
+- Payload manifests, validation sidecars, and audit outputs now carry source metadata for machine data, Advanced Hunting, NVD, normalization mode, and source file freshness.
+
+### Live Export Dry Run
+
+Entrypoint: `build/Invoke-LiveDashboardDryRun.ps1`
+
+Covered today:
+
+- Azure authentication path used by the scheduled update workflow.
+- Defender API export path.
+- Dashboard generation and validation from live exports.
+- `dashboard-audit.json`, `dashboard-live-run-manifest.json`, and generated dashboard artifact capture.
+
+Recommended use:
+
+- Run before merging changes that affect live API export, authentication, scheduled workflow behavior, generated dashboard delivery, or shipped dashboard artifacts.
+
+### Large Dataset and Import Lanes
+
+Entrypoints:
+
+- `tests/Invoke-LargeDatasetValidation.ps1`
+- `tests/Invoke-LargeImportCoverage.ps1`
+- `tests/New-BenchmarkDataset.ps1`
+- `tests/New-SyntheticSnapshotDelta.ps1`
+
+Covered today:
+
+- Large synthetic generation.
+- Raw sidecar-free replay.
+- Artifact validation mode for faster iteration.
+- Full semantic validation mode for final local sign-off.
+- Legacy vulnerability snapshot replay preparation.
+- Durable benchmark dataset registration.
+
+Recommended use:
+
+- For normalization, cache, payload, or validation changes, run the artifact gate during iteration and semantic validation before sign-off.
+- For import-path changes, include a raw sidecar-free replay and legacy snapshot replay lane.
+- For perf-sensitive changes, capture a benchmark series against `benchmark-medium-v1` before escalating to Azure acceptance.
+
+### Azure Runtime Validation
+
+Entrypoints:
+
+- `build/Invoke-AzureDeploymentValidation.ps1`
+- `tests/Measure-RunbookOnlyAzureBenchmark.ps1`
+- `tests/Measure-BranchVsMainBenchmark.ps1`
+
+Covered today:
+
+- Azure deployment package rebuild.
+- Automation runbook deployment and execution.
+- Function App deployment and seeded execution.
+- Runtime status blob diagnostics for Function App execution.
+- Azure benchmark capture for elapsed time, memory, and Function execution-unit review.
+
+Recommended use:
+
+- Run before merging Azure packaging, Automation, Function App, release packaging, or perf-sensitive large-dataset changes.
+- Prefer seeded deterministic exports when validating runtime behavior without depending on fresh API data.
+
+## Gaps Worth Tackling
+
+### 1. Freshness and Enrichment Metadata
+
+Current state:
+
+- Machine export failures during dashboard generation can still be warning-only.
+- Advanced Hunting and NVD enrichment can still be intentionally absent.
+- Payload manifests, validation sidecars, and audit outputs now expose source file freshness, record counts, and normalization mode.
+
+Remaining recommendation:
+
+- Add optional strict controls, such as `-RequireFreshMachineData` and `-RequireAdvancedHunting`, without changing default compatibility behavior.
+- Add dashboard-facing operator summaries only after the separate template/HTML review decides how that information should be displayed.
+
+### 2. Browser Runtime Smoke for Hosted Output
+
+Current state:
+
+- Node assertions and generated artifact checks catch many runtime and packaging regressions.
+- Hosted split-assets output is structurally validated in the deterministic gate.
+- `tests/Invoke-HostedDashboardRuntimeSmoke.ps1` can serve hosted output over HTTP and run a non-visual Microsoft Edge headless DOM smoke locally.
+
+Remaining recommendation:
+
+- Keep the smoke outside the default Ubuntu CI preflight unless a stable cross-platform browser dependency is introduced.
+- Consider expanding the smoke to inspect report switching and console logs if a future Playwright dependency is accepted.
+
+### 3. Negative Validation Fixtures
+
+Current state:
+
+- The regression suite covers important negative cases such as payload/manifest hash mismatch and empty library cache reuse.
+- Fixture smoke generation validates a small legacy dataset, including hosted and self-contained packaging.
+- The regression suite now validates missing hosted payload failure and package-only manifest mismatch failure.
+
+Remaining recommendation:
+
+- Add small, intentionally corrupted fixtures for validation-only behavior:
+  - embedded payload SHA mismatch;
+  - validation sidecar payload SHA mismatch;
+  - stale attestation that should force full validation;
+  - baseline audit row mismatch.
+- These should be tiny and deterministic so they can run inside preflight without large-data cost.
+
+### 4. Manual Gate Attestation
+
+Current state:
+
+- The docs clearly describe when to run large-dataset, live dry-run, and Azure validation gates.
+- CI cannot cheaply run all heavy lanes on every PR.
+- `.github/PULL_REQUEST_TEMPLATE.md` now records deterministic, live, large-dataset, Azure, and hosted-smoke gate decisions.
+
+Remaining recommendation:
+
+- Consider a future optional workflow that compares uploaded benchmark JSON against thresholds, without running the benchmark itself in CI.
+
+### 5. Large Semantic Validation Cost
+
+Current state:
+
+- The full `synthetic-50k-1_5m` semantic sign-off provides high confidence, but it can take several hours on a local workstation.
+- The current hot spots are signature generation for the source dataset and normalized payload, not the final partition comparison.
+- The semantic lane now caches source and payload signature sets during a run, but routine branch validation still pays the full cost when those artifacts are not already available.
+
+Remaining recommendation:
+
+- Add a cheaper routine semantic-review lane that uses a deterministic medium or stratified dataset, then reserve the 50k/1.5m full semantic gate for release sign-off and high-risk normalization changes.
+- Investigate durable signature cache artifacts keyed by source fingerprint, normalized payload `PayloadSha256`, semantic canonicalizer version, and validation helper version so repeat validations can reuse unchanged signatures safely.
+- Evaluate whether source and payload signature partitioning can be parallelized without increasing memory pressure or destabilizing Azure Automation/Function App parity.
+- Record phase timings from several local and Azure runs before setting thresholds, because the observed cost is dominated by host performance and dataset size.
+
+## Recommended Review Exercises
+
+Use these as a menu based on the changed surface.
+
+| Changed surface | Minimum review | Expanded review |
+| --- | --- | --- |
+| Shared PowerShell helpers | `build/Invoke-RegressionValidation.ps1` | Focused helper tests plus large artifact gate if normalization, payload, cache, or validation behavior changed |
+| Validation helpers | `build/Invoke-RegressionValidation.ps1` | `tests/Invoke-ValidationModeComparison.ps1` and large semantic validation |
+| API export logic | `build/Invoke-RegressionValidation.ps1` | `build/Invoke-LiveDashboardDryRun.ps1 -UseExistingAzContext` and Azure fresh-export run |
+| Normalization or payload shaping | `build/Invoke-RegressionValidation.ps1` | Large artifacts gate, large semantic sign-off, and benchmark series |
+| Package-only or split-assets behavior | `build/Invoke-RegressionValidation.ps1` | Materialize with `-NormalizeOnly`, package with `-PackageOnly -DualPackage`, validate self-contained and hosted outputs |
+| Azure runbook or Function App runtime | `build/Invoke-RegressionValidation.ps1` | `build/Invoke-AzureDeploymentValidation.ps1` with seeded Function App execution |
+| Performance-sensitive changes | deterministic preflight | hot phase review, validation mode comparison, benchmark series, and Azure acceptance |
+
+## Recommended Priority
+
+1. Keep the workflow trigger broadening from this branch.
+2. Keep the manifest, sidecar, and audit source metadata from this branch, then add strict freshness/enrichment controls in a separate behavior-focused change.
+3. Keep the new negative hosted-payload and package-only mismatch checks, then add stale-attestation and baseline mismatch fixtures separately.
+4. Keep the non-visual hosted browser runtime smoke as a local/manual gate until a cross-platform browser dependency is accepted.
+5. Add a cheaper routine semantic-review lane and investigate durable signature cache reuse before making the 50k/1.5m semantic gate part of frequent validation.
+6. Keep the PR checklist for manual heavy gates and revisit benchmark artifact threshold automation after several recorded runs establish normal variance.

--- a/src/powershell/Shared/Dashboard/DashboardGeneration.ps1
+++ b/src/powershell/Shared/Dashboard/DashboardGeneration.ps1
@@ -96,9 +96,16 @@ function Save-JSLibraryFile {
         $safeName = ($Name -replace '[^A-Za-z0-9._-]', '-')
         $cachePath = Join-Path $cacheDirectory ("{0}-{1}{2}" -f $safeName, $urlHash, $extension)
         if (Test-Path -LiteralPath $cachePath -PathType Leaf) {
-            Copy-Item -LiteralPath $cachePath -Destination $OutputPath -Force
-            Write-Information "Reusing cached $Name library" -InformationAction Continue
-            return $OutputPath
+            $cachedLibrary = Get-Item -LiteralPath $cachePath
+            if ($cachedLibrary.Length -le 0) {
+                Write-Warning "Cached $Name library was empty; refreshing."
+                Remove-Item -LiteralPath $cachePath -Force -ErrorAction SilentlyContinue
+            }
+            else {
+                Copy-Item -LiteralPath $cachePath -Destination $OutputPath -Force
+                Write-Information "Reusing cached $Name library" -InformationAction Continue
+                return $OutputPath
+            }
         }
     }
 
@@ -106,6 +113,11 @@ function Save-JSLibraryFile {
 
     try {
         Invoke-WebRequest -Uri $Url -OutFile $OutputPath -TimeoutSec 30
+        $downloadedLibrary = Get-Item -LiteralPath $OutputPath -ErrorAction Stop
+        if ($downloadedLibrary.Length -le 0) {
+            throw "$Name library download produced an empty file."
+        }
+
         if ($cachePath) {
             Copy-Item -LiteralPath $OutputPath -Destination $cachePath -Force
         }
@@ -113,6 +125,10 @@ function Save-JSLibraryFile {
         return $OutputPath
     }
     catch {
+        if (Test-Path -LiteralPath $OutputPath -PathType Leaf) {
+            Remove-Item -LiteralPath $OutputPath -Force -ErrorAction SilentlyContinue
+        }
+
         $errorMessage = "Failed to download $Name from $Url`: $_"
         if ($Critical) {
             Write-Error $errorMessage
@@ -2307,7 +2323,6 @@ function Get-FileSetFingerprint {
         $fileIdentity = if ($FileIdentityProperty -eq 'Name') { $file.Name } else { $file.FullName }
         [void]$builder.Append($fileIdentity).Append('|')
         [void]$builder.Append($file.Length).Append('|')
-        [void]$builder.Append($file.LastWriteTimeUtc.Ticks).Append('|')
         [void]$builder.AppendLine($hash)
     }
 
@@ -2781,6 +2796,91 @@ function Get-NvdCveFingerprintSourceFileSet {
     return [System.IO.FileInfo[]]@((Get-Item -LiteralPath $currentPath))
 }
 
+function Get-DashboardSourceFileSummary {
+    [CmdletBinding()]
+    [OutputType([pscustomobject])]
+    param(
+        [Parameter(Mandatory = $false)]
+        [AllowNull()]
+        [System.IO.FileInfo[]]$Files
+    )
+
+    $sourceFiles = @($Files | Where-Object { $null -ne $_ } | Sort-Object FullName)
+    $latestFile = @($sourceFiles | Sort-Object LastWriteTimeUtc -Descending | Select-Object -First 1)
+    $latestLastWriteTimeUtc = if ($latestFile.Count -gt 0) { $latestFile[0].LastWriteTimeUtc.ToUniversalTime() } else { $null }
+    $ageSeconds = if ($null -ne $latestLastWriteTimeUtc) {
+        [math]::Max(0, [int][math]::Round(((Get-Date).ToUniversalTime() - $latestLastWriteTimeUtc).TotalSeconds, 0))
+    }
+    else {
+        $null
+    }
+
+    return [PSCustomObject]@{
+        Present = ($sourceFiles.Count -gt 0)
+        FileCount = [int]$sourceFiles.Count
+        LatestLastWriteTimeUtc = if ($null -ne $latestLastWriteTimeUtc) { $latestLastWriteTimeUtc.ToString('o') } else { $null }
+        AgeSeconds = $ageSeconds
+        Files = @($sourceFiles | ForEach-Object {
+                [PSCustomObject]@{
+                    Name = $_.Name
+                    Length = [long]$_.Length
+                    LastWriteTimeUtc = $_.LastWriteTimeUtc.ToUniversalTime().ToString('o')
+                }
+            })
+    }
+}
+
+function Get-DashboardSourceSummary {
+    [CmdletBinding()]
+    [OutputType([pscustomobject])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$BasePath,
+
+        [Parameter(Mandatory = $false)]
+        [int]$MachineCount = 0,
+
+        [Parameter(Mandatory = $false)]
+        [int]$AdvancedHuntingCveCount = 0,
+
+        [Parameter(Mandatory = $false)]
+        [int]$AdvancedHuntingDeviceUserCount = 0,
+
+        [Parameter(Mandatory = $false)]
+        [int]$AdvancedHuntingInventoryTupleCount = 0,
+
+        [Parameter(Mandatory = $false)]
+        [int]$NvdCveCount = 0,
+
+        [Parameter(Mandatory = $false)]
+        [string]$NormalizationMode = 'unknown',
+
+        [Parameter(Mandatory = $false)]
+        [switch]$SkipObservedWindowMerge
+    )
+
+    return [PSCustomObject]@{
+        Version = 'dashboard-source-metadata-v1'
+        GeneratedOnUtc = (Get-Date).ToUniversalTime().ToString('o')
+        NormalizationMode = $NormalizationMode
+        SkipObservedWindowMerge = ($SkipObservedWindowMerge -eq $true)
+        MachineData = [PSCustomObject]@{
+            RecordCount = [int]$MachineCount
+            Source = Get-DashboardSourceFileSummary -Files (Get-MachineFingerprintSourceFileSet -BasePath $BasePath)
+        }
+        AdvancedHunting = [PSCustomObject]@{
+            CveCount = [int]$AdvancedHuntingCveCount
+            DeviceUserCount = [int]$AdvancedHuntingDeviceUserCount
+            InventoryTupleCount = [int]$AdvancedHuntingInventoryTupleCount
+            Source = Get-DashboardSourceFileSummary -Files (Get-AdvancedHuntingFingerprintSourceFileSet -BasePath $BasePath)
+        }
+        NvdCve = [PSCustomObject]@{
+            RecordCount = [int]$NvdCveCount
+            Source = Get-DashboardSourceFileSummary -Files (Get-NvdCveFingerprintSourceFileSet -BasePath $BasePath)
+        }
+    }
+}
+
 function Get-VulnerabilityPayloadFingerprintSourceFileSet {
     [CmdletBinding()]
     [OutputType([System.IO.FileInfo[]])]
@@ -3239,11 +3339,53 @@ function ConvertTo-NormalizedPayloadManifestRecord {
     )
 
     $record = [ordered]@{}
-    foreach ($property in $Manifest.PSObject.Properties) {
-        $record[$property.Name] = $property.Value
+    if ($Manifest -is [System.Collections.IDictionary]) {
+        foreach ($key in $Manifest.Keys) {
+            $record[[string]$key] = $Manifest[$key]
+        }
+    }
+    else {
+        foreach ($property in $Manifest.PSObject.Properties) {
+            $record[$property.Name] = $property.Value
+        }
     }
 
     return $record
+}
+
+function Confirm-NormalizedPayloadManifestPayloadSha {
+    [CmdletBinding()]
+    [OutputType([hashtable])]
+    param(
+        [Parameter(Mandatory = $true)]
+        $Manifest,
+
+        [Parameter(Mandatory = $true)]
+        [string]$PayloadPath,
+
+        [Parameter(Mandatory = $false)]
+        [switch]$ThrowOnMismatch
+    )
+
+    $manifestRecord = ConvertTo-NormalizedPayloadManifestRecord -Manifest $Manifest
+    $actualPayloadSha256 = Get-FileSha256Hex -Path $PayloadPath
+    $manifestPayloadSha256 = if ($manifestRecord.Contains('PayloadSha256')) { [string]$manifestRecord.PayloadSha256 } else { '' }
+
+    if (
+        -not [string]::IsNullOrWhiteSpace($manifestPayloadSha256) -and
+        -not [System.StringComparer]::OrdinalIgnoreCase.Equals($manifestPayloadSha256, $actualPayloadSha256)
+    ) {
+        $message = "Normalized payload hash mismatch for '$PayloadPath'. Manifest has '$manifestPayloadSha256' but file is '$actualPayloadSha256'."
+        if ($ThrowOnMismatch) {
+            throw $message
+        }
+
+        Write-Warning $message
+        return $null
+    }
+
+    $manifestRecord.PayloadSha256 = $actualPayloadSha256
+    return $manifestRecord
 }
 
 function Export-NormalizedPayloadArtifacts {
@@ -3431,6 +3573,7 @@ function Write-DashboardValidationSidecar {
         DeviceCount = [int]$PayloadManifest.DeviceCount
         CveCount = [int]$PayloadManifest.CveCount
         Quality = $PayloadManifest.Quality
+        SourceMetadata = if ($PayloadManifest.PSObject.Properties['SourceMetadata']) { $PayloadManifest.SourceMetadata } else { $null }
         SkipObservedWindowMerge = [bool]($PayloadManifest.PSObject.Properties['SkipObservedWindowMerge'] -and $PayloadManifest.SkipObservedWindowMerge)
         DashboardPayloadSha256 = $DashboardPayloadSha256
         DashboardPayloadRowCount = $DashboardPayloadRowCount
@@ -3523,10 +3666,17 @@ function Get-NormalizedPayloadCacheEntry {
         return $null
     }
 
-    $manifest = Get-Content -LiteralPath $manifestPath -Raw | ConvertFrom-Json -Depth 20
+    $manifest = Read-NormalizedPayloadManifest -Path $manifestPath
     if ([string]$manifest.Fingerprint -ne $fingerprint) {
         return $null
     }
+
+    $manifestRecord = Confirm-NormalizedPayloadManifestPayloadSha -Manifest $manifest -PayloadPath $payloadPath
+    if ($null -eq $manifestRecord) {
+        return $null
+    }
+
+    $manifest = [PSCustomObject]$manifestRecord
 
     Clear-StaleNormalizedPayloadCache -BasePath $BasePath -KeepPaths @($payloadPath, $manifestPath)
     return [PSCustomObject]@{
@@ -3560,6 +3710,9 @@ function Publish-NormalizedPayloadCache {
         [object]$Quality,
 
         [Parameter(Mandatory = $false)]
+        [object]$SourceMetadata,
+
+        [Parameter(Mandatory = $false)]
         [switch]$SkipObservedWindowMerge
     )
 
@@ -3583,6 +3736,7 @@ function Publish-NormalizedPayloadCache {
         DeviceCount = $DeviceCount
         CveCount = $CveCount
         Quality = $Quality
+        SourceMetadata = $SourceMetadata
         SkipObservedWindowMerge = ($SkipObservedWindowMerge -eq $true)
         SemanticValidationAttestation = $null
     }

--- a/src/powershell/Validation/Audit/DashboardAudit.ps1
+++ b/src/powershell/Validation/Audit/DashboardAudit.ps1
@@ -1955,11 +1955,20 @@ function Get-DashboardAuditResult {
                 $machines = Read-NormalizationMachineLookup -Path $ResolvedExportsPath
                 $advancedHunting = Read-AdvancedHuntingData -Path $ResolvedExportsPath
                 $advancedHuntingDeviceUsers = Read-AdvancedHuntingDeviceUserMap -Path $ResolvedExportsPath
+                $sourceMetadata = Get-DashboardSourceSummary `
+                    -BasePath $ResolvedExportsPath `
+                    -MachineCount $machines.Count `
+                    -AdvancedHuntingCveCount $advancedHunting.Count `
+                    -AdvancedHuntingDeviceUserCount $advancedHuntingDeviceUsers.Count `
+                    -AdvancedHuntingInventoryTupleCount 0 `
+                    -NvdCveCount 0 `
+                    -NormalizationMode 'validation-cache-bootstrap' `
+                    -SkipObservedWindowMerge:$skipObservedWindowMerge
                 $tempPayloadPath = Join-Path ([System.IO.Path]::GetTempPath()) ('dashboard-validation-payload-' + [System.Guid]::NewGuid().ToString('N') + '.json.gz')
                 $tempVulnsPath = Join-Path ([System.IO.Path]::GetTempPath()) ('dashboard-validation-vulns-' + [System.Guid]::NewGuid().ToString('N') + '.json')
                 try {
                     $normalizedResult = ConvertTo-NormalizedData -DataPath $ResolvedExportsPath -VulnOutputPath $tempVulnsPath -PayloadOutputPath $tempPayloadPath -Machines $machines -AdvancedHuntingData $advancedHunting -AdvancedHuntingDeviceUsers $advancedHuntingDeviceUsers -SkipObservedWindowMerge:$skipObservedWindowMerge -ConsumeLookupsOnPayloadClose
-                    $payloadCacheEntry = Publish-NormalizedPayloadCache -BasePath $ResolvedExportsPath -PayloadPath $normalizedResult.PayloadPath -VulnCount $normalizedResult.VulnCount -DeviceCount ([int]$normalizedResult.DeviceCount) -CveCount ([int]$normalizedResult.CveCount) -Quality $normalizedResult.Quality -SkipObservedWindowMerge:$skipObservedWindowMerge
+                    $payloadCacheEntry = Publish-NormalizedPayloadCache -BasePath $ResolvedExportsPath -PayloadPath $normalizedResult.PayloadPath -VulnCount $normalizedResult.VulnCount -DeviceCount ([int]$normalizedResult.DeviceCount) -CveCount ([int]$normalizedResult.CveCount) -Quality $normalizedResult.Quality -SourceMetadata $sourceMetadata -SkipObservedWindowMerge:$skipObservedWindowMerge
                 }
                 finally {
                     if (Test-Path -LiteralPath $tempPayloadPath -PathType Leaf) {
@@ -2055,6 +2064,15 @@ function Get-DashboardAuditResult {
     $baselineAuditElapsedSeconds = $null
     $baselineCoverageElapsedSeconds = $null
     $legacyFixtureRegressionElapsedSeconds = $null
+    $auditSourceMetadata = Get-DashboardSourceSummary `
+        -BasePath $ResolvedExportsPath `
+        -MachineCount $machines.Count `
+        -AdvancedHuntingCveCount $advancedHunting.Count `
+        -AdvancedHuntingDeviceUserCount 0 `
+        -AdvancedHuntingInventoryTupleCount $advancedHuntingInventory.Count `
+        -NvdCveCount $nvdCveData.Count `
+        -NormalizationMode 'full-dashboard-audit' `
+        -SkipObservedWindowMerge:$skipObservedWindowMerge
 
     $result = [PSCustomObject]@{
         GeneratedOn = (Get-Date).ToString('o')
@@ -2068,6 +2086,7 @@ function Get-DashboardAuditResult {
             UniqueVendors = @($sourceResult.VendorSet | Sort-Object)
             InputMode = [string]$sourceResult.InputMode
         }
+        SourceMetadata = $auditSourceMetadata
         Dashboard = [PSCustomObject]@{
             RowCount = $dashboardRows.Count
             Quality = $qualityMeta

--- a/src/powershell/Validation/Audit/LargeDatasetAudit.ps1
+++ b/src/powershell/Validation/Audit/LargeDatasetAudit.ps1
@@ -1772,6 +1772,7 @@ function New-AttestedStreamingDashboardAuditResult {
             Verification = 'Semantic parity was satisfied by a versioned validation attestation.'
             InputMode = if (Sync-VulnContentStoreSidecar -BasePath $ResolvedExportsPath) { 'content-store' } else { 'normalized-vuln-store' }
         }
+        SourceMetadata = if ($PayloadCacheEntry.Manifest.PSObject.Properties['SourceMetadata']) { $PayloadCacheEntry.Manifest.SourceMetadata } else { $null }
         Dashboard = [PSCustomObject]@{
             RowCount = $DashboardPayloadRowCount
             Quality = $PayloadCacheEntry.Manifest.Quality
@@ -2116,6 +2117,7 @@ function Get-StreamingDashboardAuditResult {
             Verification = 'Semantic parity was streamed directly from the current exports.'
             InputMode = if (Sync-VulnContentStoreSidecar -BasePath $ResolvedExportsPath) { 'content-store' } else { 'normalized-vuln-store' }
         }
+        SourceMetadata = if ($PayloadCacheEntry.Manifest.PSObject.Properties['SourceMetadata']) { $PayloadCacheEntry.Manifest.SourceMetadata } else { $null }
         Dashboard = [PSCustomObject]@{
             RowCount = $dashboardPayloadRowCount
             Quality = $PayloadCacheEntry.Manifest.Quality

--- a/tests/Invoke-HostedDashboardRuntimeSmoke.ps1
+++ b/tests/Invoke-HostedDashboardRuntimeSmoke.ps1
@@ -1,0 +1,452 @@
+#Requires -Version 7.0
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [ValidateScript({
+        if (-not (Test-Path -LiteralPath $_ -PathType Leaf)) {
+            throw "Dashboard HTML path '$_' does not exist."
+        }
+        return $true
+    })]
+    [string]$DashboardPath,
+
+    [Parameter(Mandatory = $false)]
+    [string]$EdgePath,
+
+    [Parameter(Mandatory = $false)]
+    [int]$Port = 0,
+
+    [Parameter(Mandatory = $false)]
+    [ValidateRange(5, 300)]
+    [int]$TimeoutSeconds = 45,
+
+    [Parameter(Mandatory = $false)]
+    [switch]$AllowSkip
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Get-FreeTcpPort {
+    [CmdletBinding()]
+    [OutputType([int])]
+    param()
+
+    $listener = [System.Net.Sockets.TcpListener]::new([System.Net.IPAddress]::Loopback, 0)
+    try {
+        $listener.Start()
+        return [int]$listener.LocalEndpoint.Port
+    }
+    finally {
+        $listener.Stop()
+    }
+}
+
+function Resolve-EdgeExecutablePath {
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory = $false)]
+        [string]$RequestedPath
+    )
+
+    if (-not [string]::IsNullOrWhiteSpace($RequestedPath)) {
+        if (Test-Path -LiteralPath $RequestedPath -PathType Leaf) {
+            return [System.IO.Path]::GetFullPath($RequestedPath)
+        }
+
+        throw "Microsoft Edge executable was not found at '$RequestedPath'."
+    }
+
+    $candidateRoots = @(
+        ${env:ProgramFiles(x86)}
+        $env:ProgramFiles
+        $env:LocalAppData
+    ) | Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
+
+    $candidates = @($candidateRoots | ForEach-Object { Join-Path $_ 'Microsoft\Edge\Application\msedge.exe' })
+
+    foreach ($candidate in $candidates) {
+        if (Test-Path -LiteralPath $candidate -PathType Leaf) {
+            return [System.IO.Path]::GetFullPath($candidate)
+        }
+    }
+
+    $command = Get-Command -Name 'msedge.exe' -ErrorAction SilentlyContinue
+    if ($command -and (Test-Path -LiteralPath $command.Source -PathType Leaf)) {
+        return [System.IO.Path]::GetFullPath($command.Source)
+    }
+
+    return $null
+}
+
+function Start-StaticHttpServer {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '', Justification = 'Starts a temporary local HTTP listener used only for a smoke test.')]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseUsingScopeModifierInNewRunspaces', '', Justification = 'ThreadJob arguments are passed through param() inside the script block.')]
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$RootPath,
+
+        [Parameter(Mandatory = $true)]
+        [string]$IndexFileName,
+
+        [Parameter(Mandatory = $true)]
+        [int]$ListenPort
+    )
+
+    return Start-ThreadJob -Name 'HostedDashboardSmokeHttpServer' -ArgumentList $RootPath, $IndexFileName, $ListenPort -ScriptBlock {
+        param($ServerRootPath, $ServerIndexFileName, $ServerPort)
+
+        $ErrorActionPreference = 'Stop'
+        $listener = [System.Net.HttpListener]::new()
+        $listener.Prefixes.Add("http://127.0.0.1:$ServerPort/")
+        $listener.Start()
+
+        try {
+            $root = [System.IO.Path]::GetFullPath($ServerRootPath)
+            $pendingContextTask = $null
+            while ($listener.IsListening) {
+                try {
+                    if ($null -eq $pendingContextTask) {
+                        $pendingContextTask = $listener.GetContextAsync()
+                    }
+
+                    if (-not $pendingContextTask.Wait(250)) {
+                        continue
+                    }
+
+                    $context = $pendingContextTask.GetAwaiter().GetResult()
+                    $pendingContextTask = $null
+                }
+                catch {
+                    break
+                }
+
+                try {
+                    $requestPath = [System.Uri]::UnescapeDataString($context.Request.Url.AbsolutePath.TrimStart('/'))
+                    if ([string]::IsNullOrWhiteSpace($requestPath)) {
+                        $requestPath = $ServerIndexFileName
+                    }
+
+                    $localRelativePath = $requestPath.Replace('/', [System.IO.Path]::DirectorySeparatorChar)
+                    $targetPath = [System.IO.Path]::GetFullPath((Join-Path $root $localRelativePath))
+                    if (-not $targetPath.StartsWith($root, [System.StringComparison]::OrdinalIgnoreCase)) {
+                        $context.Response.StatusCode = 403
+                        continue
+                    }
+
+                    if (-not (Test-Path -LiteralPath $targetPath -PathType Leaf)) {
+                        $context.Response.StatusCode = 404
+                        continue
+                    }
+
+                    $extension = [System.IO.Path]::GetExtension($targetPath).ToLowerInvariant()
+                    $context.Response.ContentType = switch ($extension) {
+                        '.html' { 'text/html; charset=utf-8' }
+                        '.css' { 'text/css; charset=utf-8' }
+                        '.js' { 'application/javascript; charset=utf-8' }
+                        '.json' { 'application/json; charset=utf-8' }
+                        '.gz' { 'application/gzip' }
+                        default { 'application/octet-stream' }
+                    }
+                    $context.Response.StatusCode = 200
+
+                    $fileStream = [System.IO.File]::OpenRead($targetPath)
+                    try {
+                        $context.Response.ContentLength64 = $fileStream.Length
+                        $fileStream.CopyTo($context.Response.OutputStream)
+                    }
+                    finally {
+                        $fileStream.Dispose()
+                    }
+                }
+                catch {
+                    try { $context.Response.StatusCode = 500 } catch { $null = $_ }
+                }
+                finally {
+                    try { $context.Response.OutputStream.Close() } catch { $null = $_ }
+                }
+            }
+        }
+        finally {
+            if ($listener.IsListening) {
+                $listener.Stop()
+            }
+            $listener.Close()
+        }
+    }
+}
+
+$resolvedDashboardPath = [System.IO.Path]::GetFullPath($DashboardPath)
+$dashboardRoot = Split-Path -Path $resolvedDashboardPath -Parent
+$dashboardFileName = Split-Path -Path $resolvedDashboardPath -Leaf
+$Port = if ($Port -gt 0) { $Port } else { Get-FreeTcpPort }
+$edgeExecutablePath = Resolve-EdgeExecutablePath -RequestedPath $EdgePath
+Write-Verbose "Resolved dashboard '$resolvedDashboardPath' and Edge '$edgeExecutablePath'."
+
+if ([string]::IsNullOrWhiteSpace($edgeExecutablePath)) {
+    if ($AllowSkip) {
+        Write-Warning 'Microsoft Edge was not found; hosted dashboard runtime smoke skipped.'
+        return
+    }
+
+    throw 'Microsoft Edge was not found. Provide -EdgePath or install Edge to run the hosted dashboard runtime smoke.'
+}
+
+$serverJob = $null
+$edgeProcess = $null
+$profilePath = Join-Path ([System.IO.Path]::GetTempPath()) ('edge-dashboard-smoke-' + [guid]::NewGuid().ToString('N'))
+$smokeRoot = Join-Path ([System.IO.Path]::GetTempPath()) ('hosted-dashboard-smoke-' + [guid]::NewGuid().ToString('N'))
+$servedRoot = Join-Path $smokeRoot 'site'
+$domOutputPath = Join-Path $smokeRoot 'dashboard.dom.html'
+$edgeErrorPath = Join-Path $smokeRoot 'edge.stderr.log'
+
+try {
+    [void](New-Item -Path $smokeRoot -ItemType Directory -Force)
+    [void](New-Item -Path $servedRoot -ItemType Directory -Force)
+    Copy-Item -Path (Join-Path $dashboardRoot '*') -Destination $servedRoot -Recurse -Force
+
+    $probeDashboardPath = Join-Path $servedRoot $dashboardFileName
+    $dashboardHtml = Get-Content -LiteralPath $probeDashboardPath -Raw
+    $bodyCloseIndex = $dashboardHtml.LastIndexOf('</body>', [System.StringComparison]::OrdinalIgnoreCase)
+    if ($bodyCloseIndex -lt 0) {
+        throw 'Dashboard HTML did not contain a closing body tag for the smoke probe.'
+    }
+
+    $probeTimeoutMilliseconds = [math]::Min(120000, [math]::Max(10000, ($TimeoutSeconds * 1000) - 1000))
+    $probeScript = @'
+<script>
+(function () {
+    var probeId = 'hostedDashboardSmokeProbe';
+    var probeTimeoutMilliseconds = __PROBE_TIMEOUT_MS__;
+        var probeCompleted = false;
+
+        function publishProbe(state, validation, message, payloadRows) {
+        var existingProbe = document.getElementById(probeId);
+        if (existingProbe && existingProbe.getAttribute('data-state') === 'ready') {
+            return;
+        }
+
+        var probe = existingProbe || document.createElement('div');
+        probe.id = probeId;
+        probe.hidden = true;
+        probe.setAttribute('data-state', state);
+        if (validation) {
+            probe.setAttribute('data-dashboard-ready', String(Boolean(validation.ready)));
+            probe.setAttribute('data-active-report', validation.activeReportId || '');
+            probe.setAttribute('data-delivery-mode', validation.deliveryMode || '');
+        }
+        if (typeof payloadRows === 'number') {
+            probe.setAttribute('data-payload-rows', String(payloadRows));
+        }
+        probe.textContent = message || state;
+
+        if (!existingProbe) {
+            document.body.appendChild(probe);
+        }
+    }
+
+    function getValidation() {
+        return window.dashboardValidation || null;
+    }
+
+    function getHostedPayloadRowCount(payload) {
+        if (!payload || !payload.vulns) {
+            return -1;
+        }
+
+        if (Array.isArray(payload.vulns)) {
+            return payload.vulns.length;
+        }
+
+        if (payload.vulns.d && Array.isArray(payload.vulns.d)) {
+            return payload.vulns.d.length;
+        }
+
+        return -1;
+    }
+
+    function getDashboardConfig() {
+        var configElement = document.getElementById('dashboardConfig');
+        if (!configElement || !configElement.textContent) {
+            throw new Error('dashboardConfig was not available.');
+        }
+
+        return JSON.parse(configElement.textContent);
+    }
+
+    async function runHostedAssetProbe() {
+        var validation = getValidation();
+        var config = getDashboardConfig();
+        if (!validation || validation.deliveryMode !== 'split-assets') {
+            throw new Error('Dashboard validation snapshot did not report split-assets mode.');
+        }
+        if (!config.payloadUrl) {
+            throw new Error('Split-assets dashboard config did not include a payloadUrl.');
+        }
+        if (!window.pako || typeof window.pako.inflate !== 'function') {
+            throw new Error('pako did not load before the hosted asset probe.');
+        }
+
+        var response = await fetch(config.payloadUrl, { cache: 'no-cache' });
+        if (!response.ok) {
+            throw new Error('Hosted payload fetch failed: ' + response.status + ' ' + response.statusText);
+        }
+
+        var compressedBytes = new Uint8Array(await response.arrayBuffer());
+        var payloadText = window.pako.inflate(compressedBytes, { to: 'string' });
+        var payload = JSON.parse(payloadText);
+        var payloadRows = getHostedPayloadRowCount(payload);
+        if (payloadRows < 0) {
+            throw new Error('Hosted payload shape was not recognized.');
+        }
+
+        probeCompleted = true;
+        publishProbe('ready', getValidation() || validation, 'hosted-payload-ready', payloadRows);
+    }
+
+    window.addEventListener('dashboard-ready', function (event) {
+        var validation = event.detail && event.detail.validation ? event.detail.validation : getValidation();
+        probeCompleted = true;
+        publishProbe('ready', validation, 'dashboard-ready');
+    });
+
+    function startProbe() {
+        runHostedAssetProbe().catch(function (error) {
+            probeCompleted = true;
+            publishProbe('error', getValidation(), error && error.message ? error.message : String(error));
+        });
+    }
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', startProbe);
+    } else {
+        startProbe();
+    }
+
+    window.setTimeout(function () {
+        if (!probeCompleted) {
+            publishProbe('timeout', getValidation(), 'Timed out waiting for dashboard readiness.');
+        }
+    }, probeTimeoutMilliseconds);
+})();
+</script>
+'@.Replace('__PROBE_TIMEOUT_MS__', [string]$probeTimeoutMilliseconds)
+    $dashboardHtml = $dashboardHtml.Insert($bodyCloseIndex, "`r`n$probeScript`r`n")
+    Set-Content -LiteralPath $probeDashboardPath -Value $dashboardHtml -Encoding utf8 -NoNewline
+
+    $serverJob = Start-StaticHttpServer -RootPath $servedRoot -IndexFileName $dashboardFileName -ListenPort $Port
+    $dashboardUrl = 'http://127.0.0.1:{0}/{1}' -f $Port, [System.Uri]::EscapeDataString($dashboardFileName)
+    Write-Verbose "Started local hosted dashboard server at $dashboardUrl."
+
+    $serverReady = $false
+    for ($attempt = 0; $attempt -lt 40 -and -not $serverReady; $attempt++) {
+        try {
+            $response = Invoke-WebRequest -Uri $dashboardUrl -TimeoutSec 1 -UseBasicParsing
+            $serverReady = ($response.StatusCode -eq 200)
+        }
+        catch {
+            Start-Sleep -Milliseconds 100
+        }
+    }
+    if (-not $serverReady) {
+        throw "Timed out waiting for local hosted dashboard server at $dashboardUrl."
+    }
+    Write-Verbose 'Local hosted dashboard server is ready.'
+
+    $virtualTimeBudgetMilliseconds = [math]::Min(120000, [math]::Max(5000, $TimeoutSeconds * 1000))
+    $edgeArguments = @(
+        '--headless=new',
+        '--disable-gpu',
+        '--disable-extensions',
+        '--no-first-run',
+        '--no-default-browser-check',
+        '--disable-background-networking',
+        "--user-data-dir=$profilePath",
+        "--virtual-time-budget=$virtualTimeBudgetMilliseconds",
+        '--dump-dom',
+        $dashboardUrl
+    )
+
+    $edgeProcess = Start-Process `
+        -FilePath $edgeExecutablePath `
+        -ArgumentList $edgeArguments `
+        -RedirectStandardOutput $domOutputPath `
+        -RedirectStandardError $edgeErrorPath `
+        -PassThru `
+        -WindowStyle Hidden
+    Write-Verbose "Started Microsoft Edge process $($edgeProcess.Id)."
+
+    $waitMilliseconds = ($TimeoutSeconds * 1000) + 15000
+    if (-not $edgeProcess.WaitForExit($waitMilliseconds)) {
+        $edgeErrors = if (Test-Path -LiteralPath $edgeErrorPath -PathType Leaf) { Get-Content -LiteralPath $edgeErrorPath -Raw } else { '' }
+        try { Stop-Process -Id $edgeProcess.Id -Force -ErrorAction SilentlyContinue } catch { Write-Verbose "Failed to stop timed-out Edge process $($edgeProcess.Id): $_" }
+        throw "Timed out waiting for Microsoft Edge to complete the hosted dashboard runtime smoke after $([math]::Round($waitMilliseconds / 1000, 1)) seconds. $edgeErrors"
+    }
+    Write-Verbose "Microsoft Edge exited with code $($edgeProcess.ExitCode)."
+
+    if ($edgeProcess.ExitCode -ne 0) {
+        $edgeErrors = if (Test-Path -LiteralPath $edgeErrorPath -PathType Leaf) { Get-Content -LiteralPath $edgeErrorPath -Raw } else { '' }
+        throw "Microsoft Edge exited with code $($edgeProcess.ExitCode). $edgeErrors"
+    }
+
+    if (-not (Test-Path -LiteralPath $domOutputPath -PathType Leaf)) {
+        throw 'Microsoft Edge did not produce a DOM snapshot.'
+    }
+
+    $dom = Get-Content -LiteralPath $domOutputPath -Raw
+    if ([string]::IsNullOrWhiteSpace($dom)) {
+        throw 'Microsoft Edge produced an empty DOM snapshot.'
+    }
+    if ($dom -notmatch 'id="statsSummary"') {
+        throw 'Hosted dashboard DOM snapshot did not contain the summary cards.'
+    }
+    if ($dom -notmatch 'id="reportSelector"') {
+        throw 'Hosted dashboard DOM snapshot did not contain the report selector.'
+    }
+    if ($dom -match 'Failed to initialize the dashboard') {
+        throw 'Hosted dashboard reported an initialization failure.'
+    }
+    if ($dom -notmatch 'id="hostedDashboardSmokeProbe"') {
+        throw 'Hosted dashboard DOM snapshot did not contain the runtime readiness smoke probe.'
+    }
+    if ($dom -notmatch 'data-state="ready"') {
+        $probeMatch = [regex]::Match($dom, '<div[^>]+id="hostedDashboardSmokeProbe"[^>]*>.*?</div>', [System.Text.RegularExpressions.RegexOptions]::Singleline)
+        $probeDetails = if ($probeMatch.Success) { $probeMatch.Value } else { 'probe details unavailable' }
+        throw "Hosted dashboard runtime readiness probe did not report ready. $probeDetails"
+    }
+    if ($dom -notmatch 'data-delivery-mode="split-assets"') {
+        throw 'Hosted dashboard validation snapshot did not report split-assets delivery mode.'
+    }
+    $payloadRowsMatch = [regex]::Match($dom, 'data-payload-rows="(?<Rows>-?\d+)"')
+    if (-not $payloadRowsMatch.Success -or [int]$payloadRowsMatch.Groups['Rows'].Value -lt 0) {
+        throw 'Hosted dashboard smoke probe did not confirm a readable hosted payload.'
+    }
+    Write-Verbose 'Hosted dashboard DOM smoke assertions passed.'
+
+    [PSCustomObject]@{
+        DashboardUrl = $dashboardUrl
+        DomLength = $dom.Length
+        EdgePath = $edgeExecutablePath
+        SmokeMode = 'edge-headless-dump-dom'
+    } | ConvertTo-Json -Depth 5
+}
+finally {
+    if ($edgeProcess -and -not $edgeProcess.HasExited) {
+        try { Stop-Process -Id $edgeProcess.Id -Force -ErrorAction SilentlyContinue } catch { Write-Verbose "Failed to stop Edge process $($edgeProcess.Id): $_" }
+    }
+    if ($serverJob) {
+        Write-Verbose 'Removing local hosted dashboard server job.'
+        try { Stop-Job -Job $serverJob -ErrorAction SilentlyContinue } catch { Write-Verbose "Failed to stop hosted dashboard server job: $_" }
+        try { Wait-Job -Job $serverJob -Timeout 5 -ErrorAction SilentlyContinue | Out-Null } catch { Write-Verbose "Failed while waiting for hosted dashboard server job to stop: $_" }
+        try { Remove-Job -Job $serverJob -Force -ErrorAction SilentlyContinue } catch { Write-Verbose "Failed to remove hosted dashboard server job: $_" }
+    }
+    if (Test-Path -LiteralPath $profilePath) {
+        Remove-Item -LiteralPath $profilePath -Recurse -Force -ErrorAction SilentlyContinue
+    }
+    if (Test-Path -LiteralPath $smokeRoot) {
+        Remove-Item -LiteralPath $smokeRoot -Recurse -Force -ErrorAction SilentlyContinue
+    }
+}

--- a/tests/Run-SharedHelperRegression.ps1
+++ b/tests/Run-SharedHelperRegression.ps1
@@ -209,6 +209,184 @@ function Test-CanonicalLayoutHelper {
     }
 }
 
+function Test-FileSetFingerprintIgnoresTimestampChange {
+    [CmdletBinding()]
+    param()
+
+    $tempRoot = Join-Path ([System.IO.Path]::GetTempPath()) ('file-fingerprint-stability-' + [guid]::NewGuid().ToString('N'))
+    [void](New-Item -Path $tempRoot -ItemType Directory -Force)
+
+    try {
+        $filePath = Join-Path $tempRoot 'source.json.gz'
+        Set-Content -LiteralPath $filePath -Value 'alpha' -NoNewline -Encoding utf8
+
+        $initialFingerprint = Get-FileSetFingerprint -Version 'test-cache-v1' -Files @((Get-Item -LiteralPath $filePath))
+        [System.IO.File]::SetLastWriteTimeUtc($filePath, ([datetime]::UtcNow.AddDays(-7)))
+        $timestampOnlyFingerprint = Get-FileSetFingerprint -Version 'test-cache-v1' -Files @((Get-Item -LiteralPath $filePath))
+
+        Set-Content -LiteralPath $filePath -Value 'bravo' -NoNewline -Encoding utf8
+        $contentChangedFingerprint = Get-FileSetFingerprint -Version 'test-cache-v1' -Files @((Get-Item -LiteralPath $filePath))
+
+        Assert-True ($initialFingerprint -eq $timestampOnlyFingerprint) 'Expected file-set fingerprints to ignore timestamp-only changes when content is unchanged.'
+        Assert-True ($timestampOnlyFingerprint -ne $contentChangedFingerprint) 'Expected file-set fingerprints to change when file content changes.'
+    }
+    finally {
+        if (Test-Path -LiteralPath $tempRoot) {
+            Remove-Item -LiteralPath $tempRoot -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+}
+
+function Test-NormalizedPayloadCacheRejectsManifestHashMismatch {
+    [CmdletBinding()]
+    param()
+
+    $tempRoot = Join-Path ([System.IO.Path]::GetTempPath()) ('payload-cache-hash-mismatch-' + [guid]::NewGuid().ToString('N'))
+    [void](New-Item -Path $tempRoot -ItemType Directory -Force)
+
+    try {
+        $currentRow = Get-TestVulnRow -Id 'cache-hash-001' -CveId 'CVE-2026-0801' -SnapshotDate '2026-03-20' -Version '8.0.0'
+        Write-NdjsonRecordsFile -Path (Get-VulnCurrentPath -BasePath $tempRoot) -Records @($currentRow)
+
+        $payloadPath = Join-Path $tempRoot 'payload.json.gz'
+        Write-GzipTextFile -Path $payloadPath -Content '{"lookups":{"devices":[],"cves":[]},"vulnsFormat":"rows-v1","vulns":[]}'
+
+        $cacheEntry = Publish-NormalizedPayloadCache -BasePath $tempRoot -PayloadPath $payloadPath -VulnCount 0 -DeviceCount 0 -CveCount 0 -Quality ([PSCustomObject]@{ FirstLastSwappedCount = 0 })
+        Assert-True ($null -ne $cacheEntry) 'Expected normalized payload cache publish to create an entry.'
+        Assert-True ($null -ne (Get-NormalizedPayloadCacheEntry -BasePath $tempRoot)) 'Expected normalized payload cache entry to be reusable before corruption.'
+
+        Set-Content -LiteralPath $cacheEntry.PayloadPath -Value 'corrupt' -NoNewline -Encoding utf8
+        $cacheMiss = Get-NormalizedPayloadCacheEntry -BasePath $tempRoot
+
+        $throwFailure = $null
+        try {
+            $null = Confirm-NormalizedPayloadManifestPayloadSha -Manifest $cacheEntry.Manifest -PayloadPath $cacheEntry.PayloadPath -ThrowOnMismatch
+        }
+        catch {
+            $throwFailure = $_
+        }
+
+        Assert-True ($null -eq $cacheMiss) 'Expected normalized payload cache lookup to reject a payload whose bytes do not match the manifest hash.'
+        Assert-True ($null -ne $throwFailure) 'Expected strict normalized payload manifest confirmation to throw on hash mismatch.'
+    }
+    finally {
+        if (Test-Path -LiteralPath $tempRoot) {
+            Remove-Item -LiteralPath $tempRoot -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+}
+
+function Test-NormalizedPayloadManifestSourceSummary {
+    [CmdletBinding()]
+    param()
+
+    $tempRoot = Join-Path ([System.IO.Path]::GetTempPath()) ('payload-source-metadata-' + [guid]::NewGuid().ToString('N'))
+    [void](New-Item -Path $tempRoot -ItemType Directory -Force)
+
+    try {
+        Write-GzipTextFile -Path (Get-MachineCurrentPath -BasePath $tempRoot) -Content '[{"id":"device-001"}]'
+        Write-GzipTextFile -Path (Get-AdvancedHuntingCurrentPath -BasePath $tempRoot) -Content '[{"CveId":"CVE-2026-0802"}]'
+        Write-GzipTextFile -Path (Get-NvdCveCurrentPath -BasePath $tempRoot) -Content '{"records":[{"CveId":"CVE-2026-0802"}]}'
+
+        $sourceMetadata = Get-DashboardSourceSummary `
+            -BasePath $tempRoot `
+            -MachineCount 1 `
+            -AdvancedHuntingCveCount 2 `
+            -AdvancedHuntingDeviceUserCount 3 `
+            -AdvancedHuntingInventoryTupleCount 4 `
+            -NvdCveCount 5 `
+            -NormalizationMode 'regression-test'
+
+        Assert-True ($sourceMetadata.Version -eq 'dashboard-source-metadata-v1') 'Expected source metadata to include a version marker.'
+        Assert-True ($sourceMetadata.MachineData.RecordCount -eq 1) 'Expected source metadata to preserve machine record count.'
+        Assert-True ($sourceMetadata.MachineData.Source.FileCount -eq 1) 'Expected source metadata to include machine source file summary.'
+        Assert-True ($sourceMetadata.AdvancedHunting.CveCount -eq 2) 'Expected source metadata to preserve Advanced Hunting CVE count.'
+        Assert-True ($sourceMetadata.AdvancedHunting.DeviceUserCount -eq 3) 'Expected source metadata to preserve Advanced Hunting device-user count.'
+        Assert-True ($sourceMetadata.AdvancedHunting.InventoryTupleCount -eq 4) 'Expected source metadata to preserve Advanced Hunting inventory tuple count.'
+        Assert-True ($sourceMetadata.NvdCve.RecordCount -eq 5) 'Expected source metadata to preserve NVD CVE count.'
+
+        $payloadPath = Join-Path $tempRoot 'payload.json.gz'
+        Write-GzipTextFile -Path $payloadPath -Content '{"lookups":{"devices":[],"cves":[]},"vulnsFormat":"rows-v1","vulns":[]}'
+
+        $cacheEntry = Publish-NormalizedPayloadCache -BasePath $tempRoot -PayloadPath $payloadPath -VulnCount 0 -DeviceCount 1 -CveCount 5 -Quality ([PSCustomObject]@{ FirstLastSwappedCount = 0 }) -SourceMetadata $sourceMetadata
+        Assert-True ($null -ne $cacheEntry.Manifest.SourceMetadata) 'Expected normalized payload manifest to carry source metadata.'
+        Assert-True ($cacheEntry.Manifest.SourceMetadata.AdvancedHunting.DeviceUserCount -eq 3) 'Expected manifest source metadata to retain enrichment counts.'
+
+        $htmlPath = Join-Path $tempRoot 'dashboard.html'
+        Set-Content -LiteralPath $htmlPath -Value '<html></html>' -NoNewline -Encoding utf8
+        $sidecarPath = Write-DashboardValidationSidecar -HtmlPath $htmlPath -PayloadManifest $cacheEntry.Manifest -DashboardPayloadSha256 $cacheEntry.Manifest.PayloadSha256 -DashboardPayloadRowCount 0
+        $sidecar = Get-Content -LiteralPath $sidecarPath -Raw | ConvertFrom-Json -Depth 20
+
+        Assert-True ($null -ne $sidecar.SourceMetadata) 'Expected validation sidecar to copy source metadata from the payload manifest.'
+        Assert-True ($sidecar.SourceMetadata.NvdCve.RecordCount -eq 5) 'Expected validation sidecar source metadata to retain NVD counts.'
+    }
+    finally {
+        if (Test-Path -LiteralPath $tempRoot) {
+            Remove-Item -LiteralPath $tempRoot -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+}
+
+function Test-SaveJSLibraryFileRefreshesEmptyCache {
+    [CmdletBinding()]
+    param()
+
+    $tempRoot = Join-Path ([System.IO.Path]::GetTempPath()) ('library-cache-empty-' + [guid]::NewGuid().ToString('N'))
+    [void](New-Item -Path $tempRoot -ItemType Directory -Force)
+    $outputPath = Join-Path $tempRoot 'library.js'
+    $secondOutputPath = Join-Path $tempRoot 'library-second.js'
+    $existingInvokeWebRequestFunction = Get-Command -Name Invoke-WebRequest -CommandType Function -ErrorAction SilentlyContinue
+    $existingInvokeWebRequestScriptBlock = if ($null -ne $existingInvokeWebRequestFunction) { (Get-Item -Path Function:Invoke-WebRequest).ScriptBlock } else { $null }
+
+    try {
+        $script:LibraryCacheRefreshDownloadAttempts = 0
+        function Invoke-WebRequest {
+            [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidOverwritingBuiltInCmdlets', '', Justification = 'Regression test shim for Save-JSLibraryFile without network access.')]
+            param(
+                [Parameter(Mandatory = $true)]
+                [string]$Uri,
+
+                [Parameter(Mandatory = $true)]
+                [string]$OutFile,
+
+                [Parameter(Mandatory = $false)]
+                [int]$TimeoutSec
+            )
+
+            $null = $Uri
+            $null = $TimeoutSec
+            $script:LibraryCacheRefreshDownloadAttempts++
+            [System.IO.File]::WriteAllText($OutFile, ("download-{0}" -f $script:LibraryCacheRefreshDownloadAttempts), [System.Text.UTF8Encoding]::new($false))
+        }
+
+        $null = Save-JSLibraryFile -Url 'https://example.invalid/library.js' -Name 'Test Library' -OutputPath $outputPath -Critical $true -CacheBasePath $tempRoot
+        $cacheDirectory = Join-Path $tempRoot '.dashboard-cache\libraries'
+        $cacheFile = Get-ChildItem -Path $cacheDirectory -File | Select-Object -First 1
+        [System.IO.File]::WriteAllBytes($cacheFile.FullName, [byte[]]@())
+
+        $null = Save-JSLibraryFile -Url 'https://example.invalid/library.js' -Name 'Test Library' -OutputPath $secondOutputPath -Critical $true -CacheBasePath $tempRoot
+        $refreshedContent = Get-Content -LiteralPath $secondOutputPath -Raw
+        $refreshedCacheLength = (Get-Item -LiteralPath $cacheFile.FullName).Length
+
+        Assert-True ($script:LibraryCacheRefreshDownloadAttempts -eq 2) 'Expected an empty cached JavaScript library to be refreshed instead of reused.'
+        Assert-True ($refreshedContent -eq 'download-2') 'Expected refreshed library output to come from the second download attempt.'
+        Assert-True ($refreshedCacheLength -gt 0) 'Expected refreshed JavaScript library cache file to be non-empty.'
+    }
+    finally {
+        if ($null -ne $existingInvokeWebRequestScriptBlock) {
+            Set-Item -Path Function:Invoke-WebRequest -Value $existingInvokeWebRequestScriptBlock
+        }
+        else {
+            Remove-Item -Path Function:Invoke-WebRequest -Force -ErrorAction SilentlyContinue
+        }
+        Remove-Variable -Name LibraryCacheRefreshDownloadAttempts -Scope Script -ErrorAction SilentlyContinue
+
+        if (Test-Path -LiteralPath $tempRoot) {
+            Remove-Item -LiteralPath $tempRoot -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+}
+
 function Test-VulnContentStoreExistenceNeedsRef {
     [CmdletBinding()]
     param()
@@ -3019,6 +3197,79 @@ function Test-DashboardSplitAssetsGenerationAndValidation {
     }
 }
 
+function Test-DashboardValidateOnlyFailsWhenHostedPayloadMissing {
+    [CmdletBinding()]
+    param()
+
+    $fixturePath = Join-Path $PSScriptRoot 'fixtures\legacy-migration-none-severity'
+    $tempRoot = Join-Path ([System.IO.Path]::GetTempPath()) ('dashboard-hosted-negative-' + [guid]::NewGuid().ToString('N'))
+    [void](New-Item -Path $tempRoot -ItemType Directory -Force)
+    $dashboardScriptPath = Join-Path (Split-Path -Path $PSScriptRoot -Parent) 'Generate-VulnerabilityDashboard.ps1'
+    $outputPath = Join-Path $tempRoot 'dashboard.html'
+    $auditPath = Join-Path $tempRoot 'audit.json'
+    $assetsPath = Join-Path $tempRoot 'dashboard.assets'
+
+    try {
+        Copy-Item -Path (Join-Path $fixturePath '*') -Destination $tempRoot -Recurse -Force
+        $null = Publish-VulnStoreFromBulkSnapshot -BasePath $tempRoot -RemoveSnapshotFiles
+
+        & $dashboardScriptPath -DirectoryPath $tempRoot -OutputPath $outputPath -ExportMachineData:$false -SplitAssets | Out-Null
+
+        $payloadAssetPath = Join-Path $assetsPath 'payload.json.gz'
+        Assert-True ((Test-Path -LiteralPath $payloadAssetPath -PathType Leaf)) 'Expected split-assets generation to write a hosted payload before the negative validation step.'
+        Remove-Item -LiteralPath $payloadAssetPath -Force
+
+        & pwsh -NoProfile -File $dashboardScriptPath -DirectoryPath $tempRoot -OutputPath $outputPath -ValidateOnly -ValidationOutputPath $auditPath | Out-Null
+        $validationExitCode = $LASTEXITCODE
+
+        Assert-True ($validationExitCode -ne 0) 'Expected ValidateOnly to fail when a hosted dashboard payload asset is missing.'
+        Assert-True (-not (Test-Path -LiteralPath $auditPath -PathType Leaf)) 'Expected missing hosted payload validation to avoid writing a passing audit artifact.'
+    }
+    finally {
+        $global:LASTEXITCODE = 0
+        if (Test-Path -LiteralPath $tempRoot) {
+            Remove-Item -LiteralPath $tempRoot -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+}
+
+function Test-PackageOnlyRejectsMismatchedNormalizedPayloadManifest {
+    [CmdletBinding()]
+    param()
+
+    $fixturePath = Join-Path $PSScriptRoot 'fixtures\legacy-migration-none-severity'
+    $tempRoot = Join-Path ([System.IO.Path]::GetTempPath()) ('dashboard-package-negative-' + [guid]::NewGuid().ToString('N'))
+    [void](New-Item -Path $tempRoot -ItemType Directory -Force)
+    $dashboardScriptPath = Join-Path (Split-Path -Path $PSScriptRoot -Parent) 'Generate-VulnerabilityDashboard.ps1'
+    $normalizedPayloadPath = Join-Path $tempRoot '.local\payload\dashboard-payload.json.gz'
+    $normalizedManifestPath = Join-Path $tempRoot '.local\payload\dashboard-payload.json'
+    $tamperedPayloadPath = Join-Path $tempRoot '.local\payload\dashboard-payload-tampered.json.gz'
+    $outputPath = Join-Path $tempRoot 'dashboard.html'
+
+    try {
+        Copy-Item -Path (Join-Path $fixturePath '*') -Destination $tempRoot -Recurse -Force
+        $null = Publish-VulnStoreFromBulkSnapshot -BasePath $tempRoot -RemoveSnapshotFiles
+
+        & $dashboardScriptPath -DirectoryPath $tempRoot -ExportMachineData:$false -NormalizeOnly -NormalizedPayloadOutputPath $normalizedPayloadPath -NormalizedPayloadManifestOutputPath $normalizedManifestPath | Out-Null
+        Assert-True ((Test-Path -LiteralPath $normalizedPayloadPath -PathType Leaf)) 'Expected NormalizeOnly to materialize a payload for the package-only negative test.'
+        Assert-True ((Test-Path -LiteralPath $normalizedManifestPath -PathType Leaf)) 'Expected NormalizeOnly to materialize a manifest for the package-only negative test.'
+
+        Write-GzipTextFile -Path $tamperedPayloadPath -Content '{"lookups":{"devices":[],"cves":[]},"vulnsFormat":"rows-v1","vulns":[]}'
+
+        & pwsh -NoProfile -File $dashboardScriptPath -DirectoryPath $tempRoot -OutputPath $outputPath -ExportMachineData:$false -PackageOnly -NormalizedPayloadInputPath $tamperedPayloadPath -NormalizedPayloadManifestInputPath $normalizedManifestPath | Out-Null
+        $packageExitCode = $LASTEXITCODE
+
+        Assert-True ($packageExitCode -ne 0) 'Expected package-only generation to reject a payload whose bytes do not match the provided manifest.'
+        Assert-True (-not (Test-Path -LiteralPath $outputPath -PathType Leaf)) 'Expected package-only manifest mismatch to avoid writing a dashboard.'
+    }
+    finally {
+        $global:LASTEXITCODE = 0
+        if (Test-Path -LiteralPath $tempRoot) {
+            Remove-Item -LiteralPath $tempRoot -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+}
+
 function Test-DashboardDualPackagingGenerationAndValidation {
     [CmdletBinding()]
     param()
@@ -3217,6 +3468,14 @@ function Test-VulnObservedWindowCacheRoundTrip {
 Write-Output 'Running shared-helper regression checks...'
 Test-CanonicalLayoutHelper
 Write-Output '  Canonical layout helper checks passed.'
+Test-FileSetFingerprintIgnoresTimestampChange
+Write-Output '  File-set fingerprint stability checks passed.'
+Test-NormalizedPayloadCacheRejectsManifestHashMismatch
+Write-Output '  Normalized payload cache integrity checks passed.'
+Test-NormalizedPayloadManifestSourceSummary
+Write-Output '  Normalized payload source metadata checks passed.'
+Test-SaveJSLibraryFileRefreshesEmptyCache
+Write-Output '  JavaScript library cache refresh checks passed.'
 Test-VulnContentStoreExistenceNeedsRef
 Write-Output '  Content-store existence checks passed.'
 Test-LocalExportArtifactCleanup
@@ -3315,6 +3574,10 @@ Test-DashboardValidationPreservesNoneSeverityData
 Write-Output '  Dashboard none-severity validation checks passed.'
 Test-DashboardSplitAssetsGenerationAndValidation
 Write-Output '  Dashboard split-assets generation and validation checks passed.'
+Test-DashboardValidateOnlyFailsWhenHostedPayloadMissing
+Write-Output '  Hosted dashboard missing-payload negative checks passed.'
+Test-PackageOnlyRejectsMismatchedNormalizedPayloadManifest
+Write-Output '  Package-only manifest mismatch negative checks passed.'
 Test-DashboardDualPackagingGenerationAndValidation
 Write-Output '  Dashboard dual packaging generation and validation checks passed.'
 Test-AdvancedHuntingBundleMatchesDedicatedReaderData


### PR DESCRIPTION
## Summary

Harden the dashboard pipeline around normalized payload integrity, source metadata, hosted package validation, and release-gate documentation.

## Changes

- Validate normalized payload bytes against manifest `PayloadSha256` for cache reuse and package-only flows.
- Treat normal cache reuse hash mismatches as cache misses so generation can safely regenerate, while package-only fails fast.
- Refresh empty cached JavaScript libraries and reject empty fresh downloads.
- Add source metadata summaries to payload manifests, validation sidecars, audits, Azure Automation, and generated runbook artifacts.
- Add focused regression coverage for timestamp-stable fingerprints, cache hash mismatch rejection, source metadata propagation, empty library cache refresh, missing hosted payload validation, and package-only manifest mismatch rejection.
- Add optional Edge-backed hosted dashboard runtime smoke over local HTTP.
- Add pipeline architecture and validation coverage review docs, including a follow-up for reducing the very expensive 50k/1.5M semantic validation cost.
- Add a PR checklist for manual heavy gates and broaden CI workflow path triggers.

## Validation

- `pwsh -NoProfile -File .\tests\Run-SharedHelperRegression.ps1`
- `pwsh -NoProfile -File .\tests\Invoke-HostedDashboardRuntimeSmoke.ps1 -DashboardPath .\.local\validation\hosted-smoke\dashboard.html -TimeoutSeconds 45 -Verbose`
- `pwsh -NoProfile -File .\build\Invoke-RegressionValidation.ps1`
- `pwsh -NoProfile -File .\tests\Invoke-LargeDatasetValidation.ps1 -SkipSyntheticGeneration -SyntheticOutputPath .\.local\large-datasets\synthetic-50k-1_5m -Validate -ValidationMode artifacts`
- `pwsh -NoProfile -File .\tests\Invoke-LargeDatasetValidation.ps1 -SkipSyntheticGeneration -SyntheticOutputPath .\.local\large-datasets\synthetic-50k-1_5m -Validate -ValidationMode semantic` passed: 50,000 devices, 1,500,000 vulnerability rows, elapsed 11,862.32s.
- `pwsh -NoProfile -File .\build\Invoke-AzureDeploymentValidation.ps1 -AutomationAccountName aa-defender-reporting -FunctionAppName func-defender-reporting -ResourceGroupName rg-defender-reporting -SkipMdePermissions -DashboardDeliveryMode Dual -FunctionExecutionDatasetPath .\.local\large-datasets\synthetic-50k-1_5m -ValidationTimeoutSeconds 7200 -FunctionExecutionTimeoutMinutes 45` passed: Automation runbook generated/uploaded dual dashboard for 1.5M rows; Function App deployment succeeded and wrote a fresh dashboard blob.
- `git diff --check`
- VS Code diagnostics: no errors found.
- Read-only agent review: no blocking findings.