### PR TITLE
Add Stage 0 pipeline observability

### DIFF
--- a/azure/Invoke-DashboardPipeline.ps1
+++ b/azure/Invoke-DashboardPipeline.ps1
@@ -159,8 +159,12 @@ $Script:PipelineControlBlobName = '_diagnostics/ExportAndGenerate.control.json'
 $Script:PipelineStatusBlobName = '_diagnostics/ExportAndGenerate.status.json'
 $Script:PipelineRunId = [guid]::NewGuid().ToString('N')
 $Script:PipelineStartedOnUtc = [datetime]::UtcNow
+$Script:PipelineArchitectureVersion = 'monolithic-v1'
+$Script:PipelineArchitectureTrack = 'stage0-observability'
 $Script:PipelineCurrentStage = 'Initializing'
 $Script:PipelineCurrentStageMessage = 'Initializing pipeline.'
+$Script:PipelineCurrentStageEnteredOnUtc = $Script:PipelineStartedOnUtc
+$Script:PipelineNormalizedPayloadCacheHit = $null
 $Script:PipelineExecutionHostDescriptor = Resolve-PipelineExecutionHostDescriptor
 $Script:PipelineExecutionHost = [string]$Script:PipelineExecutionHostDescriptor.Name
 
@@ -15044,6 +15048,98 @@ function Write-NormalizedCompactRecordFromLookup {
     Write-NormalizedCompactRecord -WriterState $WriterState -Record $Record
 }
 
