### PR TITLE
Reduce dashboard peak memory and tighten validation guardrails

### DIFF
--- a/Generate-VulnerabilityDashboard.ps1
+++ b/Generate-VulnerabilityDashboard.ps1
@@ -919,6 +919,11 @@ try {
         }
 
         $dashboardPackagingTargets = @(Get-DashboardPackagingPlan -PrimaryOutputPath $OutputPath -SplitAssets:([bool]$SplitAssets) -DualPackage:([bool]$DualPackage) -ConfiguredHostedOutputPath $HostedOutputPath -ValidationOutputPath $ValidationOutputPath)
+        if ((@($dashboardPackagingTargets | Where-Object { $_.SplitAssets }).Count -gt 0) -and (@($dashboardPackagingTargets | Where-Object { -not $_.SplitAssets }).Count -gt 0)) {
+            # Run hosted packaging first so the lighter split-assets write can complete
+            # before the heavier embedded self-contained packaging path.
+            $dashboardPackagingTargets = @($dashboardPackagingTargets | Sort-Object -Property @{ Expression = { [bool]$_.SplitAssets }; Descending = $true })
+        }
         $requiresEmbeddedBundles = (@($dashboardPackagingTargets | Where-Object { -not $_.SplitAssets }).Count -gt 0)
 
         $phaseContext = Get-LocalDiagnosticPhaseContext -Name 'Prepare client libraries'
@@ -941,16 +946,14 @@ try {
         ) -OutputPath (Join-Path $tempLibrariesPath 'pdf-export.bundle.js')
         $chartJsBundlePath = $null
         $pdfExportBundlePath = $null
-        if ($requiresEmbeddedBundles) {
-            $chartJsBundlePath = Compress-FileGzip -InputPath $chartJsLibraryPath -OutputPath (Join-Path $tempLibrariesPath 'chart.js.gz')
-            $pdfExportBundlePath = Compress-FileGzip -InputPath $pdfExportBundleSourcePath -OutputPath (Join-Path $tempLibrariesPath 'pdf-export.bundle.js.gz')
-        }
         $localPhaseTimings.Add((Complete-LocalDiagnosticPhase -PhaseContext $phaseContext)) | Out-Null
+        Invoke-PhaseTransitionGarbageCollection
 
         $phaseContext = Get-LocalDiagnosticPhaseContext -Name 'Load templates'
         Write-Host "`nLoading template files..." -ForegroundColor Cyan
         $templates = Get-DashboardTemplateContent -TemplatesPath $TemplatesPath -DefaultRootPath $PSScriptRoot
         $localPhaseTimings.Add((Complete-LocalDiagnosticPhase -PhaseContext $phaseContext)) | Out-Null
+        Invoke-PhaseTransitionGarbageCollection
 
         $lookupsJsonEscaped = ""
         $generatedOnUtc = (Get-Date).ToUniversalTime().ToString('o')
@@ -1003,6 +1006,13 @@ try {
 
         $dashboardGenerationResults = [System.Collections.Generic.List[object]]::new()
         foreach ($dashboardTarget in $dashboardPackagingTargets) {
+            if ((-not $dashboardTarget.SplitAssets) -and $requiresEmbeddedBundles -and [string]::IsNullOrWhiteSpace($chartJsBundlePath)) {
+                Write-Host "  Preparing embedded self-contained bundles..." -ForegroundColor Gray
+                $chartJsBundlePath = Compress-FileGzip -InputPath $chartJsLibraryPath -OutputPath (Join-Path $tempLibrariesPath 'chart.js.gz')
+                $pdfExportBundlePath = Compress-FileGzip -InputPath $pdfExportBundleSourcePath -OutputPath (Join-Path $tempLibrariesPath 'pdf-export.bundle.js.gz')
+                Invoke-FullGarbageCollection
+            }
+
             Write-Host (("Writing {0} dashboard to {1}..." -f $dashboardTarget.Label, $dashboardTarget.OutputPath)) -ForegroundColor Cyan
             $dashboardArtifacts = Write-DashboardArtifactBundle `
                 -TemplateHtml $templateHtml `
@@ -1070,6 +1080,16 @@ try {
                 ValidationOutputPath = if ([string]::IsNullOrWhiteSpace([string]$dashboardTarget.ValidationOutputPath)) { $null } else { [string]$dashboardTarget.ValidationOutputPath }
                 FileSizeMB = [math]::Round((Get-Item -LiteralPath $dashboardTarget.OutputPath).Length / 1MB, 2)
             }) | Out-Null
+
+            $dashboardArtifacts = $null
+            $dashboardPayloadInspection = $null
+            $dashboardPayloadSha256 = $null
+            $dashboardValidationSidecarPath = $null
+            if (-not $dashboardTarget.SplitAssets) {
+                $chartJsBundlePath = $null
+                $pdfExportBundlePath = $null
+            }
+            Invoke-FullGarbageCollection
         }
         $dashboardValidationTargets = @($dashboardGenerationResults)
 

--- a/azure/Invoke-DashboardPipeline.ps1
+++ b/azure/Invoke-DashboardPipeline.ps1
@@ -284,6 +284,21 @@ function Invoke-FullGarbageCollection {
     [System.GC]::Collect()
 }
 
