### PR TITLE
Reduce dashboard normalization memory and harden Azure blob validation

### DIFF
--- a/Setup-AzureResources.ps1
+++ b/Setup-AzureResources.ps1
@@ -243,6 +243,94 @@ function Get-ValidationDatasetFileList {
     )
 }
 
+function Get-StorageBlobRestHeaderSet {
+    [CmdletBinding()]
+    [OutputType([hashtable])]
+    param()
+
+    $accessToken = (& az account get-access-token --resource https://storage.azure.com/ --query accessToken -o tsv 2>&1 | Out-String).Trim()
+    if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($accessToken)) {
+        throw 'Failed to acquire an Azure Storage access token for blob REST operations.'
+    }
+
+    return @{
+        Authorization = "Bearer $accessToken"
+        'x-ms-version' = '2023-11-03'
+    }
+}
+
+function Get-BlobNamesViaRest {
+    [CmdletBinding()]
+    [OutputType([string[]])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$AccountName,
+
+        [Parameter(Mandatory = $true)]
+        [string]$ContainerName
+    )
+
+    $headers = Get-StorageBlobRestHeaderSet
+    $requestUri = "https://$AccountName.blob.core.windows.net/${ContainerName}?restype=container&comp=list"
+    $response = Invoke-WebRequest -Method Get -Uri $requestUri -Headers $headers -UseBasicParsing
+    if ([string]::IsNullOrWhiteSpace([string]$response.Content)) {
+        return @()
+    }
+
+    $blobNameMatches = [System.Text.RegularExpressions.Regex]::Matches([string]$response.Content, '<Blob>\s*<Name>([^<]+)</Name>')
+    return @($blobNameMatches | ForEach-Object { $_.Groups[1].Value } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
+}
+
+function Remove-BlobViaRest {
+    [CmdletBinding(SupportsShouldProcess)]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$AccountName,
+
+        [Parameter(Mandatory = $true)]
+        [string]$ContainerName,
+
+        [Parameter(Mandatory = $true)]
+        [string]$BlobName
+    )
+
+    $headers = Get-StorageBlobRestHeaderSet
+    $encodedBlobName = [System.Uri]::EscapeDataString($BlobName).Replace('%2F', '/')
+    $requestUri = "https://$AccountName.blob.core.windows.net/${ContainerName}/$encodedBlobName"
+    if ($PSCmdlet.ShouldProcess($requestUri, 'Delete blob via REST')) {
+        Invoke-WebRequest -Method Delete -Uri $requestUri -Headers $headers -UseBasicParsing | Out-Null
+    }
+}
+
+function Set-BlobViaRest {
+    [CmdletBinding(SupportsShouldProcess)]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$AccountName,
+
+        [Parameter(Mandatory = $true)]
+        [string]$ContainerName,
+
+        [Parameter(Mandatory = $true)]
+        [string]$BlobName,
+
+        [Parameter(Mandatory = $true)]
+        [string]$FilePath,
+
+        [Parameter(Mandatory = $true)]
+        [string]$ContentType
+    )
+
+    $headers = Get-StorageBlobRestHeaderSet
+    $headers['x-ms-blob-type'] = 'BlockBlob'
+    $headers['Content-Type'] = $ContentType
+    $encodedBlobName = [System.Uri]::EscapeDataString($BlobName).Replace('%2F', '/')
+    $requestUri = "https://$AccountName.blob.core.windows.net/${ContainerName}/$encodedBlobName"
+    if ($PSCmdlet.ShouldProcess($requestUri, 'Upload blob via REST')) {
+        Invoke-WebRequest -Method Put -Uri $requestUri -Headers $headers -InFile $FilePath -UseBasicParsing | Out-Null
+    }
+}
+
 function Clear-BlobContainerContent {
     [CmdletBinding()]
     param(
@@ -254,20 +342,25 @@ function Clear-BlobContainerContent {
     )
 
     $blobsJson = (& az storage blob list --account-name $AccountName --container-name $ContainerName --auth-mode login --output json 2>&1 | Out-String)
-    if ($LASTEXITCODE -ne 0) {
-        throw ("Failed to list blobs in container '{0}': {1}" -f $ContainerName, $blobsJson.Trim())
+    if ($LASTEXITCODE -eq 0) {
+        $blobs = if ([string]::IsNullOrWhiteSpace($blobsJson)) { @() } else { @($blobsJson | ConvertFrom-Json -Depth 20) }
+        foreach ($blob in @($blobs)) {
+            if ($null -eq $blob -or [string]::IsNullOrWhiteSpace([string]$blob.name)) {
+                continue
+            }
+
+            & az storage blob delete --account-name $AccountName --container-name $ContainerName --name ([string]$blob.name) --auth-mode login --output none | Out-Null
+            if ($LASTEXITCODE -ne 0) {
+                throw ("Failed to delete blob '{0}' from container '{1}'." -f ([string]$blob.name), $ContainerName)
+            }
+        }
+
+        return
     }
 
-    $blobs = if ([string]::IsNullOrWhiteSpace($blobsJson)) { @() } else { @($blobsJson | ConvertFrom-Json -Depth 20) }
-    foreach ($blob in @($blobs)) {
-        if ($null -eq $blob -or [string]::IsNullOrWhiteSpace([string]$blob.name)) {
-            continue
-        }
-
-        & az storage blob delete --account-name $AccountName --container-name $ContainerName --name ([string]$blob.name) --auth-mode login --output none | Out-Null
-        if ($LASTEXITCODE -ne 0) {
-            throw ("Failed to delete blob '{0}' from container '{1}'." -f ([string]$blob.name), $ContainerName)
-        }
+    Write-Warning ("Azure CLI blob listing failed for container '{0}'. Falling back to blob REST: {1}" -f $ContainerName, $blobsJson.Trim())
+    foreach ($blobName in @(Get-BlobNamesViaRest -AccountName $AccountName -ContainerName $ContainerName)) {
+        Remove-BlobViaRest -AccountName $AccountName -ContainerName $ContainerName -BlobName $blobName
     }
 }
 
@@ -304,9 +397,10 @@ function Initialize-ValidationExportsContainer {
     Clear-BlobContainerContent -AccountName $AccountName -ContainerName 'exports'
     foreach ($file in $datasetFiles) {
         $contentType = if ($file.Name.EndsWith('.gz')) { 'application/gzip' } else { 'application/json' }
-        & az storage blob upload --account-name $AccountName --container-name exports --name $file.Name --file $file.FullName --content-type $contentType --auth-mode login --overwrite --output none | Out-Null
+        & az storage blob upload --account-name $AccountName --container-name exports --name $file.Name --file $file.FullName --content-type $contentType --auth-mode login --overwrite --output none 2>$null | Out-Null
         if ($LASTEXITCODE -ne 0) {
-            throw ("Failed to upload '{0}' to the exports container." -f $file.Name)
+            Write-Warning ("Azure CLI blob upload failed for '{0}' in container 'exports'. Falling back to blob REST." -f $file.Name)
+            Set-BlobViaRest -AccountName $AccountName -ContainerName 'exports' -BlobName $file.Name -FilePath $file.FullName -ContentType $contentType
         }
     }
 }

--- a/azure/Invoke-DashboardPipeline.ps1
+++ b/azure/Invoke-DashboardPipeline.ps1
@@ -9847,6 +9847,63 @@ function Get-DashboardTemplateContent {
     return $templates
 }
 
+function Get-LocalDashboardRepositoryRoot {
+    [CmdletBinding()]
+    [OutputType([string])]
+    param()
+
+    $candidatePath = $PSScriptRoot
+    while (-not [string]::IsNullOrWhiteSpace($candidatePath)) {
+        if ((Test-Path -LiteralPath (Join-Path $candidatePath 'Generate-VulnerabilityDashboard.ps1') -PathType Leaf) -and
+            (Test-Path -LiteralPath (Join-Path $candidatePath 'build') -PathType Container)) {
+            return $candidatePath
+        }
+
+        $parentPath = Split-Path -Path $candidatePath -Parent
+        if ([string]::IsNullOrWhiteSpace($parentPath) -or $parentPath -eq $candidatePath) {
+            break
+        }
+
+        $candidatePath = $parentPath
+    }
+
+    return $null
+}
+
+function Find-SharedDashboardLibraryCacheFile {
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$CacheFileName
+    )
+
+    $repoRoot = Get-LocalDashboardRepositoryRoot
+    if ([string]::IsNullOrWhiteSpace($repoRoot)) {
+        return $null
+    }
+
+    $libraryCacheSuffix = [System.IO.Path]::Combine('.dashboard-cache', 'libraries')
+    foreach ($searchRoot in @(
+        (Join-Path $repoRoot 'exports'),
+        (Join-Path $repoRoot '.local')
+    )) {
+        if (-not (Test-Path -LiteralPath $searchRoot -PathType Container)) {
+            continue
+        }
+
+        $cacheMatch = Get-ChildItem -LiteralPath $searchRoot -Filter $CacheFileName -File -Recurse -ErrorAction SilentlyContinue |
+            Where-Object { $_.DirectoryName.EndsWith($libraryCacheSuffix, [System.StringComparison]::OrdinalIgnoreCase) -and $_.Length -gt 0 } |
+            Select-Object -First 1
+
+        if ($null -ne $cacheMatch) {
+            return $cacheMatch.FullName
+        }
+    }
+
+    return $null
+}
+
 function Save-JSLibraryFile {
     [CmdletBinding()]
     [OutputType([string])]
@@ -9868,6 +9925,7 @@ function Save-JSLibraryFile {
     )
 
     $cachePath = $null
+    $cacheFileName = $null
     if (-not [string]::IsNullOrWhiteSpace($CacheBasePath)) {
         $cacheDirectory = Get-DashboardCacheDirectory -BasePath $CacheBasePath -ChildPath 'libraries' -Create
         $urlHashBytes = [System.Security.Cryptography.SHA256]::HashData([System.Text.Encoding]::UTF8.GetBytes($Url))
@@ -9879,6 +9937,7 @@ function Save-JSLibraryFile {
 
         $safeName = ($Name -replace '[^A-Za-z0-9._-]', '-')
         $cachePath = Join-Path $cacheDirectory ("{0}-{1}{2}" -f $safeName, $urlHash, $extension)
+        $cacheFileName = [System.IO.Path]::GetFileName($cachePath)
         if (Test-Path -LiteralPath $cachePath -PathType Leaf) {
             $cachedLibrary = Get-Item -LiteralPath $cachePath
             if ($cachedLibrary.Length -le 0) {
@@ -9890,6 +9949,19 @@ function Save-JSLibraryFile {
                 Write-Information "Reusing cached $Name library" -InformationAction Continue
                 return $OutputPath
             }
+        }
+    }
+
+    if (-not [string]::IsNullOrWhiteSpace($cacheFileName)) {
+        $sharedCachePath = Find-SharedDashboardLibraryCacheFile -CacheFileName $cacheFileName
+        if (-not [string]::IsNullOrWhiteSpace($sharedCachePath)) {
+            Copy-Item -LiteralPath $sharedCachePath -Destination $OutputPath -Force
+            if (-not [string]::IsNullOrWhiteSpace($cachePath) -and -not $sharedCachePath.Equals($cachePath, [System.StringComparison]::OrdinalIgnoreCase)) {
+                Copy-Item -LiteralPath $sharedCachePath -Destination $cachePath -Force
+            }
+
+            Write-Information "Reusing shared cached $Name library" -InformationAction Continue
+            return $OutputPath
         }
     }
 
@@ -14509,6 +14581,10 @@ function Resolve-NormalizedInventoryLookup {
         [AllowNull()]
         [object]$SoftwareVersion,
 
+        [Parameter(Mandatory = $false)]
+        [AllowNull()]
+        [object]$SoftwareIdentityKey,
+
         [Parameter(Mandatory = $true)]
         [pscustomobject]$Context
     )
@@ -14518,11 +14594,27 @@ function Resolve-NormalizedInventoryLookup {
         return -1
     }
 
-    $inventoryKey = Get-AdvancedHuntingInventoryMatchKey `
-        -DeviceId ([string]$DeviceId) `
-        -SoftwareVendor ([string]($SoftwareVendor ?? '')) `
-        -SoftwareName ([string]($SoftwareName ?? '')) `
-        -SoftwareVersion ([string]($SoftwareVersion ?? ''))
+    $deviceIdText = [string]$DeviceId
+    if ([string]::IsNullOrWhiteSpace($deviceIdText)) {
+        return -1
+    }
+
+    $inventoryKey = $null
+    $softwareIdentityKeyText = [string]($SoftwareIdentityKey ?? '')
+    if (-not [string]::IsNullOrWhiteSpace($softwareIdentityKeyText)) {
+        $inventoryKey = @(
+            $deviceIdText
+            $softwareIdentityKeyText
+        ) -join '|'
+    }
+    else {
+        $inventoryKey = Get-AdvancedHuntingInventoryMatchKey `
+            -DeviceId $deviceIdText `
+            -SoftwareVendor ([string]($SoftwareVendor ?? '')) `
+            -SoftwareName ([string]($SoftwareName ?? '')) `
+            -SoftwareVersion ([string]($SoftwareVersion ?? ''))
+    }
+
     if ([string]::IsNullOrWhiteSpace($inventoryKey)) {
         return -1
     }
@@ -14713,19 +14805,50 @@ function Get-NormalizedContentLookupCacheEntry {
     [CmdletBinding()]
     [OutputType([object[]])]
     param(
+        [Parameter(Mandatory = $false)]
+        [switch]$IncludeInventoryIdentity,
+
+        [Parameter(Mandatory = $false)]
+        [AllowEmptyString()]
+        [string]$SoftwareInventoryIdentityKey,
+
         [Parameter(Mandatory = $true)]
         [pscustomobject]$ContentLookup
     )
 
-    return [object[]]@(
-        $ContentLookup.sw,
-        $ContentLookup.cve,
-        $ContentLookup.ver,
-        $ContentLookup.upd,
-        $ContentLookup.ua,
-        $ContentLookup.dp,
-        $ContentLookup.rp
+    $cacheEntry = [System.Collections.Generic.List[object]]::new()
+    $cacheEntry.Add($ContentLookup.sw) | Out-Null
+    $cacheEntry.Add($ContentLookup.cve) | Out-Null
+    $cacheEntry.Add($ContentLookup.ver) | Out-Null
+    $cacheEntry.Add($ContentLookup.upd) | Out-Null
+    $cacheEntry.Add($ContentLookup.ua) | Out-Null
+    $cacheEntry.Add($ContentLookup.dp) | Out-Null
+    $cacheEntry.Add($ContentLookup.rp) | Out-Null
+
+    if ($IncludeInventoryIdentity) {
+        $cacheEntry.Add($SoftwareInventoryIdentityKey) | Out-Null
+    }
+
+    return [object[]]$cacheEntry.ToArray()
+}
+
+function Get-ContentStoreDeviceProfileIdentityCache {
+    [CmdletBinding()]
+    [OutputType([string[]])]
+    param(
+        [Parameter(Mandatory = $false)]
+        [switch]$IncludeInventoryIdentity,
+
+        [Parameter(Mandatory = $false)]
+        [AllowNull()]
+        [System.Collections.Generic.List[string]]$DeviceProfileIds
     )
+
+    if (-not $IncludeInventoryIdentity -or $null -eq $DeviceProfileIds) {
+        return $null
+    }
+
+    return ,([string[]]$DeviceProfileIds.ToArray())
 }
 
 function Get-NormalizedRecordLookup {
@@ -15272,8 +15395,11 @@ function Invoke-ContentStoreNormalization {
         throw "Content dictionary '$dictionaryPath' was not found."
     }
 
-    $deviceProfileIds = [System.Collections.Generic.List[string]]::new()
-    $contentInventoryKeys = [System.Collections.Generic.List[object]]::new()
+    $hasInventoryIdentity = ($Context.AdvancedHuntingInventoryData.Count -gt 0)
+    $deviceProfileIds = $null
+    if ($hasInventoryIdentity) {
+        $deviceProfileIds = [System.Collections.Generic.List[string]]::new()
+    }
     $deviceLookupIndices = [System.Collections.Generic.List[int]]::new()
     $deviceOnboardedFlags = [System.Collections.Generic.List[bool]]::new()
     $contentLookupCache = [System.Collections.Generic.List[object]]::new()
@@ -15284,6 +15410,7 @@ function Invoke-ContentStoreNormalization {
     $contentLookupUpdateAvailableIndex = 4
     $contentLookupDiskPathIndex = 5
     $contentLookupRegistryPathIndex = 6
+    $contentLookupSoftwareIdentityKeyIndex = 7
     $processedCountRef = [ref]0
     $firstLastSwappedCountRef = [ref]0
     $writerState = $null
@@ -15293,7 +15420,9 @@ function Invoke-ContentStoreNormalization {
 
     foreach ($deviceProfile in @(Read-VulnContentDictionaryArrayEntries -Path $dictionaryPath -PropertyName 'deviceProfiles')) {
         $deviceId = [string](Get-VulnPropertyValue -InputObject $deviceProfile -Name 'id')
-        $deviceProfileIds.Add($deviceId) | Out-Null
+        if ($hasInventoryIdentity) {
+            $deviceProfileIds.Add($deviceId) | Out-Null
+        }
         $deviceLookupIndices.Add((Add-NormalizedDevice `
                 -DeviceId $deviceId `
                 -DeviceName ([string](Get-VulnPropertyValue -InputObject $deviceProfile -Name 'n')) `
@@ -15305,10 +15434,10 @@ function Invoke-ContentStoreNormalization {
         $deviceOnboardedFlags.Add(((Get-VulnPropertyValue -InputObject $deviceProfile -Name 'ob') -eq $true)) | Out-Null
     }
 
-    $deviceProfiles = $deviceProfileIds.ToArray()
+    $deviceProfiles = Get-ContentStoreDeviceProfileIdentityCache -IncludeInventoryIdentity:$hasInventoryIdentity -DeviceProfileIds $deviceProfileIds
     $deviceLookupIndices = $deviceLookupIndices.ToArray()
     $deviceOnboardedFlags = $deviceOnboardedFlags.ToArray()
-    $deviceProfileCount = $deviceProfiles.Length
+    $deviceProfileCount = $deviceLookupIndices.Length
     $onboardedDeviceProfileCount = @($deviceOnboardedFlags | Where-Object { $_ }).Count
     $deviceProfileIds = $null
 
@@ -15316,14 +15445,21 @@ function Invoke-ContentStoreNormalization {
         $softwareVendor = [string](Get-VulnPropertyValue -InputObject $contentTemplate -Name 'sv')
         $softwareName = [string](Get-VulnPropertyValue -InputObject $contentTemplate -Name 'sn')
         $softwareVersion = [string](Get-VulnPropertyValue -InputObject $contentTemplate -Name 'ver')
+        $softwareInventoryIdentityKey = if ($hasInventoryIdentity -and -not [string]::IsNullOrWhiteSpace($softwareName)) {
+            @(
+                [string]($softwareVendor ?? '')
+                $softwareName
+                [string]($softwareVersion ?? '')
+            ) -join '|'
+        }
+        else {
+            $null
+        }
 
-        $contentInventoryKeys.Add([object[]]@(
-                $softwareVendor,
-                $softwareName,
-                $softwareVersion
-            )) | Out-Null
-
-        $contentLookupCache.Add((Get-NormalizedContentLookupCacheEntry -ContentLookup (Resolve-NormalizedContentLookup `
+        $contentLookupCache.Add((Get-NormalizedContentLookupCacheEntry `
+            -IncludeInventoryIdentity:$hasInventoryIdentity `
+            -SoftwareInventoryIdentityKey $softwareInventoryIdentityKey `
+            -ContentLookup (Resolve-NormalizedContentLookup `
                 -SoftwareVendor $softwareVendor `
                 -SoftwareName $softwareName `
                 -RecommendationReference ([string](Get-VulnPropertyValue -InputObject $contentTemplate -Name 'rr')) `
@@ -15343,10 +15479,8 @@ function Invoke-ContentStoreNormalization {
                 -Context $Context))) | Out-Null
     }
 
-    $contentTemplates = $contentInventoryKeys.ToArray()
     $contentLookupCache = $contentLookupCache.ToArray()
-    $contentTemplateCount = $contentTemplates.Length
-    $contentInventoryKeys = $null
+    $contentTemplateCount = $contentLookupCache.Length
 
     # Ref streaming only needs the compact device/content lookup arrays plus
     # inventory enrichment. Release the larger source maps before processing
@@ -15477,8 +15611,6 @@ function Invoke-ContentStoreNormalization {
                             if (-not $lastSeen) { $lastSeen = '' }
 
                             $contentLookup = $contentLookupCache[$contentTemplateIndexValue]
-                            $contentTemplate = $contentTemplates[$contentTemplateIndexValue]
-                            $deviceProfileId = $deviceProfiles[$deviceProfileIndexValue]
                             $compactRecord[0] = $deviceLookupIndices[$deviceProfileIndexValue]
                             $compactRecord[1] = $contentLookup[$contentLookupCveIndex]
                             $compactRecord[2] = $contentLookup[$contentLookupSwIndex]
@@ -15489,12 +15621,15 @@ function Invoke-ContentStoreNormalization {
                             $compactRecord[7] = $contentLookup[$contentLookupUpdateIndex]
                             $compactRecord[8] = $contentLookup[$contentLookupDiskPathIndex]
                             $compactRecord[9] = $contentLookup[$contentLookupRegistryPathIndex]
-                            $compactRecord[10] = Resolve-NormalizedInventoryLookup `
-                                -DeviceId ([string]$deviceProfileId) `
-                                -SoftwareVendor ([string]$contentTemplate[0]) `
-                                -SoftwareName ([string]$contentTemplate[1]) `
-                                -SoftwareVersion ([string]$contentTemplate[2]) `
-                                -Context $Context
+                            if ($hasInventoryIdentity) {
+                                $compactRecord[10] = Resolve-NormalizedInventoryLookup `
+                                    -DeviceId ([string]$deviceProfiles[$deviceProfileIndexValue]) `
+                                    -SoftwareIdentityKey ([string]$contentLookup[$contentLookupSoftwareIdentityKeyIndex]) `
+                                    -Context $Context
+                            }
+                            else {
+                                $compactRecord[10] = -1
+                            }
 
                             if ($columnStates) {
                                 for ($columnIndex = 0; $columnIndex -lt 11; $columnIndex++) {
@@ -15623,24 +15758,25 @@ function Invoke-ContentStoreNormalization {
                                     if (-not $lastSeen) { $lastSeen = '' }
 
                                     $contentLookup = $contentLookupCache[$ctv]
-                                    $contentTemplate = $contentTemplates[$ctv]
-                                    $deviceProfileId = $deviceProfiles[$dpv]
                                     $compactRecord[0] = $deviceLookupIndices[$dpv]
-                                    $compactRecord[1] = $contentLookup.cve
-                                    $compactRecord[2] = $contentLookup.sw
-                                    $compactRecord[3] = $contentLookup.ver
+                                    $compactRecord[1] = $contentLookup[$contentLookupCveIndex]
+                                    $compactRecord[2] = $contentLookup[$contentLookupSwIndex]
+                                    $compactRecord[3] = $contentLookup[$contentLookupVersionIndex]
                                     $compactRecord[4] = Get-OrCreateIndex -value $firstSeen -list $lookups.dates -indexMap $dateIndex
                                     $compactRecord[5] = Get-OrCreateIndex -value $lastSeen -list $lookups.dates -indexMap $dateIndex
-                                    $compactRecord[6] = $contentLookup.ua
-                                    $compactRecord[7] = $contentLookup.upd
-                                    $compactRecord[8] = $contentLookup.dp
-                                    $compactRecord[9] = $contentLookup.rp
-                                    $compactRecord[10] = Resolve-NormalizedInventoryLookup `
-                                        -DeviceId ([string]$deviceProfileId) `
-                                        -SoftwareVendor ([string]$contentTemplate[0]) `
-                                        -SoftwareName ([string]$contentTemplate[1]) `
-                                        -SoftwareVersion ([string]$contentTemplate[2]) `
-                                        -Context $Context
+                                    $compactRecord[6] = $contentLookup[$contentLookupUpdateAvailableIndex]
+                                    $compactRecord[7] = $contentLookup[$contentLookupUpdateIndex]
+                                    $compactRecord[8] = $contentLookup[$contentLookupDiskPathIndex]
+                                    $compactRecord[9] = $contentLookup[$contentLookupRegistryPathIndex]
+                                    if ($hasInventoryIdentity) {
+                                        $compactRecord[10] = Resolve-NormalizedInventoryLookup `
+                                            -DeviceId ([string]$deviceProfiles[$dpv]) `
+                                            -SoftwareIdentityKey ([string]$contentLookup[$contentLookupSoftwareIdentityKeyIndex]) `
+                                            -Context $Context
+                                    }
+                                    else {
+                                        $compactRecord[10] = -1
+                                    }
 
                                     if ($columnStates) {
                                         for ($columnIndex = 0; $columnIndex -lt 11; $columnIndex++) {
@@ -15719,7 +15855,7 @@ function Invoke-ContentStoreNormalization {
         # Payload finalization only needs the compact lookup collections. Release
         # the much larger content-store scaffolding first so hosted Automation
         # does not carry that transient state into lookup serialization.
-        foreach ($transientArray in @($deviceProfiles, $contentTemplates, $deviceLookupIndices, $deviceOnboardedFlags, $contentLookupCache)) {
+        foreach ($transientArray in @($deviceProfiles, $deviceLookupIndices, $deviceOnboardedFlags, $contentLookupCache)) {
             if ($null -ne $transientArray) {
                 [System.Array]::Clear($transientArray, 0, $transientArray.Length)
             }
@@ -15741,7 +15877,6 @@ function Invoke-ContentStoreNormalization {
         }
 
         $deviceProfiles = $null
-        $contentTemplates = $null
         $deviceLookupIndices = $null
         $deviceOnboardedFlags = $null
         $contentLookupCache = $null

--- a/build/Invoke-AzureDeploymentValidation.ps1
+++ b/build/Invoke-AzureDeploymentValidation.ps1
@@ -420,6 +420,162 @@ function Resolve-FunctionExecutionDatasetPath {
     return $resolvedPath
 }
 
+function Get-StorageBlobRestHeaderSet {
+    [CmdletBinding()]
+    [OutputType([hashtable])]
+    param()
+
+    $accessToken = Invoke-AzCliText -Arguments @('account', 'get-access-token', '--resource', 'https://storage.azure.com/', '--query', 'accessToken', '-o', 'tsv')
+    if ([string]::IsNullOrWhiteSpace($accessToken)) {
+        throw 'Failed to acquire an Azure Storage access token for blob REST operations.'
+    }
+
+    return @{
+        Authorization = "Bearer $accessToken"
+        'x-ms-version' = '2023-11-03'
+    }
+}
+
+function Get-BlobNamesViaRest {
+    [CmdletBinding()]
+    [OutputType([string[]])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$AccountName,
+
+        [Parameter(Mandatory = $true)]
+        [string]$ContainerName
+    )
+
+    $headers = Get-StorageBlobRestHeaderSet
+    $requestUri = "https://$AccountName.blob.core.windows.net/${ContainerName}?restype=container&comp=list"
+    $response = Invoke-WebRequest -Method Get -Uri $requestUri -Headers $headers -UseBasicParsing
+    if ([string]::IsNullOrWhiteSpace([string]$response.Content)) {
+        return @()
+    }
+
+    $blobNameMatches = [System.Text.RegularExpressions.Regex]::Matches([string]$response.Content, '<Blob>\s*<Name>([^<]+)</Name>')
+    return @($blobNameMatches | ForEach-Object { $_.Groups[1].Value } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
+}
+
+function Remove-BlobViaRest {
+    [CmdletBinding(SupportsShouldProcess)]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$AccountName,
+
+        [Parameter(Mandatory = $true)]
+        [string]$ContainerName,
+
+        [Parameter(Mandatory = $true)]
+        [string]$BlobName
+    )
+
+    $headers = Get-StorageBlobRestHeaderSet
+    $encodedBlobName = [System.Uri]::EscapeDataString($BlobName).Replace('%2F', '/')
+    $requestUri = "https://$AccountName.blob.core.windows.net/${ContainerName}/$encodedBlobName"
+    if ($PSCmdlet.ShouldProcess($requestUri, 'Delete blob via REST')) {
+        Invoke-WebRequest -Method Delete -Uri $requestUri -Headers $headers -UseBasicParsing | Out-Null
+    }
+}
+
+function Set-BlobViaRest {
+    [CmdletBinding(SupportsShouldProcess)]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$AccountName,
+
+        [Parameter(Mandatory = $true)]
+        [string]$ContainerName,
+
+        [Parameter(Mandatory = $true)]
+        [string]$BlobName,
+
+        [Parameter(Mandatory = $true)]
+        [string]$FilePath,
+
+        [Parameter(Mandatory = $true)]
+        [string]$ContentType
+    )
+
+    $headers = Get-StorageBlobRestHeaderSet
+    $headers['x-ms-blob-type'] = 'BlockBlob'
+    $headers['Content-Type'] = $ContentType
+    $encodedBlobName = [System.Uri]::EscapeDataString($BlobName).Replace('%2F', '/')
+    $requestUri = "https://$AccountName.blob.core.windows.net/${ContainerName}/$encodedBlobName"
+    if ($PSCmdlet.ShouldProcess($requestUri, 'Upload blob via REST')) {
+        Invoke-WebRequest -Method Put -Uri $requestUri -Headers $headers -InFile $FilePath -UseBasicParsing | Out-Null
+    }
+}
+
+function Get-BlobTextViaRest {
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$AccountName,
+
+        [Parameter(Mandatory = $true)]
+        [string]$ContainerName,
+
+        [Parameter(Mandatory = $true)]
+        [string]$BlobName
+    )
+
+    $headers = Get-StorageBlobRestHeaderSet
+    $encodedBlobName = [System.Uri]::EscapeDataString($BlobName).Replace('%2F', '/')
+    $requestUri = "https://$AccountName.blob.core.windows.net/${ContainerName}/$encodedBlobName"
+
+    try {
+        $response = Invoke-WebRequest -Method Get -Uri $requestUri -Headers $headers -UseBasicParsing
+        return [string]$response.Content
+    }
+    catch {
+        if ($_.Exception.Response -and [int]$_.Exception.Response.StatusCode -eq 404) {
+            return $null
+        }
+
+        throw
+    }
+}
+
+function Get-BlobLastModifiedUtcViaRest {
+    [CmdletBinding()]
+    [OutputType([Nullable[datetime]])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$AccountName,
+
+        [Parameter(Mandatory = $true)]
+        [string]$ContainerName,
+
+        [Parameter(Mandatory = $true)]
+        [string]$BlobName
+    )
+
+    $headers = Get-StorageBlobRestHeaderSet
+    $encodedBlobName = [System.Uri]::EscapeDataString($BlobName).Replace('%2F', '/')
+    $requestUri = "https://$AccountName.blob.core.windows.net/${ContainerName}/$encodedBlobName"
+
+    try {
+        $response = Invoke-WebRequest -Method Head -Uri $requestUri -Headers $headers -UseBasicParsing
+    }
+    catch {
+        if ($_.Exception.Response -and [int]$_.Exception.Response.StatusCode -eq 404) {
+            return $null
+        }
+
+        throw
+    }
+
+    $lastModifiedHeader = [string]$response.Headers['Last-Modified']
+    if ([string]::IsNullOrWhiteSpace($lastModifiedHeader)) {
+        return $null
+    }
+
+    return ([datetimeoffset]$lastModifiedHeader).UtcDateTime
+}
+
 function Clear-BlobContainer {
     [CmdletBinding()]
     param(
@@ -430,23 +586,34 @@ function Clear-BlobContainer {
         [string]$ContainerName
     )
 
-    $blobs = @(Invoke-AzCliJson -Arguments @(
+    try {
+        $blobs = @(Invoke-AzCliJson -Arguments @(
         'storage', 'blob', 'list',
         '--account-name', $AccountName,
         '--container-name', $ContainerName,
         '--auth-mode', 'login',
         '-o', 'json'
-    ))
+        ))
 
-    foreach ($blob in @($blobs)) {
-        if ($null -eq $blob -or [string]::IsNullOrWhiteSpace([string]$blob.name)) {
-            continue
+        foreach ($blob in @($blobs)) {
+            if ($null -eq $blob -or [string]::IsNullOrWhiteSpace([string]$blob.name)) {
+                continue
+            }
+
+            & az storage blob delete --account-name $AccountName --container-name $ContainerName --name ([string]$blob.name) --auth-mode login --output none | Out-Null
+            if ($LASTEXITCODE -ne 0) {
+                throw "Failed to delete blob '$([string]$blob.name)' from container '$ContainerName'."
+            }
         }
 
-        & az storage blob delete --account-name $AccountName --container-name $ContainerName --name ([string]$blob.name) --auth-mode login --output none | Out-Null
-        if ($LASTEXITCODE -ne 0) {
-            throw "Failed to delete blob '$([string]$blob.name)' from container '$ContainerName'."
-        }
+        return
+    }
+    catch {
+        Write-ValidationLogLine -Message ("Azure CLI blob listing failed for container '{0}'. Falling back to blob REST: {1}" -f $ContainerName, $_.Exception.Message) -ForegroundColor Yellow
+    }
+
+    foreach ($blobName in @(Get-BlobNamesViaRest -AccountName $AccountName -ContainerName $ContainerName)) {
+        Remove-BlobViaRest -AccountName $AccountName -ContainerName $ContainerName -BlobName $blobName
     }
 }
 
@@ -577,9 +744,10 @@ function Seed-ExportsContainer {
     Clear-BlobContainer -AccountName $AccountName -ContainerName 'exports'
     foreach ($file in $datasetFiles) {
         $contentType = if ($file.Name.EndsWith('.gz')) { 'application/gzip' } else { 'application/json' }
-        & az storage blob upload --account-name $AccountName --container-name exports --name $file.Name --file $file.FullName --content-type $contentType --auth-mode login --overwrite --output none | Out-Null
+        & az storage blob upload --account-name $AccountName --container-name exports --name $file.Name --file $file.FullName --content-type $contentType --auth-mode login --overwrite --output none 2>$null | Out-Null
         if ($LASTEXITCODE -ne 0) {
-            throw "Failed to upload '$($file.Name)' to the Function App exports container."
+            Write-ValidationLogLine -Message ("Azure CLI blob upload failed for '{0}' in container 'exports'. Falling back to blob REST." -f $file.Name) -ForegroundColor Yellow
+            Set-BlobViaRest -AccountName $AccountName -ContainerName 'exports' -BlobName $file.Name -FilePath $file.FullName -ContentType $contentType
         }
     }
 }
@@ -927,7 +1095,7 @@ function Get-BlobLastModifiedUtc {
 
     $output = & az storage blob show --auth-mode login --account-name $StorageAccountName --container-name $ContainerName --name $BlobName --query properties.lastModified -o tsv 2>$null
     if ($LASTEXITCODE -ne 0) {
-        return $null
+        return (Get-BlobLastModifiedUtcViaRest -AccountName $StorageAccountName -ContainerName $ContainerName -BlobName $BlobName)
     }
 
     $text = ($output -join [Environment]::NewLine).Trim()
@@ -956,7 +1124,7 @@ function Get-BlobTextContent {
     try {
         & az storage blob download --auth-mode login --account-name $StorageAccountName --container-name $ContainerName --name $BlobName --file $downloadPath --output none 2>$null | Out-Null
         if ($LASTEXITCODE -ne 0 -or -not (Test-Path -LiteralPath $downloadPath -PathType Leaf)) {
-            return $null
+            return (Get-BlobTextViaRest -AccountName $StorageAccountName -ContainerName $ContainerName -BlobName $BlobName)
         }
 
         return (Get-Content -LiteralPath $downloadPath -Raw)
@@ -1041,9 +1209,9 @@ function Set-FunctionExecutionControlBlob {
     $controlFilePath = Join-Path ([System.IO.Path]::GetTempPath()) ("function-control-{0}.json" -f [guid]::NewGuid().ToString('N'))
     try {
         $controlDocument | ConvertTo-Json -Depth 10 | Set-Content -LiteralPath $controlFilePath -Encoding utf8
-        & az storage blob upload --auth-mode login --account-name $StorageAccountName --container-name $script:FunctionExecutionStatusContainerName --name $script:FunctionExecutionControlBlobName --file $controlFilePath --content-type application/json --overwrite --output none | Out-Null
+        & az storage blob upload --auth-mode login --account-name $StorageAccountName --container-name $script:FunctionExecutionStatusContainerName --name $script:FunctionExecutionControlBlobName --file $controlFilePath --content-type application/json --overwrite --output none 2>$null | Out-Null
         if ($LASTEXITCODE -ne 0) {
-            throw ("Failed to upload Function App execution control blob '{0}'." -f $script:FunctionExecutionControlBlobName)
+            Set-BlobViaRest -AccountName $StorageAccountName -ContainerName $script:FunctionExecutionStatusContainerName -BlobName $script:FunctionExecutionControlBlobName -FilePath $controlFilePath -ContentType 'application/json'
         }
     }
     finally {
@@ -1060,6 +1228,9 @@ function Remove-FunctionExecutionControlBlob {
     )
 
     & az storage blob delete --auth-mode login --account-name $StorageAccountName --container-name $script:FunctionExecutionStatusContainerName --name $script:FunctionExecutionControlBlobName --output none 2>$null | Out-Null
+    if ($LASTEXITCODE -ne 0) {
+        Remove-BlobViaRest -AccountName $StorageAccountName -ContainerName $script:FunctionExecutionStatusContainerName -BlobName $script:FunctionExecutionControlBlobName
+    }
 }
 
 function Get-FunctionExecutionActivity {

--- a/src/powershell/Shared/Dashboard/DashboardGeneration.ps1
+++ b/src/powershell/Shared/Dashboard/DashboardGeneration.ps1
@@ -63,6 +63,63 @@ function Get-DashboardTemplateContent {
     return $templates
 }
 
+function Get-LocalDashboardRepositoryRoot {
+    [CmdletBinding()]
+    [OutputType([string])]
+    param()
+
+    $candidatePath = $PSScriptRoot
+    while (-not [string]::IsNullOrWhiteSpace($candidatePath)) {
+        if ((Test-Path -LiteralPath (Join-Path $candidatePath 'Generate-VulnerabilityDashboard.ps1') -PathType Leaf) -and
+            (Test-Path -LiteralPath (Join-Path $candidatePath 'build') -PathType Container)) {
+            return $candidatePath
+        }
+
+        $parentPath = Split-Path -Path $candidatePath -Parent
+        if ([string]::IsNullOrWhiteSpace($parentPath) -or $parentPath -eq $candidatePath) {
+            break
+        }
+
+        $candidatePath = $parentPath
+    }
+
+    return $null
+}
+
+function Find-SharedDashboardLibraryCacheFile {
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$CacheFileName
+    )
+
+    $repoRoot = Get-LocalDashboardRepositoryRoot
+    if ([string]::IsNullOrWhiteSpace($repoRoot)) {
+        return $null
+    }
+
+    $libraryCacheSuffix = [System.IO.Path]::Combine('.dashboard-cache', 'libraries')
+    foreach ($searchRoot in @(
+        (Join-Path $repoRoot 'exports'),
+        (Join-Path $repoRoot '.local')
+    )) {
+        if (-not (Test-Path -LiteralPath $searchRoot -PathType Container)) {
+            continue
+        }
+
+        $cacheMatch = Get-ChildItem -LiteralPath $searchRoot -Filter $CacheFileName -File -Recurse -ErrorAction SilentlyContinue |
+            Where-Object { $_.DirectoryName.EndsWith($libraryCacheSuffix, [System.StringComparison]::OrdinalIgnoreCase) -and $_.Length -gt 0 } |
+            Select-Object -First 1
+
+        if ($null -ne $cacheMatch) {
+            return $cacheMatch.FullName
+        }
+    }
+
+    return $null
+}
+
 function Save-JSLibraryFile {
     [CmdletBinding()]
     [OutputType([string])]
@@ -84,6 +141,7 @@ function Save-JSLibraryFile {
     )
 
     $cachePath = $null
+    $cacheFileName = $null
     if (-not [string]::IsNullOrWhiteSpace($CacheBasePath)) {
         $cacheDirectory = Get-DashboardCacheDirectory -BasePath $CacheBasePath -ChildPath 'libraries' -Create
         $urlHashBytes = [System.Security.Cryptography.SHA256]::HashData([System.Text.Encoding]::UTF8.GetBytes($Url))
@@ -95,6 +153,7 @@ function Save-JSLibraryFile {
 
         $safeName = ($Name -replace '[^A-Za-z0-9._-]', '-')
         $cachePath = Join-Path $cacheDirectory ("{0}-{1}{2}" -f $safeName, $urlHash, $extension)
+        $cacheFileName = [System.IO.Path]::GetFileName($cachePath)
         if (Test-Path -LiteralPath $cachePath -PathType Leaf) {
             $cachedLibrary = Get-Item -LiteralPath $cachePath
             if ($cachedLibrary.Length -le 0) {
@@ -106,6 +165,19 @@ function Save-JSLibraryFile {
                 Write-Information "Reusing cached $Name library" -InformationAction Continue
                 return $OutputPath
             }
+        }
+    }
+
+    if (-not [string]::IsNullOrWhiteSpace($cacheFileName)) {
+        $sharedCachePath = Find-SharedDashboardLibraryCacheFile -CacheFileName $cacheFileName
+        if (-not [string]::IsNullOrWhiteSpace($sharedCachePath)) {
+            Copy-Item -LiteralPath $sharedCachePath -Destination $OutputPath -Force
+            if (-not [string]::IsNullOrWhiteSpace($cachePath) -and -not $sharedCachePath.Equals($cachePath, [System.StringComparison]::OrdinalIgnoreCase)) {
+                Copy-Item -LiteralPath $sharedCachePath -Destination $cachePath -Force
+            }
+
+            Write-Information "Reusing shared cached $Name library" -InformationAction Continue
+            return $OutputPath
         }
     }
 
@@ -4725,6 +4797,10 @@ function Resolve-NormalizedInventoryLookup {
         [AllowNull()]
         [object]$SoftwareVersion,
 
+        [Parameter(Mandatory = $false)]
+        [AllowNull()]
+        [object]$SoftwareIdentityKey,
+
         [Parameter(Mandatory = $true)]
         [pscustomobject]$Context
     )
@@ -4734,11 +4810,27 @@ function Resolve-NormalizedInventoryLookup {
         return -1
     }
 
-    $inventoryKey = Get-AdvancedHuntingInventoryMatchKey `
-        -DeviceId ([string]$DeviceId) `
-        -SoftwareVendor ([string]($SoftwareVendor ?? '')) `
-        -SoftwareName ([string]($SoftwareName ?? '')) `
-        -SoftwareVersion ([string]($SoftwareVersion ?? ''))
+    $deviceIdText = [string]$DeviceId
+    if ([string]::IsNullOrWhiteSpace($deviceIdText)) {
+        return -1
+    }
+
+    $inventoryKey = $null
+    $softwareIdentityKeyText = [string]($SoftwareIdentityKey ?? '')
+    if (-not [string]::IsNullOrWhiteSpace($softwareIdentityKeyText)) {
+        $inventoryKey = @(
+            $deviceIdText
+            $softwareIdentityKeyText
+        ) -join '|'
+    }
+    else {
+        $inventoryKey = Get-AdvancedHuntingInventoryMatchKey `
+            -DeviceId $deviceIdText `
+            -SoftwareVendor ([string]($SoftwareVendor ?? '')) `
+            -SoftwareName ([string]($SoftwareName ?? '')) `
+            -SoftwareVersion ([string]($SoftwareVersion ?? ''))
+    }
+
     if ([string]::IsNullOrWhiteSpace($inventoryKey)) {
         return -1
     }
@@ -4929,19 +5021,50 @@ function Get-NormalizedContentLookupCacheEntry {
     [CmdletBinding()]
     [OutputType([object[]])]
     param(
+        [Parameter(Mandatory = $false)]
+        [switch]$IncludeInventoryIdentity,
+
+        [Parameter(Mandatory = $false)]
+        [AllowEmptyString()]
+        [string]$SoftwareInventoryIdentityKey,
+
         [Parameter(Mandatory = $true)]
         [pscustomobject]$ContentLookup
     )
 
-    return [object[]]@(
-        $ContentLookup.sw,
-        $ContentLookup.cve,
-        $ContentLookup.ver,
-        $ContentLookup.upd,
-        $ContentLookup.ua,
-        $ContentLookup.dp,
-        $ContentLookup.rp
+    $cacheEntry = [System.Collections.Generic.List[object]]::new()
+    $cacheEntry.Add($ContentLookup.sw) | Out-Null
+    $cacheEntry.Add($ContentLookup.cve) | Out-Null
+    $cacheEntry.Add($ContentLookup.ver) | Out-Null
+    $cacheEntry.Add($ContentLookup.upd) | Out-Null
+    $cacheEntry.Add($ContentLookup.ua) | Out-Null
+    $cacheEntry.Add($ContentLookup.dp) | Out-Null
+    $cacheEntry.Add($ContentLookup.rp) | Out-Null
+
+    if ($IncludeInventoryIdentity) {
+        $cacheEntry.Add($SoftwareInventoryIdentityKey) | Out-Null
+    }
+
+    return [object[]]$cacheEntry.ToArray()
+}
+
+function Get-ContentStoreDeviceProfileIdentityCache {
+    [CmdletBinding()]
+    [OutputType([string[]])]
+    param(
+        [Parameter(Mandatory = $false)]
+        [switch]$IncludeInventoryIdentity,
+
+        [Parameter(Mandatory = $false)]
+        [AllowNull()]
+        [System.Collections.Generic.List[string]]$DeviceProfileIds
     )
+
+    if (-not $IncludeInventoryIdentity -or $null -eq $DeviceProfileIds) {
+        return $null
+    }
+
+    return ,([string[]]$DeviceProfileIds.ToArray())
 }
 
 function Get-NormalizedRecordLookup {
@@ -5488,8 +5611,11 @@ function Invoke-ContentStoreNormalization {
         throw "Content dictionary '$dictionaryPath' was not found."
     }
 
-    $deviceProfileIds = [System.Collections.Generic.List[string]]::new()
-    $contentInventoryKeys = [System.Collections.Generic.List[object]]::new()
+    $hasInventoryIdentity = ($Context.AdvancedHuntingInventoryData.Count -gt 0)
+    $deviceProfileIds = $null
+    if ($hasInventoryIdentity) {
+        $deviceProfileIds = [System.Collections.Generic.List[string]]::new()
+    }
     $deviceLookupIndices = [System.Collections.Generic.List[int]]::new()
     $deviceOnboardedFlags = [System.Collections.Generic.List[bool]]::new()
     $contentLookupCache = [System.Collections.Generic.List[object]]::new()
@@ -5500,6 +5626,7 @@ function Invoke-ContentStoreNormalization {
     $contentLookupUpdateAvailableIndex = 4
     $contentLookupDiskPathIndex = 5
     $contentLookupRegistryPathIndex = 6
+    $contentLookupSoftwareIdentityKeyIndex = 7
     $processedCountRef = [ref]0
     $firstLastSwappedCountRef = [ref]0
     $writerState = $null
@@ -5509,7 +5636,9 @@ function Invoke-ContentStoreNormalization {
 
     foreach ($deviceProfile in @(Read-VulnContentDictionaryArrayEntries -Path $dictionaryPath -PropertyName 'deviceProfiles')) {
         $deviceId = [string](Get-VulnPropertyValue -InputObject $deviceProfile -Name 'id')
-        $deviceProfileIds.Add($deviceId) | Out-Null
+        if ($hasInventoryIdentity) {
+            $deviceProfileIds.Add($deviceId) | Out-Null
+        }
         $deviceLookupIndices.Add((Add-NormalizedDevice `
                 -DeviceId $deviceId `
                 -DeviceName ([string](Get-VulnPropertyValue -InputObject $deviceProfile -Name 'n')) `
@@ -5521,10 +5650,10 @@ function Invoke-ContentStoreNormalization {
         $deviceOnboardedFlags.Add(((Get-VulnPropertyValue -InputObject $deviceProfile -Name 'ob') -eq $true)) | Out-Null
     }
 
-    $deviceProfiles = $deviceProfileIds.ToArray()
+    $deviceProfiles = Get-ContentStoreDeviceProfileIdentityCache -IncludeInventoryIdentity:$hasInventoryIdentity -DeviceProfileIds $deviceProfileIds
     $deviceLookupIndices = $deviceLookupIndices.ToArray()
     $deviceOnboardedFlags = $deviceOnboardedFlags.ToArray()
-    $deviceProfileCount = $deviceProfiles.Length
+    $deviceProfileCount = $deviceLookupIndices.Length
     $onboardedDeviceProfileCount = @($deviceOnboardedFlags | Where-Object { $_ }).Count
     $deviceProfileIds = $null
 
@@ -5532,14 +5661,21 @@ function Invoke-ContentStoreNormalization {
         $softwareVendor = [string](Get-VulnPropertyValue -InputObject $contentTemplate -Name 'sv')
         $softwareName = [string](Get-VulnPropertyValue -InputObject $contentTemplate -Name 'sn')
         $softwareVersion = [string](Get-VulnPropertyValue -InputObject $contentTemplate -Name 'ver')
+        $softwareInventoryIdentityKey = if ($hasInventoryIdentity -and -not [string]::IsNullOrWhiteSpace($softwareName)) {
+            @(
+                [string]($softwareVendor ?? '')
+                $softwareName
+                [string]($softwareVersion ?? '')
+            ) -join '|'
+        }
+        else {
+            $null
+        }
 
-        $contentInventoryKeys.Add([object[]]@(
-                $softwareVendor,
-                $softwareName,
-                $softwareVersion
-            )) | Out-Null
-
-        $contentLookupCache.Add((Get-NormalizedContentLookupCacheEntry -ContentLookup (Resolve-NormalizedContentLookup `
+        $contentLookupCache.Add((Get-NormalizedContentLookupCacheEntry `
+            -IncludeInventoryIdentity:$hasInventoryIdentity `
+            -SoftwareInventoryIdentityKey $softwareInventoryIdentityKey `
+            -ContentLookup (Resolve-NormalizedContentLookup `
                 -SoftwareVendor $softwareVendor `
                 -SoftwareName $softwareName `
                 -RecommendationReference ([string](Get-VulnPropertyValue -InputObject $contentTemplate -Name 'rr')) `
@@ -5559,10 +5695,8 @@ function Invoke-ContentStoreNormalization {
                 -Context $Context))) | Out-Null
     }
 
-    $contentTemplates = $contentInventoryKeys.ToArray()
     $contentLookupCache = $contentLookupCache.ToArray()
-    $contentTemplateCount = $contentTemplates.Length
-    $contentInventoryKeys = $null
+    $contentTemplateCount = $contentLookupCache.Length
 
     # Ref streaming only needs the compact device/content lookup arrays plus
     # inventory enrichment. Release the larger source maps before processing
@@ -5693,8 +5827,6 @@ function Invoke-ContentStoreNormalization {
                             if (-not $lastSeen) { $lastSeen = '' }
 
                             $contentLookup = $contentLookupCache[$contentTemplateIndexValue]
-                            $contentTemplate = $contentTemplates[$contentTemplateIndexValue]
-                            $deviceProfileId = $deviceProfiles[$deviceProfileIndexValue]
                             $compactRecord[0] = $deviceLookupIndices[$deviceProfileIndexValue]
                             $compactRecord[1] = $contentLookup[$contentLookupCveIndex]
                             $compactRecord[2] = $contentLookup[$contentLookupSwIndex]
@@ -5705,12 +5837,15 @@ function Invoke-ContentStoreNormalization {
                             $compactRecord[7] = $contentLookup[$contentLookupUpdateIndex]
                             $compactRecord[8] = $contentLookup[$contentLookupDiskPathIndex]
                             $compactRecord[9] = $contentLookup[$contentLookupRegistryPathIndex]
-                            $compactRecord[10] = Resolve-NormalizedInventoryLookup `
-                                -DeviceId ([string]$deviceProfileId) `
-                                -SoftwareVendor ([string]$contentTemplate[0]) `
-                                -SoftwareName ([string]$contentTemplate[1]) `
-                                -SoftwareVersion ([string]$contentTemplate[2]) `
-                                -Context $Context
+                            if ($hasInventoryIdentity) {
+                                $compactRecord[10] = Resolve-NormalizedInventoryLookup `
+                                    -DeviceId ([string]$deviceProfiles[$deviceProfileIndexValue]) `
+                                    -SoftwareIdentityKey ([string]$contentLookup[$contentLookupSoftwareIdentityKeyIndex]) `
+                                    -Context $Context
+                            }
+                            else {
+                                $compactRecord[10] = -1
+                            }
 
                             if ($columnStates) {
                                 for ($columnIndex = 0; $columnIndex -lt 11; $columnIndex++) {
@@ -5839,24 +5974,25 @@ function Invoke-ContentStoreNormalization {
                                     if (-not $lastSeen) { $lastSeen = '' }
 
                                     $contentLookup = $contentLookupCache[$ctv]
-                                    $contentTemplate = $contentTemplates[$ctv]
-                                    $deviceProfileId = $deviceProfiles[$dpv]
                                     $compactRecord[0] = $deviceLookupIndices[$dpv]
-                                    $compactRecord[1] = $contentLookup.cve
-                                    $compactRecord[2] = $contentLookup.sw
-                                    $compactRecord[3] = $contentLookup.ver
+                                    $compactRecord[1] = $contentLookup[$contentLookupCveIndex]
+                                    $compactRecord[2] = $contentLookup[$contentLookupSwIndex]
+                                    $compactRecord[3] = $contentLookup[$contentLookupVersionIndex]
                                     $compactRecord[4] = Get-OrCreateIndex -value $firstSeen -list $lookups.dates -indexMap $dateIndex
                                     $compactRecord[5] = Get-OrCreateIndex -value $lastSeen -list $lookups.dates -indexMap $dateIndex
-                                    $compactRecord[6] = $contentLookup.ua
-                                    $compactRecord[7] = $contentLookup.upd
-                                    $compactRecord[8] = $contentLookup.dp
-                                    $compactRecord[9] = $contentLookup.rp
-                                    $compactRecord[10] = Resolve-NormalizedInventoryLookup `
-                                        -DeviceId ([string]$deviceProfileId) `
-                                        -SoftwareVendor ([string]$contentTemplate[0]) `
-                                        -SoftwareName ([string]$contentTemplate[1]) `
-                                        -SoftwareVersion ([string]$contentTemplate[2]) `
-                                        -Context $Context
+                                    $compactRecord[6] = $contentLookup[$contentLookupUpdateAvailableIndex]
+                                    $compactRecord[7] = $contentLookup[$contentLookupUpdateIndex]
+                                    $compactRecord[8] = $contentLookup[$contentLookupDiskPathIndex]
+                                    $compactRecord[9] = $contentLookup[$contentLookupRegistryPathIndex]
+                                    if ($hasInventoryIdentity) {
+                                        $compactRecord[10] = Resolve-NormalizedInventoryLookup `
+                                            -DeviceId ([string]$deviceProfiles[$dpv]) `
+                                            -SoftwareIdentityKey ([string]$contentLookup[$contentLookupSoftwareIdentityKeyIndex]) `
+                                            -Context $Context
+                                    }
+                                    else {
+                                        $compactRecord[10] = -1
+                                    }
 
                                     if ($columnStates) {
                                         for ($columnIndex = 0; $columnIndex -lt 11; $columnIndex++) {
@@ -5935,7 +6071,7 @@ function Invoke-ContentStoreNormalization {
         # Payload finalization only needs the compact lookup collections. Release
         # the much larger content-store scaffolding first so hosted Automation
         # does not carry that transient state into lookup serialization.
-        foreach ($transientArray in @($deviceProfiles, $contentTemplates, $deviceLookupIndices, $deviceOnboardedFlags, $contentLookupCache)) {
+        foreach ($transientArray in @($deviceProfiles, $deviceLookupIndices, $deviceOnboardedFlags, $contentLookupCache)) {
             if ($null -ne $transientArray) {
                 [System.Array]::Clear($transientArray, 0, $transientArray.Length)
             }
@@ -5957,7 +6093,6 @@ function Invoke-ContentStoreNormalization {
         }
 
         $deviceProfiles = $null
-        $contentTemplates = $null
         $deviceLookupIndices = $null
         $deviceOnboardedFlags = $null
         $contentLookupCache = $null

--- a/tests/Run-SharedHelperRegression.ps1
+++ b/tests/Run-SharedHelperRegression.ps1
@@ -1664,9 +1664,15 @@ function Test-ResolveNormalizedInventoryLookupSkipsEmptyInventoryData {
         -SoftwareVersion '6.0.0' `
         -Context $context
 
+    $compactIdentityInventoryIndex = Resolve-NormalizedInventoryLookup `
+        -DeviceId 'device-001' `
+        -SoftwareIdentityKey 'contoso|legacy_agent|6.0.0' `
+        -Context $context
+
     Assert-True ($emptyInventoryIndex -eq -1) 'Expected empty inventory data to skip normalized inventory lookup creation.'
     Assert-True ($context.Lookups.inventory.Count -eq 1) 'Expected only the populated inventory lookup to materialize in the lookup table.'
     Assert-True ($populatedInventoryIndex -eq 0) 'Expected populated inventory data to create the first normalized inventory lookup.'
+    Assert-True ($compactIdentityInventoryIndex -eq $populatedInventoryIndex) 'Expected the compact software identity key to resolve the same normalized inventory lookup.'
     Assert-True ([string]$context.Lookups.inventory[0].cpe -eq 'cpe:/a:contoso:legacy_agent:6.0.0') 'Expected populated inventory lookup to preserve ProductCodeCpe.'
 }
 
@@ -2116,6 +2122,45 @@ function Test-InvokeContentStoreNormalizationReleasesTransientContextBeforePaylo
             Remove-Item -LiteralPath $tempRoot -Recurse -Force -ErrorAction SilentlyContinue
         }
     }
+}
+
+function Test-GetNormalizedContentLookupCacheEntryOmitsInventoryIdentityWhenUnused {
+    [CmdletBinding()]
+    param()
+
+    $contentLookup = [PSCustomObject]@{
+        sw = 1
+        cve = 2
+        ver = 3
+        upd = 4
+        ua = 1
+        dp = ,([int[]]@(5))
+        rp = ,([int[]]@(6))
+    }
+
+    $withoutInventoryIdentity = @(Get-NormalizedContentLookupCacheEntry -ContentLookup $contentLookup)
+    $withInventoryIdentity = @(Get-NormalizedContentLookupCacheEntry -IncludeInventoryIdentity -SoftwareInventoryIdentityKey 'Contoso|Legacy Agent|2.0.0' -ContentLookup $contentLookup)
+
+    Assert-True ($withoutInventoryIdentity.Count -eq 7) 'Expected content lookup cache entries without inventory data to omit the extra software identity fields.'
+    Assert-True ($withInventoryIdentity.Count -eq 8) 'Expected content lookup cache entries with inventory data to retain only the compact software identity key.'
+    Assert-True ([string]$withInventoryIdentity[7] -eq 'Contoso|Legacy Agent|2.0.0') 'Expected inventory-aware cache entries to preserve the compact software identity key.'
+}
+
+function Test-GetContentStoreDeviceProfileIdentityCacheOmitsIdsWhenUnused {
+    [CmdletBinding()]
+    param()
+
+    $deviceProfileIds = [System.Collections.Generic.List[string]]::new()
+    $deviceProfileIds.Add('device-001') | Out-Null
+    $deviceProfileIds.Add('device-002') | Out-Null
+
+    $withoutInventoryIdentity = @(Get-ContentStoreDeviceProfileIdentityCache -DeviceProfileIds $deviceProfileIds)
+    $withInventoryIdentity = @(Get-ContentStoreDeviceProfileIdentityCache -IncludeInventoryIdentity -DeviceProfileIds $deviceProfileIds)
+
+    Assert-True ($withoutInventoryIdentity.Count -eq 0) 'Expected content-store device profile identity cache to stay empty when inventory enrichment is not in use.'
+    Assert-True ($withInventoryIdentity.Count -eq 2) 'Expected content-store device profile identity cache to preserve device IDs when inventory enrichment is enabled.'
+    Assert-True ([string]$withInventoryIdentity[0] -eq 'device-001') 'Expected the first cached device ID to be preserved for inventory enrichment.'
+    Assert-True ([string]$withInventoryIdentity[1] -eq 'device-002') 'Expected the second cached device ID to be preserved for inventory enrichment.'
 }
 
 function Test-ConvertToNormalizedDataDeduplicatesRepeatedCveLookup {


### PR DESCRIPTION
## Summary
- trim transient content-store normalization state when Advanced Hunting inventory enrichment is absent
- compact inventory-aware cache identity to a single software identity key and add regressions for the new cache behavior
- reuse shared dashboard library cache files across repo-local outputs to avoid repeated downloads
- add Azure blob REST fallbacks in setup and Azure deployment validation when CLI login-mode blob operations fail on this machine

## Validation
- pwsh -NoProfile -File .\tests\Run-SharedHelperRegression.ps1
- pwsh -NoProfile -File .\build\Invoke-RegressionValidation.ps1
- pwsh -NoProfile -File .\tests\Invoke-LargeDatasetValidation.ps1 -SkipSyntheticGeneration -SyntheticOutputPath .\.local\large-datasets\synthetic-50k-1_5m -Validate -ValidationMode artifacts
- pwsh -NoProfile -File .\tests\Invoke-LargeDatasetValidation.ps1 -SkipSyntheticGeneration -SyntheticOutputPath .\.local\large-datasets\synthetic-50k-1_5m -Validate -ValidationMode semantic -AllowLargeSemanticValidation
- pwsh -NoProfile -File .\build\Invoke-LiveDashboardDryRun.ps1 -UseExistingAzContext
- pwsh -NoProfile -File .\build\Invoke-AzureDeploymentValidation.ps1 -AutomationAccountName aa-defender-reporting -FunctionAppName func-defender-reporting -SkipMdePermissions -DashboardDeliveryMode Hosted -FunctionExecutionDatasetPath .\.local\large-datasets\synthetic-50k-1_5m -FunctionExecutionTimeoutMinutes 30

## Azure result snapshot
- Automation validation passed on the 50k device / 1.5M row dataset
- Hosted Function App validation passed and wrote the dashboard blob during the acceptance run
- Latest hosted Function App acceptance run wrote the dashboard blob at 2026-05-06T06:33:39Z after invocation at 2026-05-06T06:26:05Z