### PR TITLE
Record Stage 1 baseline triggers

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -16,4 +16,7 @@
 
 - Dataset(s):
 - Artifact path(s):
+- Azure acceptance delta vs `docs/performance-baselines.md`:
+- Rewrite-trigger review (`two consecutive failures`, `>10%` elapsed or working-set regression, `>15%` execution-unit growth):
+- Accepted-envelope refresh, if this PR changes it: raw artifact path kept under `.local/`
 - Skipped gates and reason:

--- a/docs/performance-baselines.md
+++ b/docs/performance-baselines.md
@@ -40,22 +40,31 @@ The raw result JSON files from the April 5, 2026 capture remain local-only under
 | `exports-synthetic-live` | `710160384` bytes | `616402944` bytes | `593.3 MB` | `298.2 MB` | `1029.2 MB` | `1029.2 MB` | `1172889600` |
 | `review-synthetic-medium` | `333520896 to 341286912` bytes | `236150784 to 242094080` bytes | `407.6 to 412.5 MB` | `85.2 to 95.0 MB` | `580.6 to 587.6 MB` | `580.2 to 587.6 MB` | `0.0` |
 
+## Standard large Azure acceptance
+
+| Dataset | Shape | Architecture | Azure path | Acceptance markers | Review notes |
+| --- | --- | --- | --- | --- | --- |
+| `synthetic-50k-1_5m` | `50,000` devices, `1,500,000` rows, `3,097` CVEs | `monolithic-v1` | Azure Automation plus hosted Function App (`Dual`) | Function App execution accepted `2026-05-06T06:26:05Z`; dashboard blob written `2026-05-06T06:33:39Z`; blob-write interval `454s` | Treat this as the accepted Stage 1 large Azure envelope anchor until a newer accepted run replaces it. Compare future standard-dataset Azure runs against this record plus the review thresholds in `docs/performance-gate-playbook.md`, and keep the raw Azure validation artifacts local under `.local/`. |
+
 ## Capture notes
 
 - Date captured: `2026-04-05` for the original synthetic replay baselines.
 - Date captured: `2026-04-20` for the hosted `review-synthetic-medium` Azure acceptance replay.
 - Date captured: `2026-04-20` for the durable `benchmark-medium-v1` three-iteration hosted benchmark series.
+- Date captured: `2026-05-06` for the accepted standard large-dataset Azure envelope on `synthetic-50k-1_5m`.
 - Branch intent: current branch only, no `main` comparison.
 - Dataset shapes:
   - `benchmark-medium-v1`: standard durable benchmark dataset generated from the catalog entry in `tests/benchmark-datasets.json` with preset `BalancedMediumHeavy`, seed `20260322`, `120000` rows, and `1500` devices.
   - `exports-synthetic`: original `20K` synthetic replay dataset.
   - `exports-synthetic-live`: shifted synthetic live-export dataset with a latest snapshot date of `2026-04-05`.
   - `review-synthetic-medium`: `BalancedMediumHeavy` review dataset with `120000` rows and `1500` devices, validated against Azure Automation `aa-defender-reporting` and Function App `func-defender-reporting-parallel-0404a`.
+  - `synthetic-50k-1_5m`: standard large Azure acceptance dataset rooted at `.local\large-datasets\synthetic-50k-1_5m`.
 - `benchmark-medium-v1` is now the standard durable dataset for merge-tracked baseline refreshes and supersedes `review-synthetic-medium` for future benchmark-series captures.
 - `benchmark-medium-v1` Function App headline timing now uses active execution time from the runtime status blob; end-to-end invocation time and pickup delay are recorded separately for queue and cold-start review.
 - The durable `benchmark-medium-v1` persistent local cache reuse pass was effectively stable across reruns (`45.44s` to `45.49s`) and is the preferred baseline for normalized-column cache reuse.
 - The hosted review baseline was captured twice on the same dataset and command path. This document records ranges because the cold local normalization pass moved more than the hosted paths across reruns.
 - The local benchmark harness stages a private dataset copy before validation so raw datasets do not get mutated by sidecar regeneration during baseline capture.
+- The standard large Azure entry intentionally records the accepted invocation and blob-write markers that are already tracked in-repo. Preserve the raw Azure validation artifacts under `.local/` when refreshing this section so future updates can add comparable working-set or execution-unit detail without reconstructing the run later.
 
 ## Regenerating the baseline
 