+function Invoke-PhaseTransitionGarbageCollection {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $false)]
+        [AllowEmptyString()]
+        [string]$MemoryLabel
+    )
+
+    Invoke-FullGarbageCollection
+
+    if (-not [string]::IsNullOrWhiteSpace($MemoryLabel) -and (Get-Command -Name Write-MemoryUsage -ErrorAction SilentlyContinue)) {
+        Write-MemoryUsage -Label $MemoryLabel
+    }
+}
+
 function Test-IsAzureHostedEnvironment {
     [CmdletBinding()]
     [OutputType([bool])]
@@ -369,7 +384,11 @@ function New-ProgressMarkerState {
 
         [Parameter(Mandatory = $false)]
         [ValidateRange(1, 1000000)]
-        [int]$CheckInterval = 10000
+        [int]$CheckInterval = 10000,
+
+        [Parameter(Mandatory = $false)]
+        [ValidateRange(1, 9223372036854775807)]
+        [long]$TotalCount = 0
     )
 
     return [PSCustomObject]@{
@@ -377,6 +396,7 @@ function New-ProgressMarkerState {
         ProgressInterval = $ProgressInterval
         HeartbeatIntervalSeconds = $HeartbeatIntervalSeconds
         CheckInterval = [Math]::Max(1, [Math]::Min($ProgressInterval, $CheckInterval))
+        TotalCount = $TotalCount
         Stopwatch = [System.Diagnostics.Stopwatch]::StartNew()
         LastHeartbeatSecond = -1
     }
@@ -416,7 +436,15 @@ function Write-ProgressMarker {
     $elapsedSeconds = [Math]::Max(0.001, $State.Stopwatch.Elapsed.TotalSeconds)
     $rate = [Math]::Round(($Count / $elapsedSeconds), 0)
     $markerSuffix = if ($markerType -eq 'heartbeat') { ' [heartbeat]' } else { '' }
-    Write-Information ("  {0}: {1:N0} {2} processed in {3:N1}s ({4:N0}/s){5}" -f $State.ActivityName, $Count, $UnitLabel, [Math]::Round($elapsedSeconds, 1), $rate, $markerSuffix) -InformationAction Continue
+    $totalCount = if ($State.PSObject.Properties['TotalCount']) { [long]$State.TotalCount } else { 0L }
+    if ($totalCount -gt 0) {
+        $boundedCount = [Math]::Min([long]$Count, $totalCount)
+        $percentComplete = [Math]::Round(($boundedCount / [double]$totalCount) * 100.0, 1)
+        Write-Information ("  {0}: {1:N0}/{2:N0} {3} processed in {4:N1}s ({5:N0}/s, {6:N1}% complete){7}" -f $State.ActivityName, $boundedCount, $totalCount, $UnitLabel, [Math]::Round($elapsedSeconds, 1), $rate, $percentComplete, $markerSuffix) -InformationAction Continue
+    }
+    else {
+        Write-Information ("  {0}: {1:N0} {2} processed in {3:N1}s ({4:N0}/s){5}" -f $State.ActivityName, $Count, $UnitLabel, [Math]::Round($elapsedSeconds, 1), $rate, $markerSuffix) -InformationAction Continue
+    }
     $State.LastHeartbeatSecond = [Math]::Floor($State.Stopwatch.Elapsed.TotalSeconds)
 }
 
@@ -10053,7 +10081,13 @@ function Write-Base64FileContent {
     $stream = $null
 
     try {
-        $stream = [System.IO.File]::OpenRead($FilePath)
+        $stream = [System.IO.FileStream]::new(
+            $FilePath,
+            [System.IO.FileMode]::Open,
+            [System.IO.FileAccess]::Read,
+            [System.IO.FileShare]::Read,
+            4096,
+            [System.IO.FileOptions]::SequentialScan)
         while (($bytesRead = $stream.Read($inputBuffer, $pendingByteCount, $inputBlockByteCount)) -gt 0) {
             $totalByteCount = $pendingByteCount + $bytesRead
             $bytesToEncode = if ($stream.Position -lt $stream.Length) {
@@ -11649,8 +11683,16 @@ function Write-TemplatedHtml {
     )
 
     $writer = $null
+    $outputStream = $null
     try {
-        $writer = [System.IO.StreamWriter]::new($OutputPath, $false, [System.Text.UTF8Encoding]::new($false))
+        $outputStream = [System.IO.FileStream]::new(
+            $OutputPath,
+            [System.IO.FileMode]::Create,
+            [System.IO.FileAccess]::Write,
+            [System.IO.FileShare]::Read,
+            4096,
+            [System.IO.FileOptions]::WriteThrough)
+        $writer = [System.IO.StreamWriter]::new($outputStream, [System.Text.UTF8Encoding]::new($false), 4096, $false)
         $position = 0
         foreach ($segment in $Segments) {
             $placeholder = $segment.Placeholder
@@ -11678,6 +11720,9 @@ function Write-TemplatedHtml {
     finally {
         if ($writer) {
             $writer.Dispose()
+        }
+        elseif ($outputStream) {
+            $outputStream.Dispose()
         }
     }
 }
@@ -14664,6 +14709,25 @@ function Resolve-NormalizedContentLookup {
     }
 }
 
+function Get-NormalizedContentLookupCacheEntry {
+    [CmdletBinding()]
+    [OutputType([object[]])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [pscustomobject]$ContentLookup
+    )
+
+    return [object[]]@(
+        $ContentLookup.sw,
+        $ContentLookup.cve,
+        $ContentLookup.ver,
+        $ContentLookup.upd,
+        $ContentLookup.ua,
+        $ContentLookup.dp,
+        $ContentLookup.rp
+    )
+}
+
 function Get-NormalizedRecordLookup {
     [CmdletBinding()]
     [OutputType([pscustomobject])]
@@ -15085,7 +15149,7 @@ function Test-NormalizedWriterRowCount {
     }
 }
 
-function New-NoOnboardedVulnerabilityMessage {
+function Get-NoOnboardedVulnerabilityMessage {
     [CmdletBinding()]
     [OutputType([string])]
     param(
@@ -15213,6 +15277,13 @@ function Invoke-ContentStoreNormalization {
     $deviceLookupIndices = [System.Collections.Generic.List[int]]::new()
     $deviceOnboardedFlags = [System.Collections.Generic.List[bool]]::new()
     $contentLookupCache = [System.Collections.Generic.List[object]]::new()
+    $contentLookupSwIndex = 0
+    $contentLookupCveIndex = 1
+    $contentLookupVersionIndex = 2
+    $contentLookupUpdateIndex = 3
+    $contentLookupUpdateAvailableIndex = 4
+    $contentLookupDiskPathIndex = 5
+    $contentLookupRegistryPathIndex = 6
     $processedCountRef = [ref]0
     $firstLastSwappedCountRef = [ref]0
     $writerState = $null
@@ -15252,7 +15323,7 @@ function Invoke-ContentStoreNormalization {
                 $softwareVersion
             )) | Out-Null
 
-        $contentLookupCache.Add((Resolve-NormalizedContentLookup `
+        $contentLookupCache.Add((Get-NormalizedContentLookupCacheEntry -ContentLookup (Resolve-NormalizedContentLookup `
                 -SoftwareVendor $softwareVendor `
                 -SoftwareName $softwareName `
                 -RecommendationReference ([string](Get-VulnPropertyValue -InputObject $contentTemplate -Name 'rr')) `
@@ -15269,13 +15340,22 @@ function Invoke-ContentStoreNormalization {
                 -DiskPaths @(Get-StringArray -Value (Get-VulnPropertyValue -InputObject $contentTemplate -Name 'dp')) `
                 -RegistryPaths @(Get-StringArray -Value (Get-VulnPropertyValue -InputObject $contentTemplate -Name 'rp')) `
                 -SecurityUpdateAvailable ((Get-VulnPropertyValue -InputObject $contentTemplate -Name 'ua') -eq $true) `
-                -Context $Context)) | Out-Null
+                -Context $Context))) | Out-Null
     }
 
     $contentTemplates = $contentInventoryKeys.ToArray()
     $contentLookupCache = $contentLookupCache.ToArray()
     $contentTemplateCount = $contentTemplates.Length
     $contentInventoryKeys = $null
+
+    # Ref streaming only needs the compact device/content lookup arrays plus
+    # inventory enrichment. Release the larger source maps before processing
+    # the full ref set so they do not overlap with the row stream.
+    $Context.Machines = @{}
+    $Context.AdvancedHuntingData = @{}
+    $Context.AdvancedHuntingDeviceUsers = @{}
+    $Context.NvdCveData = @{}
+    Invoke-FullGarbageCollection
 
     try {
         $writerState = Open-NormalizedVulnWriter -VulnOutputPath $VulnOutputPath -VulnColumnDirectoryPath $VulnColumnDirectoryPath -PayloadOutputPath $PayloadOutputPath
@@ -15400,15 +15480,15 @@ function Invoke-ContentStoreNormalization {
                             $contentTemplate = $contentTemplates[$contentTemplateIndexValue]
                             $deviceProfileId = $deviceProfiles[$deviceProfileIndexValue]
                             $compactRecord[0] = $deviceLookupIndices[$deviceProfileIndexValue]
-                            $compactRecord[1] = $contentLookup.cve
-                            $compactRecord[2] = $contentLookup.sw
-                            $compactRecord[3] = $contentLookup.ver
+                            $compactRecord[1] = $contentLookup[$contentLookupCveIndex]
+                            $compactRecord[2] = $contentLookup[$contentLookupSwIndex]
+                            $compactRecord[3] = $contentLookup[$contentLookupVersionIndex]
                             $compactRecord[4] = Get-OrCreateIndex -value $firstSeen -list $lookups.dates -indexMap $dateIndex
                             $compactRecord[5] = Get-OrCreateIndex -value $lastSeen -list $lookups.dates -indexMap $dateIndex
-                            $compactRecord[6] = $contentLookup.ua
-                            $compactRecord[7] = $contentLookup.upd
-                            $compactRecord[8] = $contentLookup.dp
-                            $compactRecord[9] = $contentLookup.rp
+                            $compactRecord[6] = $contentLookup[$contentLookupUpdateAvailableIndex]
+                            $compactRecord[7] = $contentLookup[$contentLookupUpdateIndex]
+                            $compactRecord[8] = $contentLookup[$contentLookupDiskPathIndex]
+                            $compactRecord[9] = $contentLookup[$contentLookupRegistryPathIndex]
                             $compactRecord[10] = Resolve-NormalizedInventoryLookup `
                                 -DeviceId ([string]$deviceProfileId) `
                                 -SoftwareVendor ([string]$contentTemplate[0]) `
@@ -15691,7 +15771,7 @@ function Invoke-ContentStoreNormalization {
             $refLabels.Add([string]$refPath.Label) | Out-Null
         }
 
-        throw (New-NoOnboardedVulnerabilityMessage `
+        throw (Get-NoOnboardedVulnerabilityMessage `
                 -DataPath $DataPath `
                 -SourceKind 'content-store refs' `
                 -DeviceProfileCount $deviceProfileCount `
@@ -16704,7 +16784,7 @@ function ConvertTo-NormalizedData {
     }
 
     if ($processedCount -eq 0) {
-        throw (New-NoOnboardedVulnerabilityMessage -DataPath $DataPath -SourceKind 'export files')
+        throw (Get-NoOnboardedVulnerabilityMessage -DataPath $DataPath -SourceKind 'export files')
     }
     Write-Information "  Loaded $processedCount onboarded vulnerability records" -InformationAction Continue
 
@@ -17955,11 +18035,8 @@ try {
     ) -OutputPath (Join-Path $tempLibraries 'pdf-export.bundle.js')
     $chartJsBundlePath = $null
     $pdfExportBundlePath = $null
-    if ($requiresEmbeddedBundles) {
-        $chartJsBundlePath = Compress-FileGzip -InputPath $chartJsLibraryPath -OutputPath (Join-Path $tempLibraries 'chart.js.gz')
-        $pdfExportBundlePath = Compress-FileGzip -InputPath $pdfExportBundleSourcePath -OutputPath (Join-Path $tempLibraries 'pdf-export.bundle.js.gz')
-    }
     Write-MemoryUsage -Label "JS Libraries"
+    Invoke-PhaseTransitionGarbageCollection -MemoryLabel 'Pre-TemplateLoad'
 
     # Step 5: Load templates
     Write-Output "Loading templates..."
@@ -17997,6 +18074,7 @@ try {
     }
     $dataQualityMetaScript = '<script id="dataQualityMeta" type="application/json">' + ($dataQualityMeta | ConvertTo-Json -Compress) + '</script>'
     Write-MemoryUsage -Label "Post-Compress"
+    Invoke-PhaseTransitionGarbageCollection -MemoryLabel 'Pre-Assembly'
 
     # Step 8: Assemble final HTML
     Write-Output "Assembling dashboard HTML..."
@@ -18004,27 +18082,9 @@ try {
     $dashboardStatusBlobName = $Script:DashboardBlobName
     $dashboardStatusOutputPath = $null
 
-    if ($DashboardDeliveryMode -in @('SelfContained', 'Dual')) {
-        $selfContainedDashboardOutputPath = Join-Path -Path $tempDashboards -ChildPath $Script:DashboardBlobName
-        [void](Write-DashboardArtifactBundle `
-            -TemplateHtml $htmlTemplate `
-            -TemplateCss $cssContent `
-            -TemplateJs $jsContent `
-            -PakoLibraryPath $pakoLibraryPath `
-            -ChartJsLibraryPath $chartJsLibraryPath `
-            -ChartJsBundlePath $chartJsBundlePath `
-            -PdfExportBundleSourcePath $pdfExportBundleSourcePath `
-            -PdfExportBundlePath $pdfExportBundlePath `
-            -PayloadPath $tempPayloadPath `
-            -OutputPath $selfContainedDashboardOutputPath `
-            -LookupsJsonEscaped $lookupsJsonEscaped `
-            -DataQualitySectionHtml $dataQualitySectionHtml `
-            -DataQualityMetaScript $dataQualityMetaScript `
-            -SplitAssets $false)
-        $dashboardStatusOutputPath = $selfContainedDashboardOutputPath
-    }
-
     if ($DashboardDeliveryMode -in @('Hosted', 'Dual')) {
+        Set-PipelineExecutionStage -Stage 'WriteHostedDashboard' -Message 'Writing the hosted dashboard artifacts.'
+        [void](Write-PipelineExecutionStatus -AccountName $StorageAccountName -StorageToken $storageToken -Status 'running')
         $hostedDashboardOutputPath = Join-Path -Path $tempDashboards -ChildPath $(if ($useDualDashboard) { $Script:HostedDashboardBlobName } else { $Script:DashboardBlobName })
         $dashboardArtifacts = Write-DashboardArtifactBundle `
             -TemplateHtml $htmlTemplate `
@@ -18049,6 +18109,44 @@ try {
         if ($DashboardDeliveryMode -eq 'Hosted') {
             $dashboardStatusOutputPath = $hostedDashboardOutputPath
         }
+
+        $dashboardArtifacts = $null
+        Invoke-FullGarbageCollection
+        Write-MemoryUsage -Label 'Post-HostedAssembly'
+    }
+
+    if ($DashboardDeliveryMode -in @('SelfContained', 'Dual')) {
+        if ($requiresEmbeddedBundles -and [string]::IsNullOrWhiteSpace($chartJsBundlePath)) {
+            Write-Output '  Preparing embedded self-contained bundles...'
+            $chartJsBundlePath = Compress-FileGzip -InputPath $chartJsLibraryPath -OutputPath (Join-Path $tempLibraries 'chart.js.gz')
+            $pdfExportBundlePath = Compress-FileGzip -InputPath $pdfExportBundleSourcePath -OutputPath (Join-Path $tempLibraries 'pdf-export.bundle.js.gz')
+            Invoke-FullGarbageCollection
+            Write-MemoryUsage -Label 'Embedded Bundles'
+        }
+
+        Set-PipelineExecutionStage -Stage 'WriteSelfContainedDashboard' -Message 'Writing the self-contained dashboard artifact.'
+        [void](Write-PipelineExecutionStatus -AccountName $StorageAccountName -StorageToken $storageToken -Status 'running')
+        $selfContainedDashboardOutputPath = Join-Path -Path $tempDashboards -ChildPath $Script:DashboardBlobName
+        [void](Write-DashboardArtifactBundle `
+            -TemplateHtml $htmlTemplate `
+            -TemplateCss $cssContent `
+            -TemplateJs $jsContent `
+            -PakoLibraryPath $pakoLibraryPath `
+            -ChartJsLibraryPath $chartJsLibraryPath `
+            -ChartJsBundlePath $chartJsBundlePath `
+            -PdfExportBundleSourcePath $pdfExportBundleSourcePath `
+            -PdfExportBundlePath $pdfExportBundlePath `
+            -PayloadPath $tempPayloadPath `
+            -OutputPath $selfContainedDashboardOutputPath `
+            -LookupsJsonEscaped $lookupsJsonEscaped `
+            -DataQualitySectionHtml $dataQualitySectionHtml `
+            -DataQualityMetaScript $dataQualityMetaScript `
+            -SplitAssets $false)
+        $dashboardStatusOutputPath = $selfContainedDashboardOutputPath
+        $chartJsBundlePath = $null
+        $pdfExportBundlePath = $null
+        Invoke-FullGarbageCollection
+        Write-MemoryUsage -Label 'Post-SelfContainedAssembly'
     }
 
     $cssContent = $null

--- a/build/azure/runbook-source.ps1
+++ b/build/azure/runbook-source.ps1
@@ -1399,11 +1399,8 @@ try {
     ) -OutputPath (Join-Path $tempLibraries 'pdf-export.bundle.js')
     $chartJsBundlePath = $null
     $pdfExportBundlePath = $null
-    if ($requiresEmbeddedBundles) {
-        $chartJsBundlePath = Compress-FileGzip -InputPath $chartJsLibraryPath -OutputPath (Join-Path $tempLibraries 'chart.js.gz')
-        $pdfExportBundlePath = Compress-FileGzip -InputPath $pdfExportBundleSourcePath -OutputPath (Join-Path $tempLibraries 'pdf-export.bundle.js.gz')
-    }
     Write-MemoryUsage -Label "JS Libraries"
+    Invoke-PhaseTransitionGarbageCollection -MemoryLabel 'Pre-TemplateLoad'
 
     # Step 5: Load templates
     Write-Output "Loading templates..."
@@ -1441,6 +1438,7 @@ try {
     }
     $dataQualityMetaScript = '<script id="dataQualityMeta" type="application/json">' + ($dataQualityMeta | ConvertTo-Json -Compress) + '</script>'
     Write-MemoryUsage -Label "Post-Compress"
+    Invoke-PhaseTransitionGarbageCollection -MemoryLabel 'Pre-Assembly'
 
     # Step 8: Assemble final HTML
     Write-Output "Assembling dashboard HTML..."
@@ -1448,27 +1446,9 @@ try {
     $dashboardStatusBlobName = $Script:DashboardBlobName
     $dashboardStatusOutputPath = $null
 
-    if ($DashboardDeliveryMode -in @('SelfContained', 'Dual')) {
-        $selfContainedDashboardOutputPath = Join-Path -Path $tempDashboards -ChildPath $Script:DashboardBlobName
-        [void](Write-DashboardArtifactBundle `
-            -TemplateHtml $htmlTemplate `
-            -TemplateCss $cssContent `
-            -TemplateJs $jsContent `
-            -PakoLibraryPath $pakoLibraryPath `
-            -ChartJsLibraryPath $chartJsLibraryPath `
-            -ChartJsBundlePath $chartJsBundlePath `
-            -PdfExportBundleSourcePath $pdfExportBundleSourcePath `
-            -PdfExportBundlePath $pdfExportBundlePath `
-            -PayloadPath $tempPayloadPath `
-            -OutputPath $selfContainedDashboardOutputPath `
-            -LookupsJsonEscaped $lookupsJsonEscaped `
-            -DataQualitySectionHtml $dataQualitySectionHtml `
-            -DataQualityMetaScript $dataQualityMetaScript `
-            -SplitAssets $false)
-        $dashboardStatusOutputPath = $selfContainedDashboardOutputPath
-    }
-
     if ($DashboardDeliveryMode -in @('Hosted', 'Dual')) {
+        Set-PipelineExecutionStage -Stage 'WriteHostedDashboard' -Message 'Writing the hosted dashboard artifacts.'
+        [void](Write-PipelineExecutionStatus -AccountName $StorageAccountName -StorageToken $storageToken -Status 'running')
         $hostedDashboardOutputPath = Join-Path -Path $tempDashboards -ChildPath $(if ($useDualDashboard) { $Script:HostedDashboardBlobName } else { $Script:DashboardBlobName })
         $dashboardArtifacts = Write-DashboardArtifactBundle `
             -TemplateHtml $htmlTemplate `
@@ -1493,6 +1473,44 @@ try {
         if ($DashboardDeliveryMode -eq 'Hosted') {
             $dashboardStatusOutputPath = $hostedDashboardOutputPath
         }
+
+        $dashboardArtifacts = $null
+        Invoke-FullGarbageCollection
+        Write-MemoryUsage -Label 'Post-HostedAssembly'
+    }
+
+    if ($DashboardDeliveryMode -in @('SelfContained', 'Dual')) {
+        if ($requiresEmbeddedBundles -and [string]::IsNullOrWhiteSpace($chartJsBundlePath)) {
+            Write-Output '  Preparing embedded self-contained bundles...'
+            $chartJsBundlePath = Compress-FileGzip -InputPath $chartJsLibraryPath -OutputPath (Join-Path $tempLibraries 'chart.js.gz')
+            $pdfExportBundlePath = Compress-FileGzip -InputPath $pdfExportBundleSourcePath -OutputPath (Join-Path $tempLibraries 'pdf-export.bundle.js.gz')
+            Invoke-FullGarbageCollection
+            Write-MemoryUsage -Label 'Embedded Bundles'
+        }
+
+        Set-PipelineExecutionStage -Stage 'WriteSelfContainedDashboard' -Message 'Writing the self-contained dashboard artifact.'
+        [void](Write-PipelineExecutionStatus -AccountName $StorageAccountName -StorageToken $storageToken -Status 'running')
+        $selfContainedDashboardOutputPath = Join-Path -Path $tempDashboards -ChildPath $Script:DashboardBlobName
+        [void](Write-DashboardArtifactBundle `
+            -TemplateHtml $htmlTemplate `
+            -TemplateCss $cssContent `
+            -TemplateJs $jsContent `
+            -PakoLibraryPath $pakoLibraryPath `
+            -ChartJsLibraryPath $chartJsLibraryPath `
+            -ChartJsBundlePath $chartJsBundlePath `
+            -PdfExportBundleSourcePath $pdfExportBundleSourcePath `
+            -PdfExportBundlePath $pdfExportBundlePath `
+            -PayloadPath $tempPayloadPath `
+            -OutputPath $selfContainedDashboardOutputPath `
+            -LookupsJsonEscaped $lookupsJsonEscaped `
+            -DataQualitySectionHtml $dataQualitySectionHtml `
+            -DataQualityMetaScript $dataQualityMetaScript `
+            -SplitAssets $false)
+        $dashboardStatusOutputPath = $selfContainedDashboardOutputPath
+        $chartJsBundlePath = $null
+        $pdfExportBundlePath = $null
+        Invoke-FullGarbageCollection
+        Write-MemoryUsage -Label 'Post-SelfContainedAssembly'
     }
 
     $cssContent = $null

--- a/docs/performance-gate-playbook.md
+++ b/docs/performance-gate-playbook.md
@@ -40,6 +40,11 @@ Standard benchmark dataset:
 8. Append the benchmark JSON to `.local` history with `tests/Record-BenchmarkHistory.ps1`.
 9. Record accepted durable baselines in `docs/performance-baselines.md` and keep raw JSON artifacts under `.local/`.
 
+Guardrails:
+- `tests/Invoke-HotPhaseReview.ps1` now defaults to artifact parity review instead of semantic replay.
+- Use `-ValidationMode semantic` only when you are intentionally investigating semantic audit cost or validating semantic changes.
+- Large local semantic runs above the configured row limit require `-AllowLargeSemanticValidation` so they are not started accidentally.
+
 Timing interpretation:
 - Azure Automation already tracks active execution time from job start to job end.
 - Function App benchmark summaries now treat `function_app.elapsed_seconds` as active execution time when the runtime status blob is available.

--- a/src/powershell/Shared/Core/Core.ps1
+++ b/src/powershell/Shared/Core/Core.ps1
@@ -89,6 +89,21 @@ function Invoke-FullGarbageCollection {
     [System.GC]::Collect()
 }
 
+function Invoke-PhaseTransitionGarbageCollection {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $false)]
+        [AllowEmptyString()]
+        [string]$MemoryLabel
+    )
+
+    Invoke-FullGarbageCollection
+
+    if (-not [string]::IsNullOrWhiteSpace($MemoryLabel) -and (Get-Command -Name Write-MemoryUsage -ErrorAction SilentlyContinue)) {
+        Write-MemoryUsage -Label $MemoryLabel
+    }
+}
+
 function Test-IsAzureHostedEnvironment {
     [CmdletBinding()]
     [OutputType([bool])]
@@ -174,7 +189,11 @@ function New-ProgressMarkerState {
 
         [Parameter(Mandatory = $false)]
         [ValidateRange(1, 1000000)]
-        [int]$CheckInterval = 10000
+        [int]$CheckInterval = 10000,
+
+        [Parameter(Mandatory = $false)]
+        [ValidateRange(1, 9223372036854775807)]
+        [long]$TotalCount = 0
     )
 
     return [PSCustomObject]@{
@@ -182,6 +201,7 @@ function New-ProgressMarkerState {
         ProgressInterval = $ProgressInterval
         HeartbeatIntervalSeconds = $HeartbeatIntervalSeconds
         CheckInterval = [Math]::Max(1, [Math]::Min($ProgressInterval, $CheckInterval))
+        TotalCount = $TotalCount
         Stopwatch = [System.Diagnostics.Stopwatch]::StartNew()
         LastHeartbeatSecond = -1
     }
@@ -221,7 +241,15 @@ function Write-ProgressMarker {
     $elapsedSeconds = [Math]::Max(0.001, $State.Stopwatch.Elapsed.TotalSeconds)
     $rate = [Math]::Round(($Count / $elapsedSeconds), 0)
     $markerSuffix = if ($markerType -eq 'heartbeat') { ' [heartbeat]' } else { '' }
-    Write-Information ("  {0}: {1:N0} {2} processed in {3:N1}s ({4:N0}/s){5}" -f $State.ActivityName, $Count, $UnitLabel, [Math]::Round($elapsedSeconds, 1), $rate, $markerSuffix) -InformationAction Continue
+    $totalCount = if ($State.PSObject.Properties['TotalCount']) { [long]$State.TotalCount } else { 0L }
+    if ($totalCount -gt 0) {
+        $boundedCount = [Math]::Min([long]$Count, $totalCount)
+        $percentComplete = [Math]::Round(($boundedCount / [double]$totalCount) * 100.0, 1)
+        Write-Information ("  {0}: {1:N0}/{2:N0} {3} processed in {4:N1}s ({5:N0}/s, {6:N1}% complete){7}" -f $State.ActivityName, $boundedCount, $totalCount, $UnitLabel, [Math]::Round($elapsedSeconds, 1), $rate, $percentComplete, $markerSuffix) -InformationAction Continue
+    }
+    else {
+        Write-Information ("  {0}: {1:N0} {2} processed in {3:N1}s ({4:N0}/s){5}" -f $State.ActivityName, $Count, $UnitLabel, [Math]::Round($elapsedSeconds, 1), $rate, $markerSuffix) -InformationAction Continue
+    }
     $State.LastHeartbeatSecond = [Math]::Floor($State.Stopwatch.Elapsed.TotalSeconds)
 }
 

--- a/src/powershell/Shared/Dashboard/DashboardGeneration.ps1
+++ b/src/powershell/Shared/Dashboard/DashboardGeneration.ps1
@@ -297,7 +297,13 @@ function Write-Base64FileContent {
     $stream = $null
 
     try {
-        $stream = [System.IO.File]::OpenRead($FilePath)
+        $stream = [System.IO.FileStream]::new(
+            $FilePath,
+            [System.IO.FileMode]::Open,
+            [System.IO.FileAccess]::Read,
+            [System.IO.FileShare]::Read,
+            4096,
+            [System.IO.FileOptions]::SequentialScan)
         while (($bytesRead = $stream.Read($inputBuffer, $pendingByteCount, $inputBlockByteCount)) -gt 0) {
             $totalByteCount = $pendingByteCount + $bytesRead
             $bytesToEncode = if ($stream.Position -lt $stream.Length) {
@@ -1893,8 +1899,16 @@ function Write-TemplatedHtml {
     )
 
     $writer = $null
+    $outputStream = $null
     try {
-        $writer = [System.IO.StreamWriter]::new($OutputPath, $false, [System.Text.UTF8Encoding]::new($false))
+        $outputStream = [System.IO.FileStream]::new(
+            $OutputPath,
+            [System.IO.FileMode]::Create,
+            [System.IO.FileAccess]::Write,
+            [System.IO.FileShare]::Read,
+            4096,
+            [System.IO.FileOptions]::WriteThrough)
+        $writer = [System.IO.StreamWriter]::new($outputStream, [System.Text.UTF8Encoding]::new($false), 4096, $false)
         $position = 0
         foreach ($segment in $Segments) {
             $placeholder = $segment.Placeholder
@@ -1922,6 +1936,9 @@ function Write-TemplatedHtml {
     finally {
         if ($writer) {
             $writer.Dispose()
+        }
+        elseif ($outputStream) {
+            $outputStream.Dispose()
         }
     }
 }
@@ -4908,6 +4925,25 @@ function Resolve-NormalizedContentLookup {
     }
 }
 
+function Get-NormalizedContentLookupCacheEntry {
+    [CmdletBinding()]
+    [OutputType([object[]])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [pscustomobject]$ContentLookup
+    )
+
+    return [object[]]@(
+        $ContentLookup.sw,
+        $ContentLookup.cve,
+        $ContentLookup.ver,
+        $ContentLookup.upd,
+        $ContentLookup.ua,
+        $ContentLookup.dp,
+        $ContentLookup.rp
+    )
+}
+
 function Get-NormalizedRecordLookup {
     [CmdletBinding()]
     [OutputType([pscustomobject])]
@@ -5329,7 +5365,7 @@ function Test-NormalizedWriterRowCount {
     }
 }
 
-function New-NoOnboardedVulnerabilityMessage {
+function Get-NoOnboardedVulnerabilityMessage {
     [CmdletBinding()]
     [OutputType([string])]
     param(
@@ -5457,6 +5493,13 @@ function Invoke-ContentStoreNormalization {
     $deviceLookupIndices = [System.Collections.Generic.List[int]]::new()
     $deviceOnboardedFlags = [System.Collections.Generic.List[bool]]::new()
     $contentLookupCache = [System.Collections.Generic.List[object]]::new()
+    $contentLookupSwIndex = 0
+    $contentLookupCveIndex = 1
+    $contentLookupVersionIndex = 2
+    $contentLookupUpdateIndex = 3
+    $contentLookupUpdateAvailableIndex = 4
+    $contentLookupDiskPathIndex = 5
+    $contentLookupRegistryPathIndex = 6
     $processedCountRef = [ref]0
     $firstLastSwappedCountRef = [ref]0
     $writerState = $null
@@ -5496,7 +5539,7 @@ function Invoke-ContentStoreNormalization {
                 $softwareVersion
             )) | Out-Null
 
-        $contentLookupCache.Add((Resolve-NormalizedContentLookup `
+        $contentLookupCache.Add((Get-NormalizedContentLookupCacheEntry -ContentLookup (Resolve-NormalizedContentLookup `
                 -SoftwareVendor $softwareVendor `
                 -SoftwareName $softwareName `
                 -RecommendationReference ([string](Get-VulnPropertyValue -InputObject $contentTemplate -Name 'rr')) `
@@ -5513,13 +5556,22 @@ function Invoke-ContentStoreNormalization {
                 -DiskPaths @(Get-StringArray -Value (Get-VulnPropertyValue -InputObject $contentTemplate -Name 'dp')) `
                 -RegistryPaths @(Get-StringArray -Value (Get-VulnPropertyValue -InputObject $contentTemplate -Name 'rp')) `
                 -SecurityUpdateAvailable ((Get-VulnPropertyValue -InputObject $contentTemplate -Name 'ua') -eq $true) `
-                -Context $Context)) | Out-Null
+                -Context $Context))) | Out-Null
     }
 
     $contentTemplates = $contentInventoryKeys.ToArray()
     $contentLookupCache = $contentLookupCache.ToArray()
     $contentTemplateCount = $contentTemplates.Length
     $contentInventoryKeys = $null
+
+    # Ref streaming only needs the compact device/content lookup arrays plus
+    # inventory enrichment. Release the larger source maps before processing
+    # the full ref set so they do not overlap with the row stream.
+    $Context.Machines = @{}
+    $Context.AdvancedHuntingData = @{}
+    $Context.AdvancedHuntingDeviceUsers = @{}
+    $Context.NvdCveData = @{}
+    Invoke-FullGarbageCollection
 
     try {
         $writerState = Open-NormalizedVulnWriter -VulnOutputPath $VulnOutputPath -VulnColumnDirectoryPath $VulnColumnDirectoryPath -PayloadOutputPath $PayloadOutputPath
@@ -5644,15 +5696,15 @@ function Invoke-ContentStoreNormalization {
                             $contentTemplate = $contentTemplates[$contentTemplateIndexValue]
                             $deviceProfileId = $deviceProfiles[$deviceProfileIndexValue]
                             $compactRecord[0] = $deviceLookupIndices[$deviceProfileIndexValue]
-                            $compactRecord[1] = $contentLookup.cve
-                            $compactRecord[2] = $contentLookup.sw
-                            $compactRecord[3] = $contentLookup.ver
+                            $compactRecord[1] = $contentLookup[$contentLookupCveIndex]
+                            $compactRecord[2] = $contentLookup[$contentLookupSwIndex]
+                            $compactRecord[3] = $contentLookup[$contentLookupVersionIndex]
                             $compactRecord[4] = Get-OrCreateIndex -value $firstSeen -list $lookups.dates -indexMap $dateIndex
                             $compactRecord[5] = Get-OrCreateIndex -value $lastSeen -list $lookups.dates -indexMap $dateIndex
-                            $compactRecord[6] = $contentLookup.ua
-                            $compactRecord[7] = $contentLookup.upd
-                            $compactRecord[8] = $contentLookup.dp
-                            $compactRecord[9] = $contentLookup.rp
+                            $compactRecord[6] = $contentLookup[$contentLookupUpdateAvailableIndex]
+                            $compactRecord[7] = $contentLookup[$contentLookupUpdateIndex]
+                            $compactRecord[8] = $contentLookup[$contentLookupDiskPathIndex]
+                            $compactRecord[9] = $contentLookup[$contentLookupRegistryPathIndex]
                             $compactRecord[10] = Resolve-NormalizedInventoryLookup `
                                 -DeviceId ([string]$deviceProfileId) `
                                 -SoftwareVendor ([string]$contentTemplate[0]) `
@@ -5935,7 +5987,7 @@ function Invoke-ContentStoreNormalization {
             $refLabels.Add([string]$refPath.Label) | Out-Null
         }
 
-        throw (New-NoOnboardedVulnerabilityMessage `
+        throw (Get-NoOnboardedVulnerabilityMessage `
                 -DataPath $DataPath `
                 -SourceKind 'content-store refs' `
                 -DeviceProfileCount $deviceProfileCount `
@@ -6948,7 +7000,7 @@ function ConvertTo-NormalizedData {
     }
 
     if ($processedCount -eq 0) {
-        throw (New-NoOnboardedVulnerabilityMessage -DataPath $DataPath -SourceKind 'export files')
+        throw (Get-NoOnboardedVulnerabilityMessage -DataPath $DataPath -SourceKind 'export files')
     }
     Write-Information "  Loaded $processedCount onboarded vulnerability records" -InformationAction Continue
 

--- a/src/powershell/Validation/Audit/LargeDatasetAudit.ps1
+++ b/src/powershell/Validation/Audit/LargeDatasetAudit.ps1
@@ -513,7 +513,11 @@ function Write-PartitionedSignatureSet {
         [string]$OutputDirectoryPath,
 
         [Parameter(Mandatory = $false)]
-        [switch]$Persistent
+        [switch]$Persistent,
+
+        [Parameter(Mandatory = $false)]
+        [ValidateRange(1, 2147483647)]
+        [int]$ExpectedTotalCount = 0
     )
 
     $directoryPath = if (-not [string]::IsNullOrWhiteSpace($OutputDirectoryPath)) {
@@ -530,7 +534,7 @@ function Write-PartitionedSignatureSet {
 
     $writers = [System.IO.StreamWriter[]]::new($PartitionCount)
     $count = 0
-    $progressState = New-ProgressMarkerState -ActivityName ("Partitioned {0}" -f $Label) -ProgressInterval $ProgressInterval -HeartbeatIntervalSeconds $Script:DashboardValidationHeartbeatSeconds -CheckInterval ([Math]::Min($ProgressInterval, 10000))
+    $progressState = New-ProgressMarkerState -ActivityName ("Partitioned {0}" -f $Label) -ProgressInterval $ProgressInterval -HeartbeatIntervalSeconds $Script:DashboardValidationHeartbeatSeconds -CheckInterval ([Math]::Min($ProgressInterval, 10000)) -TotalCount $ExpectedTotalCount
     try {
         & $SignatureSource | ForEach-Object {
             $resolvedSignature = [string]$_
@@ -839,12 +843,16 @@ function Get-SourceVendorSetForAudit {
         [string]$ExportsPath,
 
         [Parameter(Mandatory = $false)]
-        [switch]$SkipObservedWindowMerge
+        [switch]$SkipObservedWindowMerge,
+
+        [Parameter(Mandatory = $false)]
+        [ValidateRange(1, 2147483647)]
+        [int]$ExpectedTotalCount = 0
     )
 
     $vendorSet = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
     $processedCount = 0
-    $progressState = New-ProgressMarkerState -ActivityName 'Indexed source vendors' -ProgressInterval $Script:DashboardValidationProgressInterval -HeartbeatIntervalSeconds $Script:DashboardValidationHeartbeatSeconds -CheckInterval 10000
+    $progressState = New-ProgressMarkerState -ActivityName 'Indexed source vendors' -ProgressInterval $Script:DashboardValidationProgressInterval -HeartbeatIntervalSeconds $Script:DashboardValidationHeartbeatSeconds -CheckInterval 10000 -TotalCount $ExpectedTotalCount
     Read-SourceAuditRecordStream -ExportsPath $ExportsPath -SkipObservedWindowMerge:$SkipObservedWindowMerge | ForEach-Object {
         $record = $_
         if ((Get-VulnPropertyValue -InputObject $record -Name 'IsOnboarded') -eq $true) {
@@ -890,13 +898,17 @@ function Read-SourceCanonicalSignatureStream {
         [ref]$FirstLastSwappedCount = ([ref]0),
 
         [Parameter(Mandatory = $false)]
-        [ref]$MissingMachineCount = ([ref]0)
+        [ref]$MissingMachineCount = ([ref]0),
+
+        [Parameter(Mandatory = $false)]
+        [ValidateRange(1, 2147483647)]
+        [int]$ExpectedTotalCount = 0
     )
 
     $deviceProfiles = @{}
     $cveEnrichmentCache = @{}
     $processedCount = 0
-    $progressState = New-ProgressMarkerState -ActivityName 'Canonicalized source' -ProgressInterval $Script:DashboardValidationProgressInterval -HeartbeatIntervalSeconds $Script:DashboardValidationHeartbeatSeconds -CheckInterval 10000
+    $progressState = New-ProgressMarkerState -ActivityName 'Canonicalized source' -ProgressInterval $Script:DashboardValidationProgressInterval -HeartbeatIntervalSeconds $Script:DashboardValidationHeartbeatSeconds -CheckInterval 10000 -TotalCount $ExpectedTotalCount
 
     Read-SourceAuditRecordStream -ExportsPath $ExportsPath -SkipObservedWindowMerge:$SkipObservedWindowMerge | ForEach-Object {
         $record = $_
@@ -1963,13 +1975,13 @@ function Get-StreamingDashboardAuditResult {
                 $advancedHuntingLoadElapsedSeconds = [math]::Round($advancedHuntingLoadStopwatch.Elapsed.TotalSeconds, 2)
 
                 $vendorIndexStopwatch = [System.Diagnostics.Stopwatch]::StartNew()
-                $vendorSet = Get-SourceVendorSetForAudit -ExportsPath $ResolvedExportsPath -SkipObservedWindowMerge:$skipObservedWindowMerge
+                $vendorSet = Get-SourceVendorSetForAudit -ExportsPath $ResolvedExportsPath -SkipObservedWindowMerge:$skipObservedWindowMerge -ExpectedTotalCount $cachedPayloadRowCount
                 $vendorIndexStopwatch.Stop()
                 $vendorIndexElapsedSeconds = [math]::Round($vendorIndexStopwatch.Elapsed.TotalSeconds, 2)
                 $sourceUniqueVendors = @($vendorSet | Sort-Object)
 
                 if (-not [string]::IsNullOrWhiteSpace($currentSourceFingerprint)) {
-                    $sourceSignatureSet = Write-PartitionedSignatureSet -Label 'source' -ProgressInterval $Script:DashboardValidationProgressInterval -OutputDirectoryPath (Get-SourceSignatureCacheDirectory -PayloadCacheEntry $PayloadCacheEntry -SourceFingerprint $currentSourceFingerprint -Create) -Persistent -SignatureSource {
+                        $sourceSignatureSet = Write-PartitionedSignatureSet -Label 'source' -ProgressInterval $Script:DashboardValidationProgressInterval -OutputDirectoryPath (Get-SourceSignatureCacheDirectory -PayloadCacheEntry $PayloadCacheEntry -SourceFingerprint $currentSourceFingerprint -Create) -Persistent -ExpectedTotalCount $cachedPayloadRowCount -SignatureSource {
                         Read-SourceCanonicalSignatureStream `
                             -ExportsPath $ResolvedExportsPath `
                             -Machines $machines `
@@ -1979,13 +1991,14 @@ function Get-StreamingDashboardAuditResult {
                             -VendorSet $vendorSet `
                             -SkipObservedWindowMerge:$skipObservedWindowMerge `
                             -FirstLastSwappedCount ([ref]$sourceFirstLastSwappedCount) `
-                            -MissingMachineCount ([ref]$sourceMissingMachineCount)
+                            -MissingMachineCount ([ref]$sourceMissingMachineCount) `
+                            -ExpectedTotalCount $cachedPayloadRowCount
                     }
                     Write-CachedSourceSignatureSetMetadata -PayloadCacheEntry $PayloadCacheEntry -SourceFingerprint $currentSourceFingerprint -SignatureSet $sourceSignatureSet -SourceMissingMachineCount $sourceMissingMachineCount -SourceFirstLastSwappedCount $sourceFirstLastSwappedCount -SourceUniqueVendors $sourceUniqueVendors | Out-Null
                     Write-Information '  Cached source signature set for future semantic comparisons.' -InformationAction Continue
                 }
                 else {
-                    $sourceSignatureSet = Write-PartitionedSignatureSet -Label 'source' -ProgressInterval $Script:DashboardValidationProgressInterval -SignatureSource {
+                        $sourceSignatureSet = Write-PartitionedSignatureSet -Label 'source' -ProgressInterval $Script:DashboardValidationProgressInterval -ExpectedTotalCount $cachedPayloadRowCount -SignatureSource {
                         Read-SourceCanonicalSignatureStream `
                             -ExportsPath $ResolvedExportsPath `
                             -Machines $machines `
@@ -1995,7 +2008,8 @@ function Get-StreamingDashboardAuditResult {
                             -VendorSet $vendorSet `
                             -SkipObservedWindowMerge:$skipObservedWindowMerge `
                             -FirstLastSwappedCount ([ref]$sourceFirstLastSwappedCount) `
-                            -MissingMachineCount ([ref]$sourceMissingMachineCount)
+                            -MissingMachineCount ([ref]$sourceMissingMachineCount) `
+                            -ExpectedTotalCount $cachedPayloadRowCount
                     }
                 }
             }
@@ -2011,7 +2025,7 @@ function Get-StreamingDashboardAuditResult {
                     Write-Information '  Reusing cached payload signature set for semantic comparison.' -InformationAction Continue
                 }
                 else {
-                    $payloadSignatureSet = Write-PartitionedSignatureSet -Label $comparisonPayloadLabel -ProgressInterval $Script:DashboardValidationProgressInterval -OutputDirectoryPath (Get-PayloadSignatureCacheDirectory -PayloadCacheEntry $PayloadCacheEntry -Create) -Persistent -SignatureSource {
+                    $payloadSignatureSet = Write-PartitionedSignatureSet -Label $comparisonPayloadLabel -ProgressInterval $Script:DashboardValidationProgressInterval -OutputDirectoryPath (Get-PayloadSignatureCacheDirectory -PayloadCacheEntry $PayloadCacheEntry -Create) -Persistent -ExpectedTotalCount $cachedPayloadRowCount -SignatureSource {
                         Read-PayloadCanonicalSignatureStream -PayloadPath $comparisonPayloadPath
                     }
                     Write-CachedPayloadSignatureSetMetadata -PayloadCacheEntry $PayloadCacheEntry -PayloadSha256 $cachedPayloadSha256 -PayloadRowCount $cachedPayloadRowCount -SignatureSet $payloadSignatureSet | Out-Null
@@ -2019,7 +2033,7 @@ function Get-StreamingDashboardAuditResult {
                 }
             }
             else {
-                $payloadSignatureSet = Write-PartitionedSignatureSet -Label $comparisonPayloadLabel -ProgressInterval $Script:DashboardValidationProgressInterval -SignatureSource {
+                $payloadSignatureSet = Write-PartitionedSignatureSet -Label $comparisonPayloadLabel -ProgressInterval $Script:DashboardValidationProgressInterval -ExpectedTotalCount $dashboardPayloadRowCount -SignatureSource {
                     Read-PayloadCanonicalSignatureStream -PayloadPath $comparisonPayloadPath
                 }
             }

--- a/tests/Invoke-HotPhaseReview.ps1
+++ b/tests/Invoke-HotPhaseReview.ps1
@@ -15,6 +15,17 @@ param(
     [switch]$ForceFullValidation,
 
     [Parameter(Mandatory = $false)]
+    [ValidateSet('artifacts', 'semantic')]
+    [string]$ValidationMode = 'artifacts',
+
+    [Parameter(Mandatory = $false)]
+    [switch]$AllowLargeSemanticValidation,
+
+    [Parameter(Mandatory = $false)]
+    [ValidateRange(100000, 50000000)]
+    [int]$SemanticValidationRowLimit = 1000000,
+
+    [Parameter(Mandatory = $false)]
     [ValidateRange(15, 3600)]
     [int]$ValidationHeartbeatSeconds = 60,
 
@@ -61,6 +72,84 @@ function Get-HeartbeatTimestampText {
     param()
 
     return (Get-Date).ToString('yyyy-MM-dd HH:mm:ss')
+}
+
+function Add-PathSuffixBeforeExtensionLocal {
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Path,
+
+        [Parameter(Mandatory = $true)]
+        [string]$Suffix
+    )
+
+    $extension = [System.IO.Path]::GetExtension($Path)
+    if ([string]::IsNullOrEmpty($extension)) {
+        return ($Path + $Suffix)
+    }
+
+    return ($Path.Substring(0, $Path.Length - $extension.Length) + $Suffix + $extension)
+}
+
+function Get-DatasetRowCountForReview {
+    [CmdletBinding()]
+    [OutputType([int])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Path
+    )
+
+    $manifestPath = Join-Path $Path 'synthetic-manifest.json'
+    if (-not (Test-Path -LiteralPath $manifestPath -PathType Leaf)) {
+        return 0
+    }
+
+    $manifest = Get-Content -Path $manifestPath -Raw | ConvertFrom-Json -Depth 20
+    if ($manifest.PSObject.Properties['actualTotalVulnRows']) {
+        return [int]$manifest.actualTotalVulnRows
+    }
+
+    if ($manifest.PSObject.Properties['actualCurrentRows'] -and $manifest.PSObject.Properties['actualHistoryRows']) {
+        return ([int]$manifest.actualCurrentRows + [int]$manifest.actualHistoryRows)
+    }
+
+    return 0
+}
+
+function Invoke-GeneratedArtifactValidation {
+    [CmdletBinding()]
+    [OutputType([pscustomobject])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$SelfContainedPath,
+
+        [Parameter(Mandatory = $true)]
+        [string]$HostedPath
+    )
+
+    $validatorScriptPath = Join-Path $PSScriptRoot 'Validate-DashboardGeneratedArtifacts.js'
+    if (-not (Test-Path -LiteralPath $validatorScriptPath -PathType Leaf)) {
+        throw "Artifact validator '$validatorScriptPath' was not found."
+    }
+
+    $nodeCommand = Get-Command -Name 'node' -ErrorAction Stop
+    & $nodeCommand.Source $validatorScriptPath $SelfContainedPath $HostedPath
+
+    $validatorExitCode = [int]$global:LASTEXITCODE
+    if ($validatorExitCode -ne 0) {
+        throw "Generated artifact validation failed with exit code $validatorExitCode."
+    }
+
+    return [PSCustomObject]@{
+        mode = 'generated-artifact-parity'
+        validatorScriptPath = [System.IO.Path]::GetFullPath($validatorScriptPath)
+        selfContainedPath = [System.IO.Path]::GetFullPath($SelfContainedPath)
+        hostedPath = [System.IO.Path]::GetFullPath($HostedPath)
+        hostedAssetsPath = Join-Path (Split-Path -Path (Resolve-Path -LiteralPath $HostedPath).Path -Parent) (([System.IO.Path]::GetFileNameWithoutExtension($HostedPath)) + '.assets')
+        passed = $true
+    }
 }
 
 function Get-HeartbeatFileStatus {
@@ -476,8 +565,25 @@ $dashboardScript = Join-Path $repoRoot 'Generate-VulnerabilityDashboard.ps1'
 $resolvedDirectoryPath = [System.IO.Path]::GetFullPath($DirectoryPath)
 $resolvedOutputRoot = [System.IO.Path]::GetFullPath($OutputRoot)
 
+if ($ValidationMode -eq 'artifacts' -and $ForceFullValidation) {
+    throw '-ForceFullValidation is only supported with -ValidationMode semantic.'
+}
+
+if ($ValidationMode -eq 'artifacts' -and $SplitAssets) {
+    throw '-SplitAssets cannot be combined with -ValidationMode artifacts. Use the default dual-package artifact review or switch to -ValidationMode semantic.'
+}
+
 if (-not (Test-Path -LiteralPath $resolvedDirectoryPath -PathType Container)) {
     throw "Directory '$resolvedDirectoryPath' was not found."
+}
+
+$datasetRowCount = Get-DatasetRowCountForReview -Path $resolvedDirectoryPath
+if ($ValidationMode -eq 'semantic' -and $datasetRowCount -gt $SemanticValidationRowLimit -and -not $AllowLargeSemanticValidation) {
+    throw ("Semantic hot phase review is blocked for datasets above {0:N0} row(s). '{1}' reports {2:N0} row(s). Re-run with -AllowLargeSemanticValidation only when you explicitly want the long semantic replay, or use -ValidationMode artifacts." -f $SemanticValidationRowLimit, $resolvedDirectoryPath, $datasetRowCount)
+}
+
+if ($ValidationMode -eq 'semantic' -and $datasetRowCount -gt $SemanticValidationRowLimit -and $AllowLargeSemanticValidation) {
+    Write-Warning ("Large semantic hot phase review override enabled for {0:N0} row(s)." -f $datasetRowCount)
 }
 
 if (-not (Test-Path -LiteralPath $resolvedOutputRoot -PathType Container)) {
@@ -485,15 +591,21 @@ if (-not (Test-Path -LiteralPath $resolvedOutputRoot -PathType Container)) {
 }
 
 $dashboardPath = Join-Path $resolvedOutputRoot 'VulnerabilityDashboard.html'
-$auditPath = Join-Path $resolvedOutputRoot 'dashboard-audit.json'
+$hostedDashboardPath = Add-PathSuffixBeforeExtensionLocal -Path $dashboardPath -Suffix '.Hosted'
+$auditPath = if ($ValidationMode -eq 'semantic') { Join-Path $resolvedOutputRoot 'dashboard-audit.json' } else { $null }
 $stdoutPath = Join-Path $resolvedOutputRoot 'hot-phase-review.stdout.log'
 $stderrPath = Join-Path $resolvedOutputRoot 'hot-phase-review.stderr.log'
 $reportPath = Join-Path $resolvedOutputRoot 'hot-phase-review.json'
 
-foreach ($path in @($dashboardPath, $auditPath, $stdoutPath, $stderrPath, $reportPath)) {
+foreach ($path in @($dashboardPath, $hostedDashboardPath, $auditPath, $stdoutPath, $stderrPath, $reportPath) | Where-Object { -not [string]::IsNullOrWhiteSpace($_) }) {
     if (Test-Path -LiteralPath $path) {
         Remove-Item -LiteralPath $path -Recurse -Force -ErrorAction SilentlyContinue
     }
+}
+
+$hostedAssetsPath = Join-Path (Split-Path -Path $hostedDashboardPath -Parent) (([System.IO.Path]::GetFileNameWithoutExtension($hostedDashboardPath)) + '.assets')
+if (Test-Path -LiteralPath $hostedAssetsPath -PathType Container) {
+    Remove-Item -LiteralPath $hostedAssetsPath -Recurse -Force -ErrorAction SilentlyContinue
 }
 
 $argumentList = @(
@@ -502,12 +614,18 @@ $argumentList = @(
     '-DirectoryPath', $resolvedDirectoryPath
     '-OutputPath', $dashboardPath
     '-ExportMachineData:$false'
-    '-Validate'
-    '-ValidationOutputPath', $auditPath
     '-ValidationHeartbeatSeconds', $ValidationHeartbeatSeconds
     '-ValidationPartitionCompareParallelism', $ValidationPartitionCompareParallelism
 )
-if ($SplitAssets) {
+if ($ValidationMode -eq 'semantic') {
+    $argumentList += '-Validate'
+    $argumentList += '-ValidationOutputPath', $auditPath
+}
+else {
+    $argumentList += '-DualPackage'
+    $argumentList += '-HostedOutputPath', $hostedDashboardPath
+}
+if ($ValidationMode -eq 'semantic' -and $SplitAssets) {
     $argumentList += '-SplitAssets'
 }
 if ($ForceFullValidation) {
@@ -544,7 +662,13 @@ Add-MeasurementSample -Samples $samples -Process $process -Stopwatch $stopwatch 
 $stopwatch.Stop()
 
 $generatorPhases = Get-LocalPhaseSummaryFromLog -Path $stdoutPath
-$audit = if (Test-Path -LiteralPath $auditPath -PathType Leaf) {
+$artifactValidationSummary = if ($ValidationMode -eq 'artifacts') {
+    Invoke-GeneratedArtifactValidation -SelfContainedPath $dashboardPath -HostedPath $hostedDashboardPath
+}
+else {
+    $null
+}
+$audit = if ($ValidationMode -eq 'semantic' -and (Test-Path -LiteralPath $auditPath -PathType Leaf)) {
     Get-Content -Path $auditPath -Raw | ConvertFrom-Json -Depth 100
 }
 else {
@@ -566,6 +690,10 @@ if ($topValidationPhase.Count -gt 0) {
 }
 elseif ($null -ne $audit) {
     $observations.Add('Validation audit completed without semantic phase timings for this dataset shape.') | Out-Null
+}
+
+if ($null -ne $artifactValidationSummary) {
+    $observations.Add('Artifact validation compared hosted and self-contained outputs instead of running semantic replay.') | Out-Null
 }
 
 if ($null -ne $auditSummary -and $auditSummary.attestationUsed) {
@@ -595,19 +723,25 @@ $report = [PSCustomObject]@{
     }
     artifacts = [PSCustomObject]@{
         dashboardPath = $dashboardPath
-        auditPath = if (Test-Path -LiteralPath $auditPath -PathType Leaf) { $auditPath } else { $null }
+        hostedDashboardPath = if (Test-Path -LiteralPath $hostedDashboardPath -PathType Leaf) { $hostedDashboardPath } else { $null }
+        auditPath = if (-not [string]::IsNullOrWhiteSpace($auditPath) -and (Test-Path -LiteralPath $auditPath -PathType Leaf)) { $auditPath } else { $null }
         stdoutPath = $stdoutPath
         stderrPath = $stderrPath
         reportPath = $reportPath
     }
     review = [PSCustomObject]@{
+        validationMode = $ValidationMode
         validationHeartbeatSeconds = $ValidationHeartbeatSeconds
         validationPartitionCompareParallelism = $ValidationPartitionCompareParallelism
         splitAssets = ($SplitAssets -eq $true)
         forceFullValidation = ($ForceFullValidation -eq $true)
+        allowLargeSemanticValidation = ($AllowLargeSemanticValidation -eq $true)
+        semanticValidationRowLimit = $SemanticValidationRowLimit
+        datasetRowCount = $datasetRowCount
     }
     generatorPhases = @($generatorPhases)
     validationAuditSummary = $auditSummary
+    artifactValidationSummary = $artifactValidationSummary
     validationPhases = @($validationPhases)
     hotPhases = @($hotPhases)
     observations = @($observations)

--- a/tests/Invoke-LargeDatasetValidation.ps1
+++ b/tests/Invoke-LargeDatasetValidation.ps1
@@ -61,6 +61,13 @@ param(
     [string]$ValidationMode = 'semantic',
 
     [Parameter(Mandatory = $false)]
+    [switch]$AllowLargeSemanticValidation,
+
+    [Parameter(Mandatory = $false)]
+    [ValidateRange(100000, 50000000)]
+    [int]$SemanticValidationRowLimit = 1000000,
+
+    [Parameter(Mandatory = $false)]
     [string]$DashboardOutputPath,
 
     [Parameter(Mandatory = $false)]
@@ -549,6 +556,15 @@ else {
         $historyPath = $historyRowsFile.FullName
         $historyRowCount += Get-StreamingCount -Source { Read-VulnNdjsonLinesFromPath -Path $historyPath }
     }
+}
+
+$totalVulnRowCount = ($currentRowCount + $historyRowCount)
+if ($resolvedValidationMode -eq 'semantic' -and $totalVulnRowCount -gt $SemanticValidationRowLimit -and -not $AllowLargeSemanticValidation) {
+    throw ("Semantic large-dataset validation is blocked for datasets above {0:N0} row(s). '{1}' contains {2:N0} row(s). Re-run with -AllowLargeSemanticValidation only when you explicitly want the long semantic replay, or switch to -ValidationMode artifacts." -f $SemanticValidationRowLimit, $resolvedSyntheticPath, $totalVulnRowCount)
+}
+
+if ($resolvedValidationMode -eq 'semantic' -and $totalVulnRowCount -gt $SemanticValidationRowLimit -and $AllowLargeSemanticValidation) {
+    Write-Warning ("Large semantic validation override enabled for {0:N0} row(s)." -f $totalVulnRowCount)
 }
 
 $generateArgs = @{

--- a/tests/Measure-StressRun.ps1
+++ b/tests/Measure-StressRun.ps1
@@ -21,6 +21,17 @@ param(
     [switch]$Validate,
 
     [Parameter(Mandatory = $false)]
+    [ValidateSet('artifacts', 'semantic')]
+    [string]$ValidationMode = 'artifacts',
+
+    [Parameter(Mandatory = $false)]
+    [switch]$AllowLargeSemanticValidation,
+
+    [Parameter(Mandatory = $false)]
+    [ValidateRange(100000, 50000000)]
+    [int]$SemanticValidationRowLimit = 1000000,
+
+    [Parameter(Mandatory = $false)]
     [ValidateRange(1, 60)]
     [int]$PollIntervalSeconds = 5
 )
@@ -201,12 +212,23 @@ $command = @(
 )
 if ($Validate) {
     $command += '-Validate'
+    $command += '-ValidationMode'
+    $command += $ValidationMode
+    $command += '-SemanticValidationRowLimit'
+    $command += [string]$SemanticValidationRowLimit
+    if ($AllowLargeSemanticValidation) {
+        $command += '-AllowLargeSemanticValidation'
+    }
 }
 
 Write-Output ("Benchmarking {0}..." -f $Name)
 Write-Output ("  Dataset: {0}" -f $resolvedSyntheticPath)
 Write-Output ("  Dashboard: {0}" -f $resolvedDashboardPath)
 Write-Output ("  Clear cache: {0}" -f ($ClearDashboardCache -eq $true))
+Write-Output ("  Validate: {0}" -f ($Validate -eq $true))
+if ($Validate) {
+    Write-Output ("  Validation mode: {0}" -f $ValidationMode)
+}
 
 $process = Start-Process -FilePath $command[0] `
     -ArgumentList $command[1..($command.Count - 1)] `
@@ -303,6 +325,12 @@ $stopwatch.Stop()
 $report = [PSCustomObject]@{
     name = $Name
     command = $command
+    validation = [PSCustomObject]@{
+        validate = ($Validate -eq $true)
+        validationMode = if ($Validate) { $ValidationMode } else { 'none' }
+        allowLargeSemanticValidation = ($AllowLargeSemanticValidation -eq $true)
+        semanticValidationRowLimit = $SemanticValidationRowLimit
+    }
     dashboard_output_path = $resolvedDashboardPath
     stdout_path = $stdoutPath
     stderr_path = $stderrPath

--- a/tests/Run-SharedHelperRegression.ps1
+++ b/tests/Run-SharedHelperRegression.ps1
@@ -23,6 +23,26 @@ function Assert-True {
     }
 }
 
+function Get-OutputRecordText {
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory = $false)]
+        [AllowNull()]
+        $Record
+    )
+
+    if ($null -eq $Record) {
+        return $null
+    }
+
+    if ($Record -is [System.Management.Automation.InformationRecord]) {
+        return [string]$Record.MessageData
+    }
+
+    return ($Record | Out-String).Trim()
+}
+
 function Get-TestVulnRow {
     [CmdletBinding()]
     param(
@@ -1999,6 +2019,105 @@ function Test-ConvertToNormalizedDataContentStorePathDoesNotUseLegacyDictionaryR
     }
 }
 
+function Test-InvokeContentStoreNormalizationReleasesTransientContextBeforePayloadClose {
+    [CmdletBinding()]
+    param()
+
+    $tempRoot = Join-Path ([System.IO.Path]::GetTempPath()) ('normalized-content-store-context-release-' + [guid]::NewGuid().ToString('N'))
+    [void](New-Item -Path $tempRoot -ItemType Directory -Force)
+    $outputPath = Join-Path $tempRoot 'normalized-vulns.json'
+    $payloadPath = Join-Path $tempRoot 'payload.json.gz'
+
+    try {
+        $currentRow = Get-TestVulnRow -Id 'content-store-context-release-001' -CveId 'CVE-2026-0154' -SnapshotDate '2026-03-20' -Version '2.0.0'
+        $currentRow.DeviceId = 'device-context-release-001'
+        $currentRow.DeviceName = 'device-context-release-001.contoso.com'
+
+        Write-NdjsonRecordsFile -Path (Get-VulnCurrentPath -BasePath $tempRoot) -Records @($currentRow)
+        Publish-VulnContentStoreUnlocked -BasePath $tempRoot
+
+        $context = Get-NormalizationContext
+        $machines = @{
+            'device-context-release-001' = [PSCustomObject]@{
+                id = 'device-context-release-001'
+                computerDnsName = 'device-context-release-001.contoso.com'
+                rbacGroupName = 'Prod'
+                osPlatform = 'Windows 11'
+                osVersion = '10.0.26100'
+                machineTags = @('Prod')
+                lastIpAddress = '10.0.0.21'
+                lastExternalIpAddress = '52.0.0.21'
+                healthStatus = 'Active'
+                riskScore = 'Medium'
+                exposureLevel = 'Low'
+                deviceValue = 'Normal'
+                managedBy = 'Intune'
+                isAadJoined = $true
+                lastSeen = '2026-03-20'
+                firstSeen = '2026-03-01'
+            }
+        }
+        $advancedHuntingData = @{
+            'CVE-2026-0154' = @{
+                PublishedDate = '2026-03-20'
+                VulnerabilityDescription = 'Context release regression.'
+                EpssScore = 0.18
+                AffectedSoftware = @('contoso:legacy_agent')
+            }
+        }
+        $advancedHuntingDeviceUsers = @{
+            'device-context-release-001' = @('alice@contoso.com')
+        }
+        $advancedHuntingInventoryData = @{
+            (Get-AdvancedHuntingInventoryMatchKey -DeviceId 'device-context-release-001' -SoftwareVendor 'Contoso' -SoftwareName 'Legacy Agent' -SoftwareVersion '2.0.0') = [PSCustomObject]@{
+                ProductCodeCpe = 'cpe:/a:contoso:legacy_agent:2.0.0'
+                EndOfSupportStatus = 'supported'
+                EndOfSupportDate = '2027-12-31'
+            }
+        }
+        $nvdCveData = @{
+            'CVE-2026-0154' = [PSCustomObject]@{
+                PublishedDate = '2026-03-19'
+                LastModifiedDate = '2026-03-21'
+                VulnerabilityDescription = 'NVD fallback metadata.'
+                BaseScore = 7.1
+                BaseSeverity = 'High'
+                Vector = 'CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:N'
+                CisaExploitAdd = $null
+                CisaActionDue = $null
+                CisaRequiredAction = $null
+                Weaknesses = @('CWE-416')
+            }
+        }
+
+        $result = Invoke-ContentStoreNormalization `
+            -DataPath $tempRoot `
+            -VulnOutputPath $outputPath `
+            -Context $context `
+            -Machines $machines `
+            -AdvancedHuntingData $advancedHuntingData `
+            -AdvancedHuntingDeviceUsers $advancedHuntingDeviceUsers `
+            -AdvancedHuntingInventoryData $advancedHuntingInventoryData `
+            -NvdCveData $nvdCveData `
+            -PayloadOutputPath $payloadPath `
+            -ConsumeLookupsOnPayloadClose
+
+        Assert-True ($result.ProcessedCount -eq 1) 'Expected content-store context-release regression fixture to normalize one row.'
+        Assert-True ([string]$result.PayloadPath -eq $payloadPath) 'Expected content-store context-release regression fixture to write the direct payload output.'
+        Assert-True ((Get-CompressedPayloadVulnCount -Path $payloadPath) -eq $result.ProcessedCount) 'Expected content-store context-release regression payload row count to match the processed count.'
+        Assert-True ($context.Machines.Count -eq 0) 'Expected content-store normalization to release machine lookups before payload close.'
+        Assert-True ($context.AdvancedHuntingData.Count -eq 0) 'Expected content-store normalization to release Advanced Hunting CVE data before payload close.'
+        Assert-True ($context.AdvancedHuntingDeviceUsers.Count -eq 0) 'Expected content-store normalization to release Advanced Hunting device-user data before payload close.'
+        Assert-True ($context.NvdCveData.Count -eq 0) 'Expected content-store normalization to release NVD CVE data before payload close.'
+        Assert-True ($context.AdvancedHuntingInventoryData.Count -eq 1) 'Expected content-store normalization to preserve inventory enrichment needed during ref streaming.'
+    }
+    finally {
+        if (Test-Path -LiteralPath $tempRoot) {
+            Remove-Item -LiteralPath $tempRoot -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+}
+
 function Test-ConvertToNormalizedDataDeduplicatesRepeatedCveLookup {
     [CmdletBinding()]
     param()
@@ -2028,7 +2147,7 @@ function Test-ConvertToNormalizedDataDeduplicatesRepeatedCveLookup {
     }
 }
 
-function Test-ConvertToNormalizedDataReportsZeroOnboardedContentStoreDiagnostics {
+function Test-ConvertToNormalizedDataReportsZeroOnboardedContentStoreDiagnostic {
     [CmdletBinding()]
     param()
 
@@ -3400,11 +3519,26 @@ function Test-DashboardDualPackagingGenerationAndValidation {
         & $dashboardScriptPath -DirectoryPath $tempRoot -ExportMachineData:$false -NormalizeOnly -NormalizedPayloadOutputPath $normalizedPayloadPath | Out-Null
         Assert-True ((Test-Path -LiteralPath $normalizedPayloadPath -PathType Leaf)) 'Expected NormalizeOnly to materialize the normalized payload for dual packaging.'
 
-        & $dashboardScriptPath -DirectoryPath $tempRoot -OutputPath $selfContainedOutputPath -ExportMachineData:$false -PackageOnly -NormalizedPayloadInputPath $normalizedPayloadPath -DualPackage -Validate -ValidationOutputPath $selfAuditPath | Out-Null
+        $packageOutput = @(& $dashboardScriptPath -DirectoryPath $tempRoot -OutputPath $selfContainedOutputPath -ExportMachineData:$false -PackageOnly -NormalizedPayloadInputPath $normalizedPayloadPath -DualPackage -Validate -ValidationOutputPath $selfAuditPath 6>&1)
+        $packageMessages = @($packageOutput | ForEach-Object { Get-OutputRecordText -Record $_ } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
+        $hostedWriteMessageIndex = -1
+        $selfContainedWriteMessageIndex = -1
+        for ($i = 0; $i -lt $packageMessages.Count; $i++) {
+            if ($hostedWriteMessageIndex -lt 0 -and $packageMessages[$i].Contains('Writing hosted dashboard to')) {
+                $hostedWriteMessageIndex = $i
+            }
+
+            if ($selfContainedWriteMessageIndex -lt 0 -and $packageMessages[$i].Contains('Writing self-contained dashboard to')) {
+                $selfContainedWriteMessageIndex = $i
+            }
+        }
 
         Assert-True ((Test-Path -LiteralPath $selfContainedOutputPath -PathType Leaf)) 'Expected dual packaging to write the self-contained dashboard HTML.'
         Assert-True ((Test-Path -LiteralPath $hostedOutputPath -PathType Leaf)) 'Expected dual packaging to write the hosted dashboard HTML.'
         Assert-True ((Test-Path -LiteralPath $hostedAssetsPath -PathType Container)) 'Expected dual packaging to create the hosted sibling asset directory.'
+        Assert-True ($hostedWriteMessageIndex -ge 0) 'Expected dual packaging output to announce hosted dashboard generation.'
+        Assert-True ($selfContainedWriteMessageIndex -ge 0) 'Expected dual packaging output to announce self-contained dashboard generation.'
+        Assert-True ($hostedWriteMessageIndex -lt $selfContainedWriteMessageIndex) 'Expected dual packaging to write the hosted dashboard before the self-contained dashboard.'
 
         foreach ($assetFileName in @('dashboard.css', 'dashboard.js', 'pako.js', 'chart.js', 'pdf-export.bundle.js', 'payload.json.gz')) {
             Assert-True ((Test-Path -LiteralPath (Join-Path $hostedAssetsPath $assetFileName) -PathType Leaf)) ("Expected dual packaging to write '{0}' to the hosted asset directory." -f $assetFileName)
@@ -3614,6 +3748,8 @@ function Test-FunctionAppWriteOutputNoEnumeratePreservesJObject {
     $observed = @(& {
         function Write-PipelineFileTraceLine {
             param($Message)
+
+            $null = $Message
         }
 
         . ([scriptblock]::Create($functionDefinition))
@@ -3710,7 +3846,7 @@ Test-ConvertToNormalizedDataContentStorePathDoesNotUseLegacyDictionaryReader
 Write-Output '  Content-store streaming normalization checks passed.'
 Test-ConvertToNormalizedDataDeduplicatesRepeatedCveLookup
 Write-Output '  Repeated CVE lookup deduplication checks passed.'
-Test-ConvertToNormalizedDataReportsZeroOnboardedContentStoreDiagnostics
+Test-ConvertToNormalizedDataReportsZeroOnboardedContentStoreDiagnostic
 Write-Output '  Zero-onboarded content-store diagnostics checks passed.'
 Test-ConvertToNormalizedDataIncludesAdvancedHuntingDeviceUserMap
 Write-Output '  Advanced Hunting device-user normalization checks passed.'


### PR DESCRIPTION
## Summary
- reduce dashboard generation peak memory by reordering dual-package output generation, delaying embedded bundle work, compacting content lookup cache entries, and releasing transient normalization context earlier
- add phase-transition garbage collection hooks and percent-complete progress markers for long-running normalization and validation paths
- make hot-phase and large-dataset validation default to artifact parity, with explicit opt-in for large semantic replay
- add focused regression coverage for transient context release and dual-package hosted-first execution order

## Validation
- `pwsh -NoProfile -File .\tests\Run-SharedHelperRegression.ps1`
- `pwsh -NoProfile -File .\build\Invoke-RegressionValidation.ps1`
- `pwsh -NoProfile -File .\build\Invoke-AzureDeploymentValidation.ps1 -AutomationAccountName aa-defender-reporting -FunctionAppName func-defender-reporting -SkipMdePermissions -DashboardDeliveryMode Hosted -FunctionExecutionDatasetPath .\.local\large-datasets\synthetic-50k-1_5m -FunctionExecutionTimeoutMinutes 30`
- `pwsh -NoProfile -File .\Setup-AzureResources.ps1 -ResourceGroupName rg-drquick-05051139 -AutomationAccountName aa-drquick-05051139 -StorageAccountName stdrq05051139s4e1 -Location eastus -DashboardDeliveryMode Hosted -SkipMdePermissions -ValidationDatasetPath .\.local\benchmark-datasets\benchmark-medium-v1`
- Edge-backed browser inspection of both self-contained and hosted outputs generated from `benchmark-medium-v1`

## Notes
- the fresh Automation Account deployment passed on the benchmark dataset and the latest runbook path looks healthy
- the hosted Function App path improved only slightly and remains a follow-up investigation after this PR merges