+function New-NormalizationProgressState {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '', Justification = 'Internal helper only creates an in-memory normalization progress tracker.')]
+    [CmdletBinding()]
+    [OutputType([pscustomobject])]
+    param(
+        [Parameter(Mandatory = $false)]
+        [ValidateRange(1, 1000000)]
+        [int]$ProgressInterval = 50000,
+
+        [Parameter(Mandatory = $false)]
+        [ValidateRange(15, 3600)]
+        [int]$HeartbeatIntervalSeconds = 60,
+
+        [Parameter(Mandatory = $false)]
+        [ValidateRange(1, 1000000)]
+        [int]$CheckInterval = 10000
+    )
+
+    return [PSCustomObject]@{
+        ProgressInterval = $ProgressInterval
+        HeartbeatIntervalSeconds = $HeartbeatIntervalSeconds
+        CheckInterval = [Math]::Max(1, [Math]::Min($ProgressInterval, $CheckInterval))
+        Stopwatch = [System.Diagnostics.Stopwatch]::StartNew()
+        LastHeartbeatSecond = -1
+    }
+}
+
+function Invoke-NormalizationCallbackEvent {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $false)]
+        [scriptblock]$Callback,
+
+        [Parameter(Mandatory = $true)]
+        $EventData
+    )
+
+    if ($null -eq $Callback -or $null -eq $EventData) {
+        return
+    }
+
+    try {
+        & $Callback $EventData
+    }
+    catch {
+        Write-Verbose ("Normalization callback failed: {0}" -f $_.Exception.Message)
+    }
+}
+
+function Invoke-NormalizationProgressCallback {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $false)]
+        $State,
+
+        [Parameter(Mandatory = $true)]
+        [long]$Count,
+
+        [Parameter(Mandatory = $false)]
+        [scriptblock]$Callback
+    )
+
+    if ($null -eq $State -or $Count -le 0 -or $null -eq $Callback) {
+        return
+    }
+
+    $markerType = 'progress'
+    $shouldInvoke = (($Count % [long]$State.ProgressInterval) -eq 0)
+    if (-not $shouldInvoke -and (($Count % [long]$State.CheckInterval) -eq 0)) {
+        $elapsedWholeSeconds = [Math]::Floor($State.Stopwatch.Elapsed.TotalSeconds)
+        if (($State.LastHeartbeatSecond + [int]$State.HeartbeatIntervalSeconds) -le $elapsedWholeSeconds) {
+            $shouldInvoke = $true
+            $markerType = 'heartbeat'
+        }
+    }
+
+    if (-not $shouldInvoke) {
+        return
+    }
+
+    $elapsedSeconds = [Math]::Max(0.001, $State.Stopwatch.Elapsed.TotalSeconds)
+    $rate = [Math]::Round(($Count / $elapsedSeconds), 0)
+    Invoke-NormalizationCallbackEvent -Callback $Callback -EventData ([PSCustomObject]@{
+            Kind = 'progress'
+            Count = $Count
+            ElapsedSeconds = [Math]::Round($elapsedSeconds, 1)
+            RatePerSecond = $rate
+            MarkerType = $markerType
+        })
+    $State.LastHeartbeatSecond = [Math]::Floor($State.Stopwatch.Elapsed.TotalSeconds)
+}
+
 function Write-NormalizedSourceRow {
     [CmdletBinding()]
     param(
@@ -15058,6 +15154,12 @@ function Write-NormalizedSourceRow {
 
         [Parameter(Mandatory = $true)]
         [ref]$ProcessedCount,
+
+        [Parameter(Mandatory = $false)]
+        $NormalizationProgressState,
+
+        [Parameter(Mandatory = $false)]
+        [scriptblock]$NormalizationProgressCallback,
 
         [Parameter(Mandatory = $false)]
         [AllowNull()]
@@ -15195,6 +15297,8 @@ function Write-NormalizedSourceRow {
         -FirstSeenValue $FirstSeenValue `
         -LastSeenValue $LastSeenValue `
         -FirstLastSwappedCount $FirstLastSwappedCount
+
+    Invoke-NormalizationProgressCallback -State $NormalizationProgressState -Count $ProcessedCount.Value -Callback $NormalizationProgressCallback
 
     if (($ProcessedCount.Value % 50000) -eq 0) {
         Write-Information ("  Processed {0} onboarded vulnerability record(s)..." -f $ProcessedCount.Value) -InformationAction Continue
@@ -15373,6 +15477,12 @@ function Invoke-ContentStoreNormalization {
         [string[]]$MergedRefPaths,
 
         [Parameter(Mandatory = $false)]
+        $NormalizationProgressState,
+
+        [Parameter(Mandatory = $false)]
+        [scriptblock]$NormalizationProgressCallback,
+
+        [Parameter(Mandatory = $false)]
         [string]$PayloadOutputPath,
 
         [Parameter(Mandatory = $false)]
@@ -15418,6 +15528,12 @@ function Invoke-ContentStoreNormalization {
     $lookupCountSummary = $null
     $consumeLookups = ($ConsumeLookupsOnPayloadClose -and -not [string]::IsNullOrWhiteSpace($PayloadOutputPath))
 
+    Invoke-NormalizationCallbackEvent -Callback $NormalizationProgressCallback -EventData ([PSCustomObject]@{
+            Kind = 'phase'
+            Phase = 'LoadContentStoreDeviceProfiles'
+            Message = 'Loading content-store device profiles into normalization lookups.'
+        })
+
     foreach ($deviceProfile in @(Read-VulnContentDictionaryArrayEntries -Path $dictionaryPath -PropertyName 'deviceProfiles')) {
         $deviceId = [string](Get-VulnPropertyValue -InputObject $deviceProfile -Name 'id')
         if ($hasInventoryIdentity) {
@@ -15440,6 +15556,12 @@ function Invoke-ContentStoreNormalization {
     $deviceProfileCount = $deviceLookupIndices.Length
     $onboardedDeviceProfileCount = @($deviceOnboardedFlags | Where-Object { $_ }).Count
     $deviceProfileIds = $null
+
+    Invoke-NormalizationCallbackEvent -Callback $NormalizationProgressCallback -EventData ([PSCustomObject]@{
+            Kind = 'phase'
+            Phase = 'LoadContentStoreTemplates'
+            Message = 'Loading content-store vulnerability templates into normalization lookups.'
+        })
 
     foreach ($contentTemplate in @(Read-VulnContentDictionaryArrayEntries -Path $dictionaryPath -PropertyName 'contentTemplates')) {
         $softwareVendor = [string](Get-VulnPropertyValue -InputObject $contentTemplate -Name 'sv')
@@ -15490,6 +15612,12 @@ function Invoke-ContentStoreNormalization {
     $Context.AdvancedHuntingDeviceUsers = @{}
     $Context.NvdCveData = @{}
     Invoke-FullGarbageCollection
+
+    Invoke-NormalizationCallbackEvent -Callback $NormalizationProgressCallback -EventData ([PSCustomObject]@{
+            Kind = 'phase'
+            Phase = 'StreamContentStoreRefs'
+            Message = 'Streaming content-store vulnerability references into the normalized payload.'
+        })
 
     try {
         $writerState = Open-NormalizedVulnWriter -VulnOutputPath $VulnOutputPath -VulnColumnDirectoryPath $VulnColumnDirectoryPath -PayloadOutputPath $PayloadOutputPath
@@ -15681,6 +15809,8 @@ function Invoke-ContentStoreNormalization {
                                 Write-CompactVulnRecordJson -Writer $jsonWriter -Record $compactRecord
                             }
 
+                            Invoke-NormalizationProgressCallback -State $NormalizationProgressState -Count $processedCountRef.Value -Callback $NormalizationProgressCallback
+
                             if (($processedCountRef.Value % 50000) -eq 0) {
                                 Write-Information ("  Processed {0} onboarded vulnerability record(s)..." -f $processedCountRef.Value) -InformationAction Continue
                             }
@@ -15828,6 +15958,8 @@ function Invoke-ContentStoreNormalization {
                                         Write-CompactVulnRecordJson -Writer $jsonWriter -Record $compactRecord
                                     }
 
+                                    Invoke-NormalizationProgressCallback -State $NormalizationProgressState -Count $processedCountRef.Value -Callback $NormalizationProgressCallback
+
                                     if (($processedCountRef.Value % 50000) -eq 0) {
                                         Write-Information ("  Processed {0} onboarded vulnerability record(s)..." -f $processedCountRef.Value) -InformationAction Continue
                                     }
@@ -15965,6 +16097,12 @@ function Invoke-RawStoreNormalization {
         [hashtable]$NvdCveData = @{},
 
         [Parameter(Mandatory = $false)]
+        $NormalizationProgressState,
+
+        [Parameter(Mandatory = $false)]
+        [scriptblock]$NormalizationProgressCallback,
+
+        [Parameter(Mandatory = $false)]
         [string]$PayloadOutputPath,
 
         [Parameter(Mandatory = $false)]
@@ -15985,6 +16123,14 @@ function Invoke-RawStoreNormalization {
     $compactRecord = [object[]]@(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -1)
     $lookupCountSummary = $null
     $consumeLookups = ($ConsumeLookupsOnPayloadClose -and -not [string]::IsNullOrWhiteSpace($PayloadOutputPath))
+    $normalizationProgressStateForStream = $NormalizationProgressState
+    $normalizationProgressCallbackForStream = $NormalizationProgressCallback
+
+    Invoke-NormalizationCallbackEvent -Callback $NormalizationProgressCallback -EventData ([PSCustomObject]@{
+            Kind = 'phase'
+            Phase = 'StreamRawVulnStoreRows'
+            Message = 'Streaming raw vulnerability store rows into the normalized payload.'
+        })
 
     try {
         $writerState = Open-NormalizedVulnWriter -VulnOutputPath $VulnOutputPath -VulnColumnDirectoryPath $VulnColumnDirectoryPath -PayloadOutputPath $PayloadOutputPath
@@ -16327,7 +16473,9 @@ function Invoke-RawStoreNormalization {
                             -Context $Context `
                             -FirstSeenValue $seenFirstValue `
                             -LastSeenValue $seenLastValue `
-                            -FirstLastSwappedCount $firstLastSwappedCountRef
+                            -FirstLastSwappedCount $firstLastSwappedCountRef `
+                            -NormalizationProgressState $normalizationProgressStateForStream `
+                            -NormalizationProgressCallback $normalizationProgressCallbackForStream
                 }
 
                 if (Get-Command -Name Write-MemoryUsage -ErrorAction SilentlyContinue) {
@@ -16770,7 +16918,10 @@ function ConvertTo-NormalizedData {
         [string]$PayloadOutputPath,
 
         [Parameter(Mandatory = $false)]
-        [switch]$ConsumeLookupsOnPayloadClose
+        [switch]$ConsumeLookupsOnPayloadClose,
+
+        [Parameter(Mandatory = $false)]
+        [scriptblock]$NormalizationProgressCallback
     )
 
     Write-Information '  Normalizing data structure...' -InformationAction Continue
@@ -16793,6 +16944,7 @@ function ConvertTo-NormalizedData {
     $autoColumnDir = $null
     $lookupCountSummary = $null
     $consumeLookups = ($ConsumeLookupsOnPayloadClose -and -not [string]::IsNullOrWhiteSpace($PayloadOutputPath))
+    $normalizationProgressState = if ($null -ne $NormalizationProgressCallback) { New-NormalizationProgressState } else { $null }
 
     # Auto-enable column-store format for better gzip compression when caller
     # has not explicitly specified a column directory.
@@ -16821,7 +16973,7 @@ function ConvertTo-NormalizedData {
         else {
             Write-Information '  Content-store detected; using fast path (no merge).' -InformationAction Continue
         }
-        $rawNormalizationResult = Invoke-ContentStoreNormalization -DataPath $DataPath -VulnOutputPath $VulnOutputPath -VulnColumnDirectoryPath $VulnColumnDirectoryPath -Context $context -Machines $Machines -AdvancedHuntingData $AdvancedHuntingData -AdvancedHuntingDeviceUsers $AdvancedHuntingDeviceUsers -AdvancedHuntingInventoryData $AdvancedHuntingInventoryData -NvdCveData $NvdCveData -MergedRefPaths $mergedRefPaths -PayloadOutputPath $PayloadOutputPath -ConsumeLookupsOnPayloadClose:$consumeLookups
+        $rawNormalizationResult = Invoke-ContentStoreNormalization -DataPath $DataPath -VulnOutputPath $VulnOutputPath -VulnColumnDirectoryPath $VulnColumnDirectoryPath -Context $context -Machines $Machines -AdvancedHuntingData $AdvancedHuntingData -AdvancedHuntingDeviceUsers $AdvancedHuntingDeviceUsers -AdvancedHuntingInventoryData $AdvancedHuntingInventoryData -NvdCveData $NvdCveData -MergedRefPaths $mergedRefPaths -NormalizationProgressState $normalizationProgressState -NormalizationProgressCallback $NormalizationProgressCallback -PayloadOutputPath $PayloadOutputPath -ConsumeLookupsOnPayloadClose:$consumeLookups
         $processedCount = [int]$rawNormalizationResult.ProcessedCount
         $firstLastSwappedCount = [int]$rawNormalizationResult.FirstLastSwappedCount
         $hasNoTags = ($rawNormalizationResult.HasNoTags -eq $true)
@@ -16840,7 +16992,7 @@ function ConvertTo-NormalizedData {
     }
     elseif ($effectiveSkipObservedWindowMerge -and $storeExists) {
         Write-Information '  Raw store detected; using raw store normalization fast path.' -InformationAction Continue
-        $rawNormalizationResult = Invoke-RawStoreNormalization -DataPath $DataPath -VulnOutputPath $VulnOutputPath -VulnColumnDirectoryPath $VulnColumnDirectoryPath -Context $context -Machines $Machines -AdvancedHuntingData $AdvancedHuntingData -AdvancedHuntingDeviceUsers $AdvancedHuntingDeviceUsers -AdvancedHuntingInventoryData $AdvancedHuntingInventoryData -NvdCveData $NvdCveData -PayloadOutputPath $PayloadOutputPath -ConsumeLookupsOnPayloadClose:$consumeLookups
+        $rawNormalizationResult = Invoke-RawStoreNormalization -DataPath $DataPath -VulnOutputPath $VulnOutputPath -VulnColumnDirectoryPath $VulnColumnDirectoryPath -Context $context -Machines $Machines -AdvancedHuntingData $AdvancedHuntingData -AdvancedHuntingDeviceUsers $AdvancedHuntingDeviceUsers -AdvancedHuntingInventoryData $AdvancedHuntingInventoryData -NvdCveData $NvdCveData -NormalizationProgressState $normalizationProgressState -NormalizationProgressCallback $NormalizationProgressCallback -PayloadOutputPath $PayloadOutputPath -ConsumeLookupsOnPayloadClose:$consumeLookups
         $processedCount = [int]$rawNormalizationResult.ProcessedCount
         $firstLastSwappedCount = [int]$rawNormalizationResult.FirstLastSwappedCount
         $hasNoTags = ($rawNormalizationResult.HasNoTags -eq $true)
@@ -16861,6 +17013,12 @@ function ConvertTo-NormalizedData {
         try {
             $writerState = Open-NormalizedVulnWriter -VulnOutputPath $VulnOutputPath -VulnColumnDirectoryPath $VulnColumnDirectoryPath -PayloadOutputPath $PayloadOutputPath
             $compactRecord = [object[]]@(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -1)
+
+            Invoke-NormalizationCallbackEvent -Callback $NormalizationProgressCallback -EventData ([PSCustomObject]@{
+                    Kind = 'phase'
+                    Phase = 'StreamNormalizationSourceRows'
+                    Message = 'Streaming normalization source rows into the normalized payload.'
+                })
 
             # IMPORTANT: Use pipeline (| ForEach-Object) not foreach() to avoid
             # collecting all source rows into memory at once.
@@ -16896,7 +17054,9 @@ function ConvertTo-NormalizedData {
                     -Context $context `
                     -FirstSeenValue $v.PSObject.Properties['FirstSeenTimestamp']?.Value `
                     -LastSeenValue $v.PSObject.Properties['LastSeenTimestamp']?.Value `
-                    -FirstLastSwappedCount ([ref]$firstLastSwappedCount)
+                        -FirstLastSwappedCount ([ref]$firstLastSwappedCount) `
+                        -NormalizationProgressState $normalizationProgressState `
+                        -NormalizationProgressCallback $NormalizationProgressCallback
             }
 
             Sync-NormalizedVulnWriter -WriterState $writerState
@@ -17003,6 +17163,7 @@ function Set-PipelineExecutionStage {
 
     $Script:PipelineCurrentStage = $Stage
     $Script:PipelineCurrentStageMessage = $Message
+    $Script:PipelineCurrentStageEnteredOnUtc = [datetime]::UtcNow
 }
 
 function Write-PipelineExecutionStatus {
@@ -17041,10 +17202,13 @@ function Write-PipelineExecutionStatus {
             runId = $Script:PipelineRunId
             executionHost = $Script:PipelineExecutionHost
             executionHostEvidence = if ($null -ne $Script:PipelineExecutionHostDescriptor) { [string]$Script:PipelineExecutionHostDescriptor.Evidence } else { $null }
+            pipelineArchitectureVersion = $Script:PipelineArchitectureVersion
+            pipelineArchitectureTrack = $Script:PipelineArchitectureTrack
             status = $Status
             stage = $Stage
             message = $Message
             startedOnUtc = $Script:PipelineStartedOnUtc.ToString('o')
+            stageEnteredOnUtc = $Script:PipelineCurrentStageEnteredOnUtc.ToString('o')
             updatedOnUtc = ([datetime]::UtcNow).ToString('o')
             storageAccountName = $AccountName
             dashboardDeliveryMode = if ([string]::IsNullOrWhiteSpace($DashboardDeliveryMode)) { $null } else { $DashboardDeliveryMode }
@@ -17059,6 +17223,10 @@ function Write-PipelineExecutionStatus {
 
         foreach ($key in $AdditionalProperties.Keys) {
             $statusDocument[$key] = $AdditionalProperties[$key]
+        }
+
+        if ($null -ne $Script:PipelineNormalizedPayloadCacheHit) {
+            $statusDocument.normalizedPayloadCacheHit = [bool]$Script:PipelineNormalizedPayloadCacheHit
         }
 
         $statusDocument | ConvertTo-Json -Depth 12 | Set-Content -LiteralPath $statusFilePath -Encoding utf8
@@ -18049,13 +18217,18 @@ try {
     $tempPayloadPath = Join-Path -Path $tempRoot -ChildPath 'payload.json.gz'
     $syntheticManifestPath = Join-Path -Path $tempExports -ChildPath 'synthetic-manifest.json'
     $skipObservedWindowMerge = (Test-Path -LiteralPath $syntheticManifestPath -PathType Leaf)
+    Set-PipelineExecutionStage -Stage 'CheckDashboardPayloadCache' -Message 'Checking for a reusable normalized payload cache.'
+    [void](Write-PipelineExecutionStatus -AccountName $StorageAccountName -StorageToken $storageToken -Status 'running')
     $payloadCacheEntry = Get-NormalizedPayloadCacheEntry -BasePath $tempExports -SkipObservedWindowMerge:$skipObservedWindowMerge
+    $Script:PipelineNormalizedPayloadCacheHit = ($null -ne $payloadCacheEntry)
     Invoke-FullGarbageCollection
     Write-MemoryUsage -Label "Post-PayloadCacheCheck"
     $machines = $null
     $advancedHuntingData = $null
     $normalizedQuality = $null
     if ($payloadCacheEntry) {
+        Set-PipelineExecutionStage -Stage 'PrepareDashboardPayload' -Message 'Reusing the cached normalized payload for dashboard packaging.'
+        [void](Write-PipelineExecutionStatus -AccountName $StorageAccountName -StorageToken $storageToken -Status 'running')
         Write-Output "Preparing data for embedding..."
         Write-Output ("  Reusing cached normalized payload ({0})..." -f $payloadCacheEntry.Fingerprint.Substring(0, 12))
         Copy-Item -LiteralPath $payloadCacheEntry.PayloadPath -Destination $tempPayloadPath -Force
@@ -18066,6 +18239,8 @@ try {
     }
     else {
         # Step 1: Read machine and Advanced Hunting data
+        Set-PipelineExecutionStage -Stage 'ReadNormalizationInputs' -Message 'Loading machine and Advanced Hunting inputs for dashboard normalization.'
+        [void](Write-PipelineExecutionStatus -AccountName $StorageAccountName -StorageToken $storageToken -Status 'running')
         $machines = Read-NormalizationMachineLookup -Path $tempExports
         Invoke-FullGarbageCollection
         Write-MemoryUsage -Label "Post-MachineRead"
@@ -18090,11 +18265,62 @@ try {
         Write-MemoryUsage -Label "Post-NormalizationInputs"
 
         # Step 2: Normalize data while the working set is still lean
+        Set-PipelineExecutionStage -Stage 'NormalizeDashboardData' -Message 'Normalizing export data into the compact dashboard payload model.'
+        [void](Write-PipelineExecutionStatus -AccountName $StorageAccountName -StorageToken $storageToken -Status 'running')
         Write-Output "Normalizing data..."
         if ($skipObservedWindowMerge) {
             Write-Output "Synthetic manifest detected. Skipping observed-window merge for stress normalization."
         }
-        $normalizedResult = ConvertTo-NormalizedData -DataPath $tempExports -VulnOutputPath $tempVulnsPath -PayloadOutputPath $tempPayloadPath -Machines $machines -AdvancedHuntingData $advancedHuntingData -AdvancedHuntingDeviceUsers $advancedHuntingDeviceUsers -SkipObservedWindowMerge:$skipObservedWindowMerge -ConsumeLookupsOnPayloadClose
+        $normalizationStatusState = @{
+            SubPhase = $null
+            PhaseMessage = $Script:PipelineCurrentStageMessage
+            PhaseStartedOnUtc = [datetime]::UtcNow
+            PhaseRowCountBase = 0L
+            LastReportedRowCount = 0L
+        }
+        $normalizedResult = ConvertTo-NormalizedData -DataPath $tempExports -VulnOutputPath $tempVulnsPath -PayloadOutputPath $tempPayloadPath -Machines $machines -AdvancedHuntingData $advancedHuntingData -AdvancedHuntingDeviceUsers $advancedHuntingDeviceUsers -SkipObservedWindowMerge:$skipObservedWindowMerge -ConsumeLookupsOnPayloadClose -NormalizationProgressCallback {
+            param($NormalizationEvent)
+
+            if ($null -eq $NormalizationEvent) {
+                return
+            }
+
+            $additionalProperties = @{}
+            $statusMessage = $Script:PipelineCurrentStageMessage
+            $eventKind = if ($NormalizationEvent.PSObject.Properties['Kind']) { [string]$NormalizationEvent.Kind } else { '' }
+            switch ($eventKind) {
+                'phase' {
+                    $normalizationStatusState.SubPhase = if ($NormalizationEvent.PSObject.Properties['Phase']) { [string]$NormalizationEvent.Phase } else { $null }
+                    $normalizationStatusState.PhaseMessage = if ($NormalizationEvent.PSObject.Properties['Message']) { [string]$NormalizationEvent.Message } else { $Script:PipelineCurrentStageMessage }
+                    $normalizationStatusState.PhaseStartedOnUtc = [datetime]::UtcNow
+                    $normalizationStatusState.PhaseRowCountBase = [long]$normalizationStatusState.LastReportedRowCount
+                    $statusMessage = [string]$normalizationStatusState.PhaseMessage
+                    if (-not [string]::IsNullOrWhiteSpace([string]$normalizationStatusState.SubPhase)) {
+                        $additionalProperties['normalizedSubPhase'] = [string]$normalizationStatusState.SubPhase
+                    }
+                }
+                'progress' {
+                    $currentRowCount = [long]$NormalizationEvent.Count
+                    $normalizationStatusState.LastReportedRowCount = $currentRowCount
+                    $phaseElapsedSeconds = [Math]::Max(0.001, ([datetime]::UtcNow - [datetime]$normalizationStatusState.PhaseStartedOnUtc).TotalSeconds)
+                    $phaseProcessedCount = [Math]::Max(0L, ($currentRowCount - [long]$normalizationStatusState.PhaseRowCountBase))
+                    $phaseRate = [Math]::Round(($phaseProcessedCount / $phaseElapsedSeconds), 0)
+                    $statusMessage = ('{0} Processed {1:N0} onboarded vulnerability record(s) over {2:N1}s in the current subphase ({3:N0}/s).' -f [string]$normalizationStatusState.PhaseMessage, $currentRowCount, $phaseElapsedSeconds, $phaseRate)
+                    if (-not [string]::IsNullOrWhiteSpace([string]$normalizationStatusState.SubPhase)) {
+                        $additionalProperties['normalizedSubPhase'] = [string]$normalizationStatusState.SubPhase
+                    }
+                    $additionalProperties['normalizedRowCount'] = $currentRowCount
+                    $additionalProperties['normalizedSubPhaseRowCount'] = $phaseProcessedCount
+                    $additionalProperties['normalizedProgressElapsedSeconds'] = [Math]::Round($phaseElapsedSeconds, 1)
+                    $additionalProperties['normalizedRowRatePerSecond'] = $phaseRate
+                    if ($NormalizationEvent.PSObject.Properties['MarkerType']) {
+                        $additionalProperties['normalizedProgressMarkerType'] = [string]$NormalizationEvent.MarkerType
+                    }
+                }
+            }
+
+            [void](Write-PipelineExecutionStatus -AccountName $StorageAccountName -StorageToken $storageToken -Status 'running' -Stage 'NormalizeDashboardData' -Message $statusMessage -AdditionalProperties $additionalProperties)
+        }
         Write-MemoryUsage -Label "Post-ConvertToNormalizedData"
         $machines = $null
         $advancedHuntingData = $null
@@ -18103,6 +18329,8 @@ try {
         Write-MemoryUsage -Label "Post-NormalizationCleanup"
 
         # Step 3: Prepare payload for embedding
+        Set-PipelineExecutionStage -Stage 'PrepareDashboardPayload' -Message 'Preparing and caching the normalized payload for dashboard packaging.'
+        [void](Write-PipelineExecutionStatus -AccountName $StorageAccountName -StorageToken $storageToken -Status 'running')
         Write-Output "Preparing data for embedding..."
         $vulnCount = $normalizedResult.VulnCount
         $deviceCount = [int]$normalizedResult.DeviceCount
@@ -18147,6 +18375,8 @@ try {
     $requiresEmbeddedBundles = ($DashboardDeliveryMode -ne 'Hosted')
 
     # Step 4: Download JavaScript libraries
+    Set-PipelineExecutionStage -Stage 'PrepareDashboardLibraries' -Message 'Preparing cached client libraries for dashboard packaging.'
+    [void](Write-PipelineExecutionStatus -AccountName $StorageAccountName -StorageToken $storageToken -Status 'running')
     Write-Output "Preparing dashboard client libraries..."
     $lib = $Script:LibraryConfig.ChartJs
     $chartJsLibraryPath = Save-JSLibraryFile -Url $lib.Url -Name $lib.Name -OutputPath (Join-Path $tempLibraries 'chart.js') -Critical $lib.Critical
@@ -18174,6 +18404,8 @@ try {
     Invoke-PhaseTransitionGarbageCollection -MemoryLabel 'Pre-TemplateLoad'
 
     # Step 5: Load templates
+    Set-PipelineExecutionStage -Stage 'LoadDashboardTemplates' -Message 'Loading dashboard templates before final artifact assembly.'
+    [void](Write-PipelineExecutionStatus -AccountName $StorageAccountName -StorageToken $storageToken -Status 'running')
     Write-Output "Loading templates..."
     $htmlTemplatePath = Join-Path -Path $tempTemplates -ChildPath "dashboard.html"
     $cssTemplatePath = Join-Path -Path $tempTemplates -ChildPath "dashboard.css"

--- a/build/Invoke-AzureDeploymentValidation.ps1
+++ b/build/Invoke-AzureDeploymentValidation.ps1
@@ -1205,7 +1205,7 @@ function Get-FunctionExecutionStatusSummaryText {
         $rowCountText = [string]$StatusDocument.normalizedRowCount
         [long]$rowCountValue = 0
         if ([long]::TryParse($rowCountText, [ref]$rowCountValue)) {
-            $metadataParts.Add(("rows={0:N0}" -f $rowCountValue)) | Out-Null
+            $metadataParts.Add(("rows={0}" -f $rowCountValue.ToString('N0', [System.Globalization.CultureInfo]::InvariantCulture))) | Out-Null
         }
         elseif (-not [string]::IsNullOrWhiteSpace($rowCountText)) {
             $metadataParts.Add("rows=$rowCountText") | Out-Null

--- a/build/Invoke-AzureDeploymentValidation.ps1
+++ b/build/Invoke-AzureDeploymentValidation.ps1
@@ -1177,11 +1177,46 @@ function Get-FunctionExecutionStatusSummaryText {
     $statusText = if ($StatusDocument.PSObject.Properties['status']) { [string]$StatusDocument.status } else { 'unknown' }
     $stageText = if ($StatusDocument.PSObject.Properties['stage']) { [string]$StatusDocument.stage } else { 'unknown' }
     $messageText = if ($StatusDocument.PSObject.Properties['message']) { [string]$StatusDocument.message } else { '' }
-    if ([string]::IsNullOrWhiteSpace($messageText)) {
-        return ("{0}/{1}" -f $statusText, $stageText)
+    $summaryText = if ([string]::IsNullOrWhiteSpace($messageText)) {
+        ("{0}/{1}" -f $statusText, $stageText)
+    }
+    else {
+        ("{0}/{1}: {2}" -f $statusText, $stageText, $messageText)
     }
 
-    return ("{0}/{1}: {2}" -f $statusText, $stageText, $messageText)
+    $metadataParts = [System.Collections.Generic.List[string]]::new()
+    $architectureVersionText = if ($StatusDocument.PSObject.Properties['pipelineArchitectureVersion']) { [string]$StatusDocument.pipelineArchitectureVersion } else { '' }
+    if (-not [string]::IsNullOrWhiteSpace($architectureVersionText)) {
+        $metadataParts.Add("arch=$architectureVersionText") | Out-Null
+    }
+
+    if ($StatusDocument.PSObject.Properties['normalizedPayloadCacheHit']) {
+        $metadataParts.Add(("payloadCache={0}" -f $(if ([bool]$StatusDocument.normalizedPayloadCacheHit) { 'hit' } else { 'miss' }))) | Out-Null
+    }
+
+    if ($StatusDocument.PSObject.Properties['normalizedSubPhase']) {
+        $subPhaseText = [string]$StatusDocument.normalizedSubPhase
+        if (-not [string]::IsNullOrWhiteSpace($subPhaseText)) {
+            $metadataParts.Add("subphase=$subPhaseText") | Out-Null
+        }
+    }
+
+    if ($StatusDocument.PSObject.Properties['normalizedRowCount']) {
+        $rowCountText = [string]$StatusDocument.normalizedRowCount
+        [long]$rowCountValue = 0
+        if ([long]::TryParse($rowCountText, [ref]$rowCountValue)) {
+            $metadataParts.Add(("rows={0:N0}" -f $rowCountValue)) | Out-Null
+        }
+        elseif (-not [string]::IsNullOrWhiteSpace($rowCountText)) {
+            $metadataParts.Add("rows=$rowCountText") | Out-Null
+        }
+    }
+
+    if ($metadataParts.Count -eq 0) {
+        return $summaryText
+    }
+
+    return ("{0} ({1})" -f $summaryText, ($metadataParts -join ', '))
 }
 
 function Set-FunctionExecutionControlBlob {

--- a/build/azure/runbook-source.ps1
+++ b/build/azure/runbook-source.ps1
@@ -159,8 +159,12 @@ $Script:PipelineControlBlobName = '_diagnostics/ExportAndGenerate.control.json'
 $Script:PipelineStatusBlobName = '_diagnostics/ExportAndGenerate.status.json'
 $Script:PipelineRunId = [guid]::NewGuid().ToString('N')
 $Script:PipelineStartedOnUtc = [datetime]::UtcNow
+$Script:PipelineArchitectureVersion = 'monolithic-v1'
+$Script:PipelineArchitectureTrack = 'stage0-observability'
 $Script:PipelineCurrentStage = 'Initializing'
 $Script:PipelineCurrentStageMessage = 'Initializing pipeline.'
+$Script:PipelineCurrentStageEnteredOnUtc = $Script:PipelineStartedOnUtc
+$Script:PipelineNormalizedPayloadCacheHit = $null
 $Script:PipelineExecutionHostDescriptor = Resolve-PipelineExecutionHostDescriptor
 $Script:PipelineExecutionHost = [string]$Script:PipelineExecutionHostDescriptor.Name
 
@@ -232,6 +236,7 @@ function Set-PipelineExecutionStage {
 
     $Script:PipelineCurrentStage = $Stage
     $Script:PipelineCurrentStageMessage = $Message
+    $Script:PipelineCurrentStageEnteredOnUtc = [datetime]::UtcNow
 }
 
 function Write-PipelineExecutionStatus {
@@ -270,10 +275,13 @@ function Write-PipelineExecutionStatus {
             runId = $Script:PipelineRunId
             executionHost = $Script:PipelineExecutionHost
             executionHostEvidence = if ($null -ne $Script:PipelineExecutionHostDescriptor) { [string]$Script:PipelineExecutionHostDescriptor.Evidence } else { $null }
+            pipelineArchitectureVersion = $Script:PipelineArchitectureVersion
+            pipelineArchitectureTrack = $Script:PipelineArchitectureTrack
             status = $Status
             stage = $Stage
             message = $Message
             startedOnUtc = $Script:PipelineStartedOnUtc.ToString('o')
+            stageEnteredOnUtc = $Script:PipelineCurrentStageEnteredOnUtc.ToString('o')
             updatedOnUtc = ([datetime]::UtcNow).ToString('o')
             storageAccountName = $AccountName
             dashboardDeliveryMode = if ([string]::IsNullOrWhiteSpace($DashboardDeliveryMode)) { $null } else { $DashboardDeliveryMode }
@@ -288,6 +296,10 @@ function Write-PipelineExecutionStatus {
 
         foreach ($key in $AdditionalProperties.Keys) {
             $statusDocument[$key] = $AdditionalProperties[$key]
+        }
+
+        if ($null -ne $Script:PipelineNormalizedPayloadCacheHit) {
+            $statusDocument.normalizedPayloadCacheHit = [bool]$Script:PipelineNormalizedPayloadCacheHit
         }
 
         $statusDocument | ConvertTo-Json -Depth 12 | Set-Content -LiteralPath $statusFilePath -Encoding utf8
@@ -1278,13 +1290,18 @@ try {
     $tempPayloadPath = Join-Path -Path $tempRoot -ChildPath 'payload.json.gz'
     $syntheticManifestPath = Join-Path -Path $tempExports -ChildPath 'synthetic-manifest.json'
     $skipObservedWindowMerge = (Test-Path -LiteralPath $syntheticManifestPath -PathType Leaf)
+    Set-PipelineExecutionStage -Stage 'CheckDashboardPayloadCache' -Message 'Checking for a reusable normalized payload cache.'
+    [void](Write-PipelineExecutionStatus -AccountName $StorageAccountName -StorageToken $storageToken -Status 'running')
     $payloadCacheEntry = Get-NormalizedPayloadCacheEntry -BasePath $tempExports -SkipObservedWindowMerge:$skipObservedWindowMerge
+    $Script:PipelineNormalizedPayloadCacheHit = ($null -ne $payloadCacheEntry)
     Invoke-FullGarbageCollection
     Write-MemoryUsage -Label "Post-PayloadCacheCheck"
     $machines = $null
     $advancedHuntingData = $null
     $normalizedQuality = $null
     if ($payloadCacheEntry) {
+        Set-PipelineExecutionStage -Stage 'PrepareDashboardPayload' -Message 'Reusing the cached normalized payload for dashboard packaging.'
+        [void](Write-PipelineExecutionStatus -AccountName $StorageAccountName -StorageToken $storageToken -Status 'running')
         Write-Output "Preparing data for embedding..."
         Write-Output ("  Reusing cached normalized payload ({0})..." -f $payloadCacheEntry.Fingerprint.Substring(0, 12))
         Copy-Item -LiteralPath $payloadCacheEntry.PayloadPath -Destination $tempPayloadPath -Force
@@ -1295,6 +1312,8 @@ try {
     }
     else {
         # Step 1: Read machine and Advanced Hunting data
+        Set-PipelineExecutionStage -Stage 'ReadNormalizationInputs' -Message 'Loading machine and Advanced Hunting inputs for dashboard normalization.'
+        [void](Write-PipelineExecutionStatus -AccountName $StorageAccountName -StorageToken $storageToken -Status 'running')
         $machines = Read-NormalizationMachineLookup -Path $tempExports
         Invoke-FullGarbageCollection
         Write-MemoryUsage -Label "Post-MachineRead"
@@ -1319,11 +1338,62 @@ try {
         Write-MemoryUsage -Label "Post-NormalizationInputs"
 
         # Step 2: Normalize data while the working set is still lean
+        Set-PipelineExecutionStage -Stage 'NormalizeDashboardData' -Message 'Normalizing export data into the compact dashboard payload model.'
+        [void](Write-PipelineExecutionStatus -AccountName $StorageAccountName -StorageToken $storageToken -Status 'running')
         Write-Output "Normalizing data..."
         if ($skipObservedWindowMerge) {
             Write-Output "Synthetic manifest detected. Skipping observed-window merge for stress normalization."
         }
-        $normalizedResult = ConvertTo-NormalizedData -DataPath $tempExports -VulnOutputPath $tempVulnsPath -PayloadOutputPath $tempPayloadPath -Machines $machines -AdvancedHuntingData $advancedHuntingData -AdvancedHuntingDeviceUsers $advancedHuntingDeviceUsers -SkipObservedWindowMerge:$skipObservedWindowMerge -ConsumeLookupsOnPayloadClose
+        $normalizationStatusState = @{
+            SubPhase = $null
+            PhaseMessage = $Script:PipelineCurrentStageMessage
+            PhaseStartedOnUtc = [datetime]::UtcNow
+            PhaseRowCountBase = 0L
+            LastReportedRowCount = 0L
+        }
+        $normalizedResult = ConvertTo-NormalizedData -DataPath $tempExports -VulnOutputPath $tempVulnsPath -PayloadOutputPath $tempPayloadPath -Machines $machines -AdvancedHuntingData $advancedHuntingData -AdvancedHuntingDeviceUsers $advancedHuntingDeviceUsers -SkipObservedWindowMerge:$skipObservedWindowMerge -ConsumeLookupsOnPayloadClose -NormalizationProgressCallback {
+            param($NormalizationEvent)
+
+            if ($null -eq $NormalizationEvent) {
+                return
+            }
+
+            $additionalProperties = @{}
+            $statusMessage = $Script:PipelineCurrentStageMessage
+            $eventKind = if ($NormalizationEvent.PSObject.Properties['Kind']) { [string]$NormalizationEvent.Kind } else { '' }
+            switch ($eventKind) {
+                'phase' {
+                    $normalizationStatusState.SubPhase = if ($NormalizationEvent.PSObject.Properties['Phase']) { [string]$NormalizationEvent.Phase } else { $null }
+                    $normalizationStatusState.PhaseMessage = if ($NormalizationEvent.PSObject.Properties['Message']) { [string]$NormalizationEvent.Message } else { $Script:PipelineCurrentStageMessage }
+                    $normalizationStatusState.PhaseStartedOnUtc = [datetime]::UtcNow
+                    $normalizationStatusState.PhaseRowCountBase = [long]$normalizationStatusState.LastReportedRowCount
+                    $statusMessage = [string]$normalizationStatusState.PhaseMessage
+                    if (-not [string]::IsNullOrWhiteSpace([string]$normalizationStatusState.SubPhase)) {
+                        $additionalProperties['normalizedSubPhase'] = [string]$normalizationStatusState.SubPhase
+                    }
+                }
+                'progress' {
+                    $currentRowCount = [long]$NormalizationEvent.Count
+                    $normalizationStatusState.LastReportedRowCount = $currentRowCount
+                    $phaseElapsedSeconds = [Math]::Max(0.001, ([datetime]::UtcNow - [datetime]$normalizationStatusState.PhaseStartedOnUtc).TotalSeconds)
+                    $phaseProcessedCount = [Math]::Max(0L, ($currentRowCount - [long]$normalizationStatusState.PhaseRowCountBase))
+                    $phaseRate = [Math]::Round(($phaseProcessedCount / $phaseElapsedSeconds), 0)
+                    $statusMessage = ('{0} Processed {1:N0} onboarded vulnerability record(s) over {2:N1}s in the current subphase ({3:N0}/s).' -f [string]$normalizationStatusState.PhaseMessage, $currentRowCount, $phaseElapsedSeconds, $phaseRate)
+                    if (-not [string]::IsNullOrWhiteSpace([string]$normalizationStatusState.SubPhase)) {
+                        $additionalProperties['normalizedSubPhase'] = [string]$normalizationStatusState.SubPhase
+                    }
+                    $additionalProperties['normalizedRowCount'] = $currentRowCount
+                    $additionalProperties['normalizedSubPhaseRowCount'] = $phaseProcessedCount
+                    $additionalProperties['normalizedProgressElapsedSeconds'] = [Math]::Round($phaseElapsedSeconds, 1)
+                    $additionalProperties['normalizedRowRatePerSecond'] = $phaseRate
+                    if ($NormalizationEvent.PSObject.Properties['MarkerType']) {
+                        $additionalProperties['normalizedProgressMarkerType'] = [string]$NormalizationEvent.MarkerType
+                    }
+                }
+            }
+
+            [void](Write-PipelineExecutionStatus -AccountName $StorageAccountName -StorageToken $storageToken -Status 'running' -Stage 'NormalizeDashboardData' -Message $statusMessage -AdditionalProperties $additionalProperties)
+        }
         Write-MemoryUsage -Label "Post-ConvertToNormalizedData"
         $machines = $null
         $advancedHuntingData = $null
@@ -1332,6 +1402,8 @@ try {
         Write-MemoryUsage -Label "Post-NormalizationCleanup"
 
         # Step 3: Prepare payload for embedding
+        Set-PipelineExecutionStage -Stage 'PrepareDashboardPayload' -Message 'Preparing and caching the normalized payload for dashboard packaging.'
+        [void](Write-PipelineExecutionStatus -AccountName $StorageAccountName -StorageToken $storageToken -Status 'running')
         Write-Output "Preparing data for embedding..."
         $vulnCount = $normalizedResult.VulnCount
         $deviceCount = [int]$normalizedResult.DeviceCount
@@ -1376,6 +1448,8 @@ try {
     $requiresEmbeddedBundles = ($DashboardDeliveryMode -ne 'Hosted')
 
     # Step 4: Download JavaScript libraries
+    Set-PipelineExecutionStage -Stage 'PrepareDashboardLibraries' -Message 'Preparing cached client libraries for dashboard packaging.'
+    [void](Write-PipelineExecutionStatus -AccountName $StorageAccountName -StorageToken $storageToken -Status 'running')
     Write-Output "Preparing dashboard client libraries..."
     $lib = $Script:LibraryConfig.ChartJs
     $chartJsLibraryPath = Save-JSLibraryFile -Url $lib.Url -Name $lib.Name -OutputPath (Join-Path $tempLibraries 'chart.js') -Critical $lib.Critical
@@ -1403,6 +1477,8 @@ try {
     Invoke-PhaseTransitionGarbageCollection -MemoryLabel 'Pre-TemplateLoad'
 
     # Step 5: Load templates
+    Set-PipelineExecutionStage -Stage 'LoadDashboardTemplates' -Message 'Loading dashboard templates before final artifact assembly.'
+    [void](Write-PipelineExecutionStatus -AccountName $StorageAccountName -StorageToken $storageToken -Status 'running')
     Write-Output "Loading templates..."
     $htmlTemplatePath = Join-Path -Path $tempTemplates -ChildPath "dashboard.html"
     $cssTemplatePath = Join-Path -Path $tempTemplates -ChildPath "dashboard.css"

--- a/docs/pipeline-architecture-review.md
+++ b/docs/pipeline-architecture-review.md
@@ -1,90 +1,115 @@
 # Pipeline Architecture Review
 
-This review covers the Defender reporting data path from API export through dashboard generation. It is based on the tracked source and maintainer docs, with generated outputs and local history treated as non-authoritative.
+This review captures the post-merge architecture decision after PR #37. It is based on the tracked source and maintainer docs, with generated outputs and local history treated as non-authoritative.
+
+## Current Validated State
+
+The current monolithic pipeline is no longer failing its Azure acceptance gate.
+
+- Azure Automation passed on the 50k device / 1.5M row hosted dataset.
+- The hosted Function App validation also completed successfully on the same dataset during the keeper merge acceptance run.
+- The latest hosted Function App acceptance invocation was accepted at `2026-05-06T06:26:05Z` and wrote the dashboard blob at `2026-05-06T06:33:39Z`.
+- Recent keeper changes already reduced transient normalization state, reused shared library caches, and hardened blob validation against Azure CLI data-plane failures on this machine.
+
+That changes the architecture decision. A high-risk sharded rewrite is no longer the right immediate next step.
+
+## Decision
+
+Keep the current runtime architecture as the accepted baseline and name it `monolithic-v1`.
+
+Treat a staged, shard-oriented rewrite as a contingency path, not the active implementation scope for this branch.
+
+The next work should lock in observability, planning metadata, and escalation criteria so we can prove when a larger rewrite is actually required.
 
 ## Pipeline Map
 
 1. API export
    - [Invoke-VulnerabilityExport.ps1](../Invoke-VulnerabilityExport.ps1) authenticates to Defender for Endpoint, downloads bulk vulnerability snapshots, refreshes machine data, optionally refreshes Advanced Hunting enrichment, and writes canonical gzip stores under `exports/`.
-   - The shared export helpers live in [MdeExport.ps1](../src/powershell/Shared/DefenderApi/MdeExport.ps1), with store layout helpers in [Core.ps1](../src/powershell/Shared/Core/Core.ps1), [VulnerabilityStore.ps1](../src/powershell/Shared/Stores/VulnerabilityStore.ps1), [VulnerabilitySnapshotImport.ps1](../src/powershell/Shared/Stores/VulnerabilitySnapshotImport.ps1), and [MachineStore.ps1](../src/powershell/Shared/Stores/MachineStore.ps1).
+   - Shared export helpers live under `src/powershell/Shared/DefenderApi`, `src/powershell/Shared/Core`, and `src/powershell/Shared/Stores`.
 
 2. Normalization
-   - [Generate-VulnerabilityDashboard.ps1](../Generate-VulnerabilityDashboard.ps1) reads canonical stores, optionally refreshes machine data, loads Advanced Hunting and NVD enrichment, and calls `ConvertTo-NormalizedData` from [DashboardGeneration.ps1](../src/powershell/Shared/Dashboard/DashboardGeneration.ps1).
-   - Normalization can run from content-store sidecars or raw current/history rows. It can also reuse normalized column caches and normalized payload caches under `.dashboard-cache/`.
+   - [Generate-VulnerabilityDashboard.ps1](../Generate-VulnerabilityDashboard.ps1) reads canonical stores, loads machine and enrichment data, and calls `ConvertTo-NormalizedData` from [DashboardGeneration.ps1](../src/powershell/Shared/Dashboard/DashboardGeneration.ps1).
+   - Normalization can run from content-store sidecars or raw current/history rows and can reuse normalized column and payload caches under `.dashboard-cache/`.
 
 3. Payload preparation
-   - The generator writes a compressed payload with lookup tables plus vulnerability rows or columns. `-NormalizeOnly` can materialize this payload and its manifest; `-PackageOnly` can package a previously materialized payload.
-   - Cache identity comes from `Get-DashboardPayloadCacheFingerprint`, which depends on vulnerability, machine, Advanced Hunting, NVD, and normalization-mode inputs.
+   - The generator writes a compressed payload with lookup tables plus vulnerability rows or columns.
+   - `-NormalizeOnly` materializes the payload and manifest; `-PackageOnly` packages a previously materialized payload.
 
 4. Dashboard packaging
-   - `Write-DashboardArtifactBundle` combines templates, payload, pako, Chart.js, and the PDF export bundle into either a self-contained HTML file or a hosted split-assets directory.
+   - `Write-DashboardArtifactBundle` combines templates, payload, pako, Chart.js, and the PDF export bundle into self-contained or hosted split-assets output.
    - `-DualPackage` writes both delivery modes from the same normalized payload.
 
 5. Validation and delivery
    - `Invoke-DashboardValidation` and the audit helpers validate payload/source parity, enrichment, report semantics, and legacy fixture behavior.
    - Azure Automation and Function App entrypoints are built from [runbook-source.ps1](../build/azure/runbook-source.ps1) plus the manifest-driven helper bundle.
 
-## Findings
+## Locked Plan
 
-### Addressed on This Branch
+### Stage 0: Observability and Architecture Scaffolding
 
-1. Cache fingerprints include file timestamps after computing content hashes.
-   - `Get-FileSetFingerprint` already computes SHA-256 for every source file, but it also includes `LastWriteTimeUtc.Ticks` in the fingerprint material.
-   - Result: identical export content with a different timestamp misses the normalized payload, observed-window, and related caches. This is inefficient and especially expensive for large datasets because cache lookup already paid the cost of content hashing.
-   - Branch result: file-set fingerprints are now content-addressed by file identity, length, and SHA-256. A regression proves timestamp-only changes do not invalidate cache identity while content changes still do.
+This is the active branch scope.
 
-2. Normalized payload cache entries are trusted without verifying the cached payload bytes against the manifest hash.
-   - `Get-NormalizedPayloadCacheEntry` checks the cache fingerprint and manifest fingerprint, but it does not verify that `PayloadSha256` still matches the payload file.
-   - Result: a partial or corrupted cached payload can be reused until a later phase happens to detect it.
-   - Branch result: cached payload bytes are validated against manifest `PayloadSha256` before returning a cache hit. Normal generation treats mismatches as cache misses and rechecks after copy; `-PackageOnly` fails fast when a provided manifest hash does not match the provided payload.
+1. Stamp the runtime path with explicit architecture metadata.
+   - Emit `pipelineArchitectureVersion = monolithic-v1` in the Azure pipeline status blob.
+   - Keep the current pipeline behavior unchanged.
 
-3. JavaScript library cache reuse accepts zero-byte files.
-   - `Save-JSLibraryFile` reuses any cached library path that exists.
-   - Result: a failed or interrupted previous download can poison later self-contained and hosted dashboard packages.
-   - Branch result: empty cached library files are rejected and refreshed, and new downloads are verified as non-empty before caching or packaging.
+2. Make Stage D diagnosable without a debugger.
+   - Replace the single coarse `GenerateDashboard` runtime status with finer status transitions for cache reuse, normalization inputs, normalization, payload preparation, library preparation, template loading, and hosted/self-contained assembly.
+   - When a normalized payload cache hit is available, the pipeline intentionally skips the normalization-input and normalization stages. Status reporting must make that path explicit instead of leaving operators to infer it.
+   - Preserve the existing success/failure contract for the status blob so current tooling keeps working.
 
-4. Operator-visible data freshness and enrichment metadata is thin.
-   - Machine export failures during dashboard generation are warning-only and reuse existing machine data. Advanced Hunting enrichment is optional and may be intentionally absent.
-   - Result: operators need better metadata to distinguish intentional offline generation from degraded freshness or enrichment.
-   - Branch result: payload manifests, validation sidecars, and audit outputs now carry source summaries for machine data, Advanced Hunting, NVD, normalization mode, and source file freshness. Strict freshness/enrichment policy remains a compatibility-preserving follow-up.
+3. Surface the new metadata in the validation path.
+   - Keep the current heartbeat and timeout logic.
+   - Include architecture-version context in the Function App status summary so future Azure regressions are attributable to a known execution model.
 
-### Deferred Follow-Ups
+4. Record the decision in tracked docs.
+   - This file is the decision record for keeping `monolithic-v1` as the accepted baseline until a concrete trigger forces a larger rewrite.
 
-1. Add a strict freshness mode for machine data.
-   - Candidate: `-RequireFreshMachineData` or `-AllowStaleMachineData` with a configurable maximum age and validation-sidecar metadata.
+### Stage 1: Baseline Capture and Triggering
 
-2. Add explicit Advanced Hunting expectation controls.
-   - Candidate: `-RequireAdvancedHunting` plus policy around the source count metadata now emitted in manifests, sidecars, and audits.
+Do this after Stage 0 is merged.
 
-3. Expand JavaScript fixture coverage for `columns-v1` payloads.
-   - Validation helper coverage already canonicalizes rows and columns, but the browser-side assertion scripts should exercise column payloads too.
+1. Capture durable post-acceptance benchmark baselines.
+   - Use the repo performance workflow and Azure acceptance artifacts to record the accepted envelope for the current monolithic pipeline.
 
-4. Add machine-history continuity diagnostics.
-   - Candidate: warn when quarterly history files have unexpected gaps, overlaps, or out-of-order observed dates.
+2. Add explicit rewrite triggers.
+   - Escalate only if repeated Azure acceptance runs regress materially or fail.
+   - Use the existing repo thresholds as the minimum review bar: investigate elapsed or working-set regressions above `10%`, and investigate Azure Function execution-unit growth above `15%`.
 
-## Implementation Plan
+### Stage 2: Resume-Oriented Enhancements
 
-1. Harden cache identity and cache hit validation.
-   - Remove timestamp material from `Get-FileSetFingerprint`.
-   - Add normalized payload manifest hash confirmation and use it in cache lookup plus package-only manifest handling.
+Only start this if Stage 1 shows that observability is not enough.
 
-2. Harden dashboard library caching.
-   - Refresh empty cached library files.
-   - Treat empty fresh downloads as failed downloads before cache publish.
+1. Add source fingerprint and payload lineage metadata to the runtime status or sidecar path.
+2. Add explicit resume checkpoints around already-materialized payload reuse.
+3. Keep the current payload contract unchanged.
 
-3. Add focused regression coverage.
-   - Fingerprint stability for timestamp-only changes.
-   - Normalized payload cache miss on payload/manifest hash mismatch.
-   - Library cache refresh when an empty cached file exists.
+### Stage 3: Staged Rewrite Contingency
 
-4. Rebuild generated helper artifacts.
-   - Run the shared helper build because [DashboardGeneration.ps1](../src/powershell/Shared/Dashboard/DashboardGeneration.ps1) changes feed [shared-helpers.ps1](../build/generated/shared-helpers.ps1), Azure runbook, and Function App artifacts.
+Only start this if the accepted `monolithic-v1` path regresses again.
 
-5. Validate.
-   - Run the focused shared-helper regression test first.
-   - Run the deterministic preflight before final review.
+1. Introduce durable shard planning and shard-local normalization artifacts.
+2. Stream the global reduce and final materialization phases.
+3. Gate the staged path behind an explicit architecture-version setting and preserve the current payload contract until parity is proven.
+
+## Escalation Triggers
+
+Start the staged rewrite only when at least one of these conditions becomes true:
+
+1. Two consecutive hosted Function App Azure acceptance runs fail on the standard 50k / 1.5M dataset.
+2. Hosted Function App Azure acceptance regresses materially beyond the accepted baseline and keeps doing so after localized fixes.
+3. Operational requirements demand resumability across invocations rather than a single successful monolithic run.
+
+## First Implementation on This Branch
+
+This branch implements Stage 0 only:
+
+1. add architecture-version metadata to the pipeline status blob
+2. add finer status transitions inside Stage D
+3. surface the architecture version in the validation status summary
 
 ## Review Notes
 
-- The export phase already uses staged partial vulnerability downloads and transactional machine store publishing, so this branch does not replace those mechanisms.
-- The validation attestation fast path is intentionally payload-oriented. Dashboard runtime behavior remains covered by the Node dashboard assertion suite and browser inspection gates rather than by semantic payload replay.
+- The export phase already uses staged partial vulnerability downloads and transactional machine store publishing, so this review does not replace those mechanisms.
+- The validation attestation fast path remains payload-oriented. Dashboard runtime behavior is still covered by the Node dashboard assertion suite, semantic validation, and Azure acceptance runs.
+- If `monolithic-v1` remains within the accepted Azure envelope, prefer smaller focused improvements over a speculative rewrite.

--- a/src/powershell/Shared/Dashboard/DashboardGeneration.ps1
+++ b/src/powershell/Shared/Dashboard/DashboardGeneration.ps1
@@ -5260,6 +5260,98 @@ function Write-NormalizedCompactRecordFromLookup {
     Write-NormalizedCompactRecord -WriterState $WriterState -Record $Record
 }
 
+function New-NormalizationProgressState {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '', Justification = 'Internal helper only creates an in-memory normalization progress tracker.')]
+    [CmdletBinding()]
+    [OutputType([pscustomobject])]
+    param(
+        [Parameter(Mandatory = $false)]
+        [ValidateRange(1, 1000000)]
+        [int]$ProgressInterval = 50000,
+
+        [Parameter(Mandatory = $false)]
+        [ValidateRange(15, 3600)]
+        [int]$HeartbeatIntervalSeconds = 60,
+
+        [Parameter(Mandatory = $false)]
+        [ValidateRange(1, 1000000)]
+        [int]$CheckInterval = 10000
+    )
+
+    return [PSCustomObject]@{
+        ProgressInterval = $ProgressInterval
+        HeartbeatIntervalSeconds = $HeartbeatIntervalSeconds
+        CheckInterval = [Math]::Max(1, [Math]::Min($ProgressInterval, $CheckInterval))
+        Stopwatch = [System.Diagnostics.Stopwatch]::StartNew()
+        LastHeartbeatSecond = -1
+    }
+}
+
+function Invoke-NormalizationCallbackEvent {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $false)]
+        [scriptblock]$Callback,
+
+        [Parameter(Mandatory = $true)]
+        $EventData
+    )
+
+    if ($null -eq $Callback -or $null -eq $EventData) {
+        return
+    }
+
+    try {
+        & $Callback $EventData
+    }
+    catch {
+        Write-Verbose ("Normalization callback failed: {0}" -f $_.Exception.Message)
+    }
+}
+
+function Invoke-NormalizationProgressCallback {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $false)]
+        $State,
+
+        [Parameter(Mandatory = $true)]
+        [long]$Count,
+
+        [Parameter(Mandatory = $false)]
+        [scriptblock]$Callback
+    )
+
+    if ($null -eq $State -or $Count -le 0 -or $null -eq $Callback) {
+        return
+    }
+
+    $markerType = 'progress'
+    $shouldInvoke = (($Count % [long]$State.ProgressInterval) -eq 0)
+    if (-not $shouldInvoke -and (($Count % [long]$State.CheckInterval) -eq 0)) {
+        $elapsedWholeSeconds = [Math]::Floor($State.Stopwatch.Elapsed.TotalSeconds)
+        if (($State.LastHeartbeatSecond + [int]$State.HeartbeatIntervalSeconds) -le $elapsedWholeSeconds) {
+            $shouldInvoke = $true
+            $markerType = 'heartbeat'
+        }
+    }
+
+    if (-not $shouldInvoke) {
+        return
+    }
+
+    $elapsedSeconds = [Math]::Max(0.001, $State.Stopwatch.Elapsed.TotalSeconds)
+    $rate = [Math]::Round(($Count / $elapsedSeconds), 0)
+    Invoke-NormalizationCallbackEvent -Callback $Callback -EventData ([PSCustomObject]@{
+            Kind = 'progress'
+            Count = $Count
+            ElapsedSeconds = [Math]::Round($elapsedSeconds, 1)
+            RatePerSecond = $rate
+            MarkerType = $markerType
+        })
+    $State.LastHeartbeatSecond = [Math]::Floor($State.Stopwatch.Elapsed.TotalSeconds)
+}
+
 function Write-NormalizedSourceRow {
     [CmdletBinding()]
     param(
@@ -5274,6 +5366,12 @@ function Write-NormalizedSourceRow {
 
         [Parameter(Mandatory = $true)]
         [ref]$ProcessedCount,
+
+        [Parameter(Mandatory = $false)]
+        $NormalizationProgressState,
+
+        [Parameter(Mandatory = $false)]
+        [scriptblock]$NormalizationProgressCallback,
 
         [Parameter(Mandatory = $false)]
         [AllowNull()]
@@ -5411,6 +5509,8 @@ function Write-NormalizedSourceRow {
         -FirstSeenValue $FirstSeenValue `
         -LastSeenValue $LastSeenValue `
         -FirstLastSwappedCount $FirstLastSwappedCount
+
+    Invoke-NormalizationProgressCallback -State $NormalizationProgressState -Count $ProcessedCount.Value -Callback $NormalizationProgressCallback
 
     if (($ProcessedCount.Value % 50000) -eq 0) {
         Write-Information ("  Processed {0} onboarded vulnerability record(s)..." -f $ProcessedCount.Value) -InformationAction Continue
@@ -5589,6 +5689,12 @@ function Invoke-ContentStoreNormalization {
         [string[]]$MergedRefPaths,
 
         [Parameter(Mandatory = $false)]
+        $NormalizationProgressState,
+
+        [Parameter(Mandatory = $false)]
+        [scriptblock]$NormalizationProgressCallback,
+
+        [Parameter(Mandatory = $false)]
         [string]$PayloadOutputPath,
 
         [Parameter(Mandatory = $false)]
@@ -5634,6 +5740,12 @@ function Invoke-ContentStoreNormalization {
     $lookupCountSummary = $null
     $consumeLookups = ($ConsumeLookupsOnPayloadClose -and -not [string]::IsNullOrWhiteSpace($PayloadOutputPath))
 
+    Invoke-NormalizationCallbackEvent -Callback $NormalizationProgressCallback -EventData ([PSCustomObject]@{
+            Kind = 'phase'
+            Phase = 'LoadContentStoreDeviceProfiles'
+            Message = 'Loading content-store device profiles into normalization lookups.'
+        })
+
     foreach ($deviceProfile in @(Read-VulnContentDictionaryArrayEntries -Path $dictionaryPath -PropertyName 'deviceProfiles')) {
         $deviceId = [string](Get-VulnPropertyValue -InputObject $deviceProfile -Name 'id')
         if ($hasInventoryIdentity) {
@@ -5656,6 +5768,12 @@ function Invoke-ContentStoreNormalization {
     $deviceProfileCount = $deviceLookupIndices.Length
     $onboardedDeviceProfileCount = @($deviceOnboardedFlags | Where-Object { $_ }).Count
     $deviceProfileIds = $null
+
+    Invoke-NormalizationCallbackEvent -Callback $NormalizationProgressCallback -EventData ([PSCustomObject]@{
+            Kind = 'phase'
+            Phase = 'LoadContentStoreTemplates'
+            Message = 'Loading content-store vulnerability templates into normalization lookups.'
+        })
 
     foreach ($contentTemplate in @(Read-VulnContentDictionaryArrayEntries -Path $dictionaryPath -PropertyName 'contentTemplates')) {
         $softwareVendor = [string](Get-VulnPropertyValue -InputObject $contentTemplate -Name 'sv')
@@ -5706,6 +5824,12 @@ function Invoke-ContentStoreNormalization {
     $Context.AdvancedHuntingDeviceUsers = @{}
     $Context.NvdCveData = @{}
     Invoke-FullGarbageCollection
+
+    Invoke-NormalizationCallbackEvent -Callback $NormalizationProgressCallback -EventData ([PSCustomObject]@{
+            Kind = 'phase'
+            Phase = 'StreamContentStoreRefs'
+            Message = 'Streaming content-store vulnerability references into the normalized payload.'
+        })
 
     try {
         $writerState = Open-NormalizedVulnWriter -VulnOutputPath $VulnOutputPath -VulnColumnDirectoryPath $VulnColumnDirectoryPath -PayloadOutputPath $PayloadOutputPath
@@ -5897,6 +6021,8 @@ function Invoke-ContentStoreNormalization {
                                 Write-CompactVulnRecordJson -Writer $jsonWriter -Record $compactRecord
                             }
 
+                            Invoke-NormalizationProgressCallback -State $NormalizationProgressState -Count $processedCountRef.Value -Callback $NormalizationProgressCallback
+
                             if (($processedCountRef.Value % 50000) -eq 0) {
                                 Write-Information ("  Processed {0} onboarded vulnerability record(s)..." -f $processedCountRef.Value) -InformationAction Continue
                             }
@@ -6044,6 +6170,8 @@ function Invoke-ContentStoreNormalization {
                                         Write-CompactVulnRecordJson -Writer $jsonWriter -Record $compactRecord
                                     }
 
+                                    Invoke-NormalizationProgressCallback -State $NormalizationProgressState -Count $processedCountRef.Value -Callback $NormalizationProgressCallback
+
                                     if (($processedCountRef.Value % 50000) -eq 0) {
                                         Write-Information ("  Processed {0} onboarded vulnerability record(s)..." -f $processedCountRef.Value) -InformationAction Continue
                                     }
@@ -6181,6 +6309,12 @@ function Invoke-RawStoreNormalization {
         [hashtable]$NvdCveData = @{},
 
         [Parameter(Mandatory = $false)]
+        $NormalizationProgressState,
+
+        [Parameter(Mandatory = $false)]
+        [scriptblock]$NormalizationProgressCallback,
+
+        [Parameter(Mandatory = $false)]
         [string]$PayloadOutputPath,
 
         [Parameter(Mandatory = $false)]
@@ -6201,6 +6335,14 @@ function Invoke-RawStoreNormalization {
     $compactRecord = [object[]]@(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -1)
     $lookupCountSummary = $null
     $consumeLookups = ($ConsumeLookupsOnPayloadClose -and -not [string]::IsNullOrWhiteSpace($PayloadOutputPath))
+    $normalizationProgressStateForStream = $NormalizationProgressState
+    $normalizationProgressCallbackForStream = $NormalizationProgressCallback
+
+    Invoke-NormalizationCallbackEvent -Callback $NormalizationProgressCallback -EventData ([PSCustomObject]@{
+            Kind = 'phase'
+            Phase = 'StreamRawVulnStoreRows'
+            Message = 'Streaming raw vulnerability store rows into the normalized payload.'
+        })
 
     try {
         $writerState = Open-NormalizedVulnWriter -VulnOutputPath $VulnOutputPath -VulnColumnDirectoryPath $VulnColumnDirectoryPath -PayloadOutputPath $PayloadOutputPath
@@ -6543,7 +6685,9 @@ function Invoke-RawStoreNormalization {
                             -Context $Context `
                             -FirstSeenValue $seenFirstValue `
                             -LastSeenValue $seenLastValue `
-                            -FirstLastSwappedCount $firstLastSwappedCountRef
+                            -FirstLastSwappedCount $firstLastSwappedCountRef `
+                            -NormalizationProgressState $normalizationProgressStateForStream `
+                            -NormalizationProgressCallback $normalizationProgressCallbackForStream
                 }
 
                 if (Get-Command -Name Write-MemoryUsage -ErrorAction SilentlyContinue) {
@@ -6986,7 +7130,10 @@ function ConvertTo-NormalizedData {
         [string]$PayloadOutputPath,
 
         [Parameter(Mandatory = $false)]
-        [switch]$ConsumeLookupsOnPayloadClose
+        [switch]$ConsumeLookupsOnPayloadClose,
+
+        [Parameter(Mandatory = $false)]
+        [scriptblock]$NormalizationProgressCallback
     )
 
     Write-Information '  Normalizing data structure...' -InformationAction Continue
@@ -7009,6 +7156,7 @@ function ConvertTo-NormalizedData {
     $autoColumnDir = $null
     $lookupCountSummary = $null
     $consumeLookups = ($ConsumeLookupsOnPayloadClose -and -not [string]::IsNullOrWhiteSpace($PayloadOutputPath))
+    $normalizationProgressState = if ($null -ne $NormalizationProgressCallback) { New-NormalizationProgressState } else { $null }
 
     # Auto-enable column-store format for better gzip compression when caller
     # has not explicitly specified a column directory.
@@ -7037,7 +7185,7 @@ function ConvertTo-NormalizedData {
         else {
             Write-Information '  Content-store detected; using fast path (no merge).' -InformationAction Continue
         }
-        $rawNormalizationResult = Invoke-ContentStoreNormalization -DataPath $DataPath -VulnOutputPath $VulnOutputPath -VulnColumnDirectoryPath $VulnColumnDirectoryPath -Context $context -Machines $Machines -AdvancedHuntingData $AdvancedHuntingData -AdvancedHuntingDeviceUsers $AdvancedHuntingDeviceUsers -AdvancedHuntingInventoryData $AdvancedHuntingInventoryData -NvdCveData $NvdCveData -MergedRefPaths $mergedRefPaths -PayloadOutputPath $PayloadOutputPath -ConsumeLookupsOnPayloadClose:$consumeLookups
+        $rawNormalizationResult = Invoke-ContentStoreNormalization -DataPath $DataPath -VulnOutputPath $VulnOutputPath -VulnColumnDirectoryPath $VulnColumnDirectoryPath -Context $context -Machines $Machines -AdvancedHuntingData $AdvancedHuntingData -AdvancedHuntingDeviceUsers $AdvancedHuntingDeviceUsers -AdvancedHuntingInventoryData $AdvancedHuntingInventoryData -NvdCveData $NvdCveData -MergedRefPaths $mergedRefPaths -NormalizationProgressState $normalizationProgressState -NormalizationProgressCallback $NormalizationProgressCallback -PayloadOutputPath $PayloadOutputPath -ConsumeLookupsOnPayloadClose:$consumeLookups
         $processedCount = [int]$rawNormalizationResult.ProcessedCount
         $firstLastSwappedCount = [int]$rawNormalizationResult.FirstLastSwappedCount
         $hasNoTags = ($rawNormalizationResult.HasNoTags -eq $true)
@@ -7056,7 +7204,7 @@ function ConvertTo-NormalizedData {
     }
     elseif ($effectiveSkipObservedWindowMerge -and $storeExists) {
         Write-Information '  Raw store detected; using raw store normalization fast path.' -InformationAction Continue
-        $rawNormalizationResult = Invoke-RawStoreNormalization -DataPath $DataPath -VulnOutputPath $VulnOutputPath -VulnColumnDirectoryPath $VulnColumnDirectoryPath -Context $context -Machines $Machines -AdvancedHuntingData $AdvancedHuntingData -AdvancedHuntingDeviceUsers $AdvancedHuntingDeviceUsers -AdvancedHuntingInventoryData $AdvancedHuntingInventoryData -NvdCveData $NvdCveData -PayloadOutputPath $PayloadOutputPath -ConsumeLookupsOnPayloadClose:$consumeLookups
+        $rawNormalizationResult = Invoke-RawStoreNormalization -DataPath $DataPath -VulnOutputPath $VulnOutputPath -VulnColumnDirectoryPath $VulnColumnDirectoryPath -Context $context -Machines $Machines -AdvancedHuntingData $AdvancedHuntingData -AdvancedHuntingDeviceUsers $AdvancedHuntingDeviceUsers -AdvancedHuntingInventoryData $AdvancedHuntingInventoryData -NvdCveData $NvdCveData -NormalizationProgressState $normalizationProgressState -NormalizationProgressCallback $NormalizationProgressCallback -PayloadOutputPath $PayloadOutputPath -ConsumeLookupsOnPayloadClose:$consumeLookups
         $processedCount = [int]$rawNormalizationResult.ProcessedCount
         $firstLastSwappedCount = [int]$rawNormalizationResult.FirstLastSwappedCount
         $hasNoTags = ($rawNormalizationResult.HasNoTags -eq $true)
@@ -7077,6 +7225,12 @@ function ConvertTo-NormalizedData {
         try {
             $writerState = Open-NormalizedVulnWriter -VulnOutputPath $VulnOutputPath -VulnColumnDirectoryPath $VulnColumnDirectoryPath -PayloadOutputPath $PayloadOutputPath
             $compactRecord = [object[]]@(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -1)
+
+            Invoke-NormalizationCallbackEvent -Callback $NormalizationProgressCallback -EventData ([PSCustomObject]@{
+                    Kind = 'phase'
+                    Phase = 'StreamNormalizationSourceRows'
+                    Message = 'Streaming normalization source rows into the normalized payload.'
+                })
 
             # IMPORTANT: Use pipeline (| ForEach-Object) not foreach() to avoid
             # collecting all source rows into memory at once.
@@ -7112,7 +7266,9 @@ function ConvertTo-NormalizedData {
                     -Context $context `
                     -FirstSeenValue $v.PSObject.Properties['FirstSeenTimestamp']?.Value `
                     -LastSeenValue $v.PSObject.Properties['LastSeenTimestamp']?.Value `
-                    -FirstLastSwappedCount ([ref]$firstLastSwappedCount)
+                        -FirstLastSwappedCount ([ref]$firstLastSwappedCount) `
+                        -NormalizationProgressState $normalizationProgressState `
+                        -NormalizationProgressCallback $NormalizationProgressCallback
             }
 
             Sync-NormalizedVulnWriter -WriterState $writerState

--- a/tests/Run-SharedHelperRegression.ps1
+++ b/tests/Run-SharedHelperRegression.ps1
@@ -1731,6 +1731,94 @@ function Test-GetNormalizedRecordLookupHandlesScalarPathInputs {
     Assert-True ($context.Lookups.regPaths.Count -eq 1) 'Expected scalar registry path input to materialize one registry path lookup.'
 }
 
+function Test-InvokeNormalizationProgressCallbackUsesCountAndHeartbeat {
+    [CmdletBinding()]
+    param()
+
+    $progressEvents = [System.Collections.Generic.List[object]]::new()
+    $progressState = New-NormalizationProgressState -ProgressInterval 3 -HeartbeatIntervalSeconds 60 -CheckInterval 1
+
+    Invoke-NormalizationProgressCallback -State $progressState -Count 1 -Callback {
+        param($ProgressEvent)
+
+        $progressEvents.Add($ProgressEvent) | Out-Null
+    }
+    Assert-True ($progressEvents.Count -eq 0) 'Expected normalization progress callback to remain quiet before the progress interval is reached.'
+
+    Invoke-NormalizationProgressCallback -State $progressState -Count 3 -Callback {
+        param($ProgressEvent)
+
+        $progressEvents.Add($ProgressEvent) | Out-Null
+    }
+
+    Assert-True ($progressEvents.Count -eq 1) 'Expected normalization progress callback to fire when the progress interval is reached.'
+    Assert-True ([string]$progressEvents[0].Kind -eq 'progress') 'Expected normalization progress callback events to identify progress updates.'
+    Assert-True ([string]$progressEvents[0].MarkerType -eq 'progress') 'Expected interval-driven normalization callback events to be labeled as progress updates.'
+    Assert-True ([long]$progressEvents[0].Count -eq 3) 'Expected normalization progress callback events to carry the processed row count.'
+
+    $heartbeatEvents = [System.Collections.Generic.List[object]]::new()
+    $heartbeatState = [PSCustomObject]@{
+        ProgressInterval = 100
+        HeartbeatIntervalSeconds = 60
+        CheckInterval = 1
+        Stopwatch = [PSCustomObject]@{
+            Elapsed = [TimeSpan]::FromSeconds(61)
+        }
+        LastHeartbeatSecond = -1
+    }
+
+    Invoke-NormalizationProgressCallback -State $heartbeatState -Count 1 -Callback {
+        param($ProgressEvent)
+
+        $heartbeatEvents.Add($ProgressEvent) | Out-Null
+    }
+
+    Assert-True ($heartbeatEvents.Count -eq 1) 'Expected normalization progress callback to emit a heartbeat event after the heartbeat interval elapses.'
+    Assert-True ([string]$heartbeatEvents[0].MarkerType -eq 'heartbeat') 'Expected elapsed-time normalization callback events to be labeled as heartbeats.'
+}
+
+function Test-ConvertToNormalizedDataReportsContentStoreNormalizationPhase {
+    [CmdletBinding()]
+    param()
+
+    $tempRoot = Join-Path ([System.IO.Path]::GetTempPath()) ('normalized-progress-callback-' + [guid]::NewGuid().ToString('N'))
+    [void](New-Item -Path $tempRoot -ItemType Directory -Force)
+    $outputPath = Join-Path $tempRoot 'normalized-vulns.json'
+
+    try {
+        $currentRow = Get-TestVulnRow -Id 'progress-callback-001' -CveId 'CVE-2026-0999' -SnapshotDate '2026-03-20' -Version '1.0.0'
+        $historyRow = Get-TestVulnRow -Id 'progress-callback-002' -CveId 'CVE-2026-1000' -SnapshotDate '2026-03-18' -Version '1.0.1'
+        Write-NdjsonRecordsFile -Path (Get-VulnCurrentPath -BasePath $tempRoot) -Records @($currentRow)
+        [void](New-Item -Path (Get-VulnHistoryPath -BasePath $tempRoot -PeriodKey '2026Q1') -ItemType File -Force)
+        Write-NdjsonRecordsFile -Path (Get-VulnHistoryRowsPath -BasePath $tempRoot -PeriodKey '2026Q1') -Records @($historyRow)
+        Publish-VulnContentStoreUnlocked -BasePath $tempRoot
+
+        $events = [System.Collections.Generic.List[object]]::new()
+        $result = ConvertTo-NormalizedData -DataPath $tempRoot -VulnOutputPath $outputPath -Machines @{} -AdvancedHuntingData @{} -SkipObservedWindowMerge -NormalizationProgressCallback {
+            param($ProgressEvent)
+
+            $events.Add([PSCustomObject]@{
+                Kind = [string]$ProgressEvent.Kind
+                Phase = [string]$ProgressEvent.Phase
+                Message = [string]$ProgressEvent.Message
+                }) | Out-Null
+        }
+
+        Assert-True ($result.VulnCount -eq 2) 'Expected content-store normalization to preserve both onboarded test rows.'
+        Assert-True ($events.Count -gt 0) 'Expected ConvertTo-NormalizedData to forward normalization callback events when a callback is provided.'
+
+        $phaseNames = @($events | Where-Object { [string]$_.Kind -eq 'phase' } | ForEach-Object { [string]$_.Phase })
+        Assert-True ('LoadContentStoreDeviceProfiles' -in $phaseNames) 'Expected content-store normalization to report device-profile loading through the normalization callback.'
+        Assert-True ('LoadContentStoreTemplates' -in $phaseNames) 'Expected content-store normalization to report template loading through the normalization callback.'
+        Assert-True ('StreamContentStoreRefs' -in $phaseNames) 'Expected content-store normalization to report ref streaming through the normalization callback.'
+    }
+    finally {
+        if (Test-Path -LiteralPath $tempRoot) {
+            Remove-Item -LiteralPath $tempRoot -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+}
+
 function Test-ConvertToNormalizedDataUsesStableDeviceIdFallback {
     [CmdletBinding()]
     param()
@@ -3808,6 +3896,39 @@ function Test-FunctionAppWriteOutputNoEnumeratePreservesJObject {
     Assert-True ((Get-VulnPropertyValue -InputObject $observed[0] -Name 'ob') -eq $true) 'Expected Function App Write-Output -NoEnumerate to preserve compact boolean properties.'
 }
 
+function Test-FunctionExecutionStatusSummaryIncludesNormalizationProgressInfo {
+    [CmdletBinding()]
+    param()
+
+    $repoRoot = Split-Path -Path $PSScriptRoot -Parent
+    $validationScriptPath = Join-Path $repoRoot 'build\Invoke-AzureDeploymentValidation.ps1'
+    Assert-True ((Test-Path -LiteralPath $validationScriptPath -PathType Leaf)) "Expected validation script at '$validationScriptPath'."
+
+    $scriptText = Get-Content -LiteralPath $validationScriptPath -Raw
+    $functionMatch = [regex]::Match($scriptText, '(?s)function Get-FunctionExecutionStatusSummaryText \{.*?\r?\n\}\r?\n\r?\nfunction Set-FunctionExecutionControlBlob')
+    Assert-True ($functionMatch.Success) 'Expected validation script to contain Get-FunctionExecutionStatusSummaryText.'
+
+    $functionDefinition = $functionMatch.Value -replace '\r?\n\r?\nfunction Set-FunctionExecutionControlBlob\z', ''
+    $summary = & {
+        . ([scriptblock]::Create($functionDefinition))
+
+        Get-FunctionExecutionStatusSummaryText -StatusDocument ([PSCustomObject]@{
+                status = 'running'
+                stage = 'NormalizeDashboardData'
+                message = 'Streaming content-store vulnerability references into the normalized payload.'
+                pipelineArchitectureVersion = 'monolithic-v1'
+                normalizedPayloadCacheHit = $false
+                normalizedSubPhase = 'StreamContentStoreRefs'
+                normalizedRowCount = 125000
+            })
+    }
+
+    Assert-True ($summary -like '*arch=monolithic-v1*') 'Expected validation status summary text to retain architecture metadata.'
+    Assert-True ($summary -like '*payloadCache=miss*') 'Expected validation status summary text to retain payload-cache metadata.'
+    Assert-True ($summary -like '*subphase=StreamContentStoreRefs*') 'Expected validation status summary text to surface normalization subphase metadata.'
+    Assert-True ($summary -like '*rows=125,000*') 'Expected validation status summary text to surface formatted normalization row counts.'
+}
+
 Write-Output 'Running shared-helper regression checks...'
 Test-CanonicalLayoutHelper
 Write-Output '  Canonical layout helper checks passed.'
@@ -3877,6 +3998,10 @@ Test-AddNormalizedCveUsesStableSeverityIndexLookup
 Write-Output '  CVE severity lookup checks passed.'
 Test-GetNormalizedRecordLookupHandlesScalarPathInputs
 Write-Output '  Scalar path lookup checks passed.'
+Test-InvokeNormalizationProgressCallbackUsesCountAndHeartbeat
+Write-Output '  Normalization progress callback cadence checks passed.'
+Test-ConvertToNormalizedDataReportsContentStoreNormalizationPhase
+Write-Output '  Content-store normalization phase callback checks passed.'
 Test-ConvertToNormalizedDataUsesStableDeviceIdFallback
 Write-Output '  Stable device fallback identity checks passed.'
 Test-ConvertToNormalizedDataWritesExpectedRowCount
@@ -3949,4 +4074,6 @@ Test-VulnObservedWindowCacheRoundTrip
 Write-Output '  Observed-window cache round-trip checks passed.'
 Test-FunctionAppWriteOutputNoEnumeratePreservesJObject
 Write-Output '  Function App Write-Output -NoEnumerate checks passed.'
+Test-FunctionExecutionStatusSummaryIncludesNormalizationProgressInfo
+Write-Output '  Function execution status summary metadata checks passed.'
 Write-Output 'Shared-helper regression checks passed.'

--- a/tests/Run-SharedHelperRegression.ps1
+++ b/tests/Run-SharedHelperRegression.ps1
@@ -3909,24 +3909,37 @@ function Test-FunctionExecutionStatusSummaryIncludesNormalizationProgressInfo {
     Assert-True ($functionMatch.Success) 'Expected validation script to contain Get-FunctionExecutionStatusSummaryText.'
 
     $functionDefinition = $functionMatch.Value -replace '\r?\n\r?\nfunction Set-FunctionExecutionControlBlob\z', ''
-    $summary = & {
-        . ([scriptblock]::Create($functionDefinition))
+    $originalCulture = [System.Globalization.CultureInfo]::CurrentCulture
+    $originalUiCulture = [System.Globalization.CultureInfo]::CurrentUICulture
+    try {
+        $nonEnglishCulture = [System.Globalization.CultureInfo]::GetCultureInfo('de-DE')
+        [System.Threading.Thread]::CurrentThread.CurrentCulture = $nonEnglishCulture
+        [System.Threading.Thread]::CurrentThread.CurrentUICulture = $nonEnglishCulture
 
-        Get-FunctionExecutionStatusSummaryText -StatusDocument ([PSCustomObject]@{
-                status = 'running'
-                stage = 'NormalizeDashboardData'
-                message = 'Streaming content-store vulnerability references into the normalized payload.'
-                pipelineArchitectureVersion = 'monolithic-v1'
-                normalizedPayloadCacheHit = $false
-                normalizedSubPhase = 'StreamContentStoreRefs'
-                normalizedRowCount = 125000
-            })
+        $summary = & {
+            . ([scriptblock]::Create($functionDefinition))
+
+            Get-FunctionExecutionStatusSummaryText -StatusDocument ([PSCustomObject]@{
+                    status = 'running'
+                    stage = 'NormalizeDashboardData'
+                    message = 'Streaming content-store vulnerability references into the normalized payload.'
+                    pipelineArchitectureVersion = 'monolithic-v1'
+                    normalizedPayloadCacheHit = $false
+                    normalizedSubPhase = 'StreamContentStoreRefs'
+                    normalizedRowCount = 125000
+                })
+        }
+    }
+    finally {
+        [System.Threading.Thread]::CurrentThread.CurrentCulture = $originalCulture
+        [System.Threading.Thread]::CurrentThread.CurrentUICulture = $originalUiCulture
     }
 
     Assert-True ($summary -like '*arch=monolithic-v1*') 'Expected validation status summary text to retain architecture metadata.'
     Assert-True ($summary -like '*payloadCache=miss*') 'Expected validation status summary text to retain payload-cache metadata.'
     Assert-True ($summary -like '*subphase=StreamContentStoreRefs*') 'Expected validation status summary text to surface normalization subphase metadata.'
     Assert-True ($summary -like '*rows=125,000*') 'Expected validation status summary text to surface formatted normalization row counts.'
+    Assert-True ($summary -notlike '*rows=125.000*') 'Expected validation status summary text to avoid host-culture row count formatting.'
 }
 
 Write-Output 'Running shared-helper regression checks...'


### PR DESCRIPTION
## Summary

This PR implements the Stage 0 observability slice for the Azure dashboard pipeline while keeping the accepted runtime architecture as `monolithic-v1`.

It adds:
- explicit pipeline architecture metadata in the Azure status blob
- finer Stage D status transitions for payload cache check, normalization inputs, normalization, payload preparation, library preparation, and template loading
- normalization subphase and row-progress reporting during content-store and raw-store normalization
- Function App validation heartbeat formatting for the new status metadata
- focused regression coverage for normalization callback behavior and status summary formatting
- the updated architecture decision record locking `monolithic-v1` as the current baseline

## Validation

Local:
- `pwsh -NoProfile -File .\tests\Run-SharedHelperRegression.ps1`
- `pwsh -NoProfile -File .\build\Invoke-RegressionValidation.ps1`

Azure:
- `pwsh -NoProfile -File .\build\Invoke-AzureDeploymentValidation.ps1 -AutomationAccountName aa-defender-reporting -FunctionAppName func-defender-reporting -SkipMdePermissions -DashboardDeliveryMode Hosted -FunctionExecutionDatasetPath .\.local\large-datasets\synthetic-50k-1_5m -FunctionExecutionTimeoutMinutes 30`
- Azure Automation validation passed
- Azure Function App deployment validation passed
- Hosted Function App execution accepted at `2026-05-06T17:13:21.5524642Z`
- Hosted heartbeat reported the new normalization status details, including:
  - `subphase=LoadContentStoreDeviceProfiles`
  - `subphase=StreamContentStoreRefs`
  - `rows=100,000`
  - `rows=600,000`
  - `rows=1,100,000`
  - `rows=1,500,000`
- Function App wrote the hosted dashboard blob at `2026-05-06T17:22:07Z`
- Azure deployment validation completed successfully