--- a/docs/performance-gate-playbook.md
+++ b/docs/performance-gate-playbook.md
@@ -10,7 +10,7 @@ This playbook keeps performance work measurable while preserving memory headroom
 | Hot phase review | Every refactor that touches normalization, payload generation, validation, or Azure packaging | `pwsh -NoProfile -File .\tests\Invoke-HotPhaseReview.ps1 -DirectoryPath <dataset>` | `hot-phase-review.json`, stdout log, validation audit | Investigate generator or validation phases that regress by more than `5%` or materially shift relative ordering |
 | Synthetic benchmark | After a change that appears to improve or regress performance | `pwsh -NoProfile -File .\tests\Measure-BranchVsMainBenchmark.ps1 -CurrentOnly -DatasetPath <dataset> -ResultsOutputPath <path>` | branch benchmark JSON | Investigate local elapsed or peak memory regressions above `10%` |
 | Local history capture | After any benchmark you expect to compare again later | `pwsh -NoProfile -File .\tests\Record-BenchmarkHistory.ps1 -BenchmarkResultPath <path>` | `.local\benchmark-history\benchmark-history.jsonl`, `latest-summary.md` | Use for longitudinal local tracking; do not update merge-tracked docs for one-off review datasets |
-| Azure acceptance | Before merging perf-sensitive changes and before release packaging changes | `pwsh -NoProfile -File .\build\Invoke-AzureDeploymentValidation.ps1 -AutomationAccountName <name> -FunctionAppName <name>` | live Azure validation artifacts | Investigate runbook or Function App regressions above `10%`; investigate Function execution-unit growth above `15%` |
+| Azure acceptance | Before merging perf-sensitive changes and before release packaging changes | `pwsh -NoProfile -File .\build\Invoke-AzureDeploymentValidation.ps1 -AutomationAccountName <name> -FunctionAppName <name>` | live Azure validation artifacts | Investigate runbook or Function App regressions above `10%`; investigate Function execution-unit growth above `15%`; compare the standard large-dataset run against the accepted envelope in `docs/performance-baselines.md` |
 | Baseline refresh | After an accepted improvement or a durable dataset change | update `docs/performance-baselines.md` and keep raw JSON under `.local/` | doc summary plus local raw artifacts | Capture only after the new behavior is accepted |
 
 ## Dataset cadence
@@ -27,6 +27,12 @@ Standard benchmark dataset:
 - Generator: `pwsh -NoProfile -File .\tests\New-BenchmarkDataset.ps1 -DatasetId benchmark-medium-v1`
 - Series capture: `pwsh -NoProfile -File .\tests\Invoke-BenchmarkSeries.ps1 -BenchmarkDatasetId benchmark-medium-v1 -Iterations 3 -IncludePersistentLocalWorkflow`
 - Shape: `BalancedMediumHeavy`, `1,500` devices, `120,000` vulnerability rows, seed `20260322`
+
+Standard large Azure acceptance dataset:
+- Dataset path: `.local\large-datasets\synthetic-50k-1_5m`
+- Shape: `50,000` devices, `1,500,000` vulnerability rows, `3,097` CVEs
+- Accepted architecture anchor: `monolithic-v1`
+- Compare future hosted Azure acceptance runs against the latest accepted envelope in `docs/performance-baselines.md`
 
 ## Recommended workflow
 
@@ -49,6 +55,14 @@ Timing interpretation:
 - Azure Automation already tracks active execution time from job start to job end.
 - Function App benchmark summaries now treat `function_app.elapsed_seconds` as active execution time when the runtime status blob is available.
 - Function App invoke-to-finish time remains available as `function_app.end_to_end_elapsed_seconds` so queue delay and cold-start variance can still be reviewed separately.
+
+## Rewrite trigger review
+
+- Use the standard `synthetic-50k-1_5m` Azure acceptance lane as the rewrite-trigger anchor for `monolithic-v1`.
+- Do not escalate on a single Azure failure or a single noisy run.
+- Investigate any runbook or hosted Function App elapsed or working-set regression above `10%` relative to the accepted envelope in `docs/performance-baselines.md`.
+- Investigate any hosted Function App execution-unit growth above `15%`.
+- Escalate to the staged rewrite only after two consecutive hosted Function App Azure acceptance failures on the standard large dataset, repeated beyond-threshold regressions that persist after localized fixes, or a new resumability requirement.
 
 ## Hot phase interpretation
 


### PR DESCRIPTION
## Summary

This PR packages the Stage 1 follow-up from the pipeline architecture review.

It does not change runtime behavior. It updates the tracked operational docs so future Azure acceptance runs can be compared against the accepted `monolithic-v1` envelope without reopening the architecture memo.

Changes:
- record the accepted standard large Azure anchor for `synthetic-50k-1_5m` in `docs/performance-baselines.md`
- wire the existing `10%` elapsed/working-set and `15%` execution-unit thresholds into `docs/performance-gate-playbook.md`
- add PR-template note fields for Azure acceptance delta and rewrite-trigger review

## Validation

- `git diff --check`

## Notes

- runtime behavior is unchanged
- no PowerShell, generated artifact, or browser validation was needed for this docs/template-only follow-up
- the large Azure acceptance entry records the accepted invocation/blob markers already tracked in-repo and points future refreshes back to the raw local Azure validation artifacts under `.local/`
