### PR TITLE
Add routine semantic review lane

### DIFF
--- a/build/Invoke-RegressionValidation.ps1
+++ b/build/Invoke-RegressionValidation.ps1
@@ -212,6 +212,13 @@ if ($analyzerResults) {
     throw "ScriptAnalyzer returned findings:`n$formatted"
 }
 
+Write-Output 'Running routine semantic review wrapper smoke...'
+Reset-LastExitCode
+& (Join-Path $repoRoot 'tests\Invoke-RoutineSemanticReview.ps1') -WhatIf
+if (Test-LastExitCodeFailed) {
+    throw 'tests/Invoke-RoutineSemanticReview.ps1 smoke failed.'
+}
+
 Write-Output 'Running shared-helper regression tests...'
 & (Join-Path $repoRoot 'tests\Run-SharedHelperRegression.ps1')
 

--- a/docs/performance-gate-playbook.md
+++ b/docs/performance-gate-playbook.md
@@ -8,6 +8,7 @@ This playbook keeps performance work measurable while preserving memory headroom
 | --- | --- | --- | --- | --- |
 | Deterministic preflight | Every PR and before any perf run | `pwsh -NoProfile -File .\build\Invoke-RegressionValidation.ps1` | parser, ScriptAnalyzer, fixture smoke | Must pass |
 | Hot phase review | Every refactor that touches normalization, payload generation, validation, or Azure packaging | `pwsh -NoProfile -File .\tests\Invoke-HotPhaseReview.ps1 -DirectoryPath <dataset>` | `hot-phase-review.json`, stdout log, validation audit | Investigate generator or validation phases that regress by more than `5%` or materially shift relative ordering |
+| Routine semantic review | When semantic or validation changes need repeatable review during iteration | `pwsh -NoProfile -File .\tests\Invoke-RoutineSemanticReview.ps1` | medium-dataset `hot-phase-review.json`, audit, stdout/stderr logs | Use before escalating to the `synthetic-50k-1_5m` semantic sign-off lane |
 | Synthetic benchmark | After a change that appears to improve or regress performance | `pwsh -NoProfile -File .\tests\Measure-BranchVsMainBenchmark.ps1 -CurrentOnly -DatasetPath <dataset> -ResultsOutputPath <path>` | branch benchmark JSON | Investigate local elapsed or peak memory regressions above `10%` |
 | Local history capture | After any benchmark you expect to compare again later | `pwsh -NoProfile -File .\tests\Record-BenchmarkHistory.ps1 -BenchmarkResultPath <path>` | `.local\benchmark-history\benchmark-history.jsonl`, `latest-summary.md` | Use for longitudinal local tracking; do not update merge-tracked docs for one-off review datasets |
 | Azure acceptance | Before merging perf-sensitive changes and before release packaging changes | `pwsh -NoProfile -File .\build\Invoke-AzureDeploymentValidation.ps1 -AutomationAccountName <name> -FunctionAppName <name>` | live Azure validation artifacts | Investigate runbook or Function App regressions above `10%`; investigate Function execution-unit growth above `15%`; compare the standard large-dataset run against the accepted envelope in `docs/performance-baselines.md` |
@@ -38,13 +39,14 @@ Standard large Azure acceptance dataset:
 
 1. Run the deterministic preflight.
 2. Run `tests/Invoke-HotPhaseReview.ps1` on the representative local dataset you are using for the refactor.
-3. If validation dominates, run `tests/Invoke-ValidationModeComparison.ps1` to split package-only, force-full validation, and attested validation into separate measured runs.
-4. Review the top generator phases plus the audit `PhaseTimings` values from the hot-phase or validation-mode report.
-5. Make one focused change at a time and re-run the relevant local review command.
-6. Once the local review looks better, refresh `benchmark-medium-v1` if needed and capture a benchmark result with `tests/Measure-BranchVsMainBenchmark.ps1` or `tests/Invoke-BenchmarkSeries.ps1`.
-7. If the change is still favorable, validate the large dataset in Azure.
-8. Append the benchmark JSON to `.local` history with `tests/Record-BenchmarkHistory.ps1`.
-9. Record accepted durable baselines in `docs/performance-baselines.md` and keep raw JSON artifacts under `.local/`.
+3. If semantic or validation behavior changed, run `tests/Invoke-RoutineSemanticReview.ps1` before escalating to the large semantic sign-off lane.
+4. If validation dominates, run `tests/Invoke-ValidationModeComparison.ps1` to split package-only, force-full validation, and attested validation into separate measured runs.
+5. Review the top generator phases plus the audit `PhaseTimings` values from the hot-phase or validation-mode report.
+6. Make one focused change at a time and re-run the relevant local review command.
+7. Once the local review looks better, refresh `benchmark-medium-v1` if needed and capture a benchmark result with `tests/Measure-BranchVsMainBenchmark.ps1` or `tests/Invoke-BenchmarkSeries.ps1`.
+8. If the change is still favorable, validate the large dataset in Azure.
+9. Append the benchmark JSON to `.local` history with `tests/Record-BenchmarkHistory.ps1`.
+10. Record accepted durable baselines in `docs/performance-baselines.md` and keep raw JSON artifacts under `.local/`.
 
 Guardrails:
 - `tests/Invoke-HotPhaseReview.ps1` now defaults to artifact parity review instead of semantic replay.

--- a/docs/test-coverage-validation-review.md
+++ b/docs/test-coverage-validation-review.md
@@ -168,7 +168,7 @@ Current state:
 
 Remaining recommendation:
 
-- Add a cheaper routine semantic-review lane that uses a deterministic medium or stratified dataset, then reserve the 50k/1.5m full semantic gate for release sign-off and high-risk normalization changes.
+- Keep the new routine semantic-review lane on a deterministic medium dataset, then reserve the 50k/1.5m full semantic gate for release sign-off and high-risk normalization changes.
 - Investigate durable signature cache artifacts keyed by source fingerprint, normalized payload `PayloadSha256`, semantic canonicalizer version, and validation helper version so repeat validations can reuse unchanged signatures safely.
 - Evaluate whether source and payload signature partitioning can be parallelized without increasing memory pressure or destabilizing Azure Automation/Function App parity.
 - Record phase timings from several local and Azure runs before setting thresholds, because the observed cost is dominated by host performance and dataset size.
@@ -193,5 +193,5 @@ Use these as a menu based on the changed surface.
 2. Keep the manifest, sidecar, and audit source metadata from this branch, then add strict freshness/enrichment controls in a separate behavior-focused change.
 3. Keep the new negative hosted-payload and package-only mismatch checks, then add stale-attestation and baseline mismatch fixtures separately.
 4. Keep the non-visual hosted browser runtime smoke as a local/manual gate until a cross-platform browser dependency is accepted.
-5. Add a cheaper routine semantic-review lane and investigate durable signature cache reuse before making the 50k/1.5m semantic gate part of frequent validation.
+5. Keep the routine semantic-review lane and investigate durable signature cache reuse before making the 50k/1.5m semantic gate part of frequent validation.
 6. Keep the PR checklist for manual heavy gates and revisit benchmark artifact threshold automation after several recorded runs establish normal variance.

--- a/tests/Invoke-RoutineSemanticReview.ps1
+++ b/tests/Invoke-RoutineSemanticReview.ps1
@@ -1,0 +1,99 @@
+﻿#Requires -Version 7.0
+
+[CmdletBinding(SupportsShouldProcess)]
+param(
+    [Parameter(Mandatory = $false)]
+    [string]$BenchmarkDatasetId = 'benchmark-medium-v1',
+
+    [Parameter(Mandatory = $false)]
+    [string]$OutputRoot = (Join-Path (Split-Path -Path $PSScriptRoot -Parent) ('.local\routine-semantic-review\' + (Get-Date -Format 'yyyyMMdd-HHmmss'))),
+
+    [Parameter(Mandatory = $false)]
+    [switch]$ForceDatasetRefresh,
+
+    [Parameter(Mandatory = $false)]
+    [ValidateRange(100000, 50000000)]
+    [int]$SemanticValidationRowLimit = 1000000,
+
+    [Parameter(Mandatory = $false)]
+    [ValidateRange(15, 3600)]
+    [int]$ValidationHeartbeatSeconds = 60,
+
+    [Parameter(Mandatory = $false)]
+    [ValidateRange(1, 64)]
+    [int]$ValidationPartitionCompareParallelism = 1,
+
+    [Parameter(Mandatory = $false)]
+    [ValidateRange(1, 60)]
+    [int]$PollIntervalSeconds = 5
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+. (Join-Path $PSScriptRoot 'Import-BenchmarkDatasetCatalog.ps1')
+
+$repoRoot = Split-Path -Path $PSScriptRoot -Parent
+$definition = Get-BenchmarkDatasetDefinition -DatasetId $BenchmarkDatasetId -RepoRoot $repoRoot
+if ($null -eq $definition) {
+    throw "Benchmark dataset definition '$BenchmarkDatasetId' was not found."
+}
+
+$datasetScriptPath = Join-Path $PSScriptRoot 'New-BenchmarkDataset.ps1'
+$reviewScriptPath = Join-Path $PSScriptRoot 'Invoke-HotPhaseReview.ps1'
+if (-not (Test-Path -LiteralPath $datasetScriptPath -PathType Leaf)) {
+    throw "Benchmark dataset materializer was not found: '$datasetScriptPath'"
+}
+
+if (-not (Test-Path -LiteralPath $reviewScriptPath -PathType Leaf)) {
+    throw "Hot phase review script was not found: '$reviewScriptPath'"
+}
+
+$resolvedDatasetPath = Resolve-BenchmarkDatasetOutputPath -Definition $definition -RepoRoot $repoRoot
+$resolvedOutputRoot = [System.IO.Path]::GetFullPath($OutputRoot)
+
+$plan = [PSCustomObject]@{
+    benchmarkDatasetId = $BenchmarkDatasetId
+    datasetPath = $resolvedDatasetPath
+    outputRoot = $resolvedOutputRoot
+    validationMode = 'semantic'
+    forceFullValidation = $true
+    semanticValidationRowLimit = $SemanticValidationRowLimit
+    validationHeartbeatSeconds = $ValidationHeartbeatSeconds
+    validationPartitionCompareParallelism = $ValidationPartitionCompareParallelism
+    pollIntervalSeconds = $PollIntervalSeconds
+}
+
+Write-Output 'Running routine semantic review...'
+Write-Output ("  Benchmark dataset id: {0}" -f $plan.benchmarkDatasetId)
+Write-Output ("  Dataset path: {0}" -f $plan.datasetPath)
+Write-Output ("  Output root: {0}" -f $plan.outputRoot)
+Write-Output '  Validation mode: semantic (full review)'
+
+if ($PSCmdlet.ShouldProcess($resolvedDatasetPath, ("Ensure benchmark dataset '{0}' is ready" -f $BenchmarkDatasetId))) {
+    $datasetArguments = @{
+        DatasetId = $BenchmarkDatasetId
+    }
+    if ($ForceDatasetRefresh) {
+        $datasetArguments['Force'] = $true
+    }
+
+    & $datasetScriptPath @datasetArguments
+}
+
+if ($PSCmdlet.ShouldProcess($resolvedDatasetPath, 'Run full semantic hot phase review')) {
+    $reviewArguments = @{
+        DirectoryPath = $resolvedDatasetPath
+        OutputRoot = $resolvedOutputRoot
+        ValidationMode = 'semantic'
+        ForceFullValidation = $true
+        SemanticValidationRowLimit = $SemanticValidationRowLimit
+        ValidationHeartbeatSeconds = $ValidationHeartbeatSeconds
+        ValidationPartitionCompareParallelism = $ValidationPartitionCompareParallelism
+        PollIntervalSeconds = $PollIntervalSeconds
+    }
+
+    & $reviewScriptPath @reviewArguments
+}
+
+return $plan

--- a/tests/README.md
+++ b/tests/README.md
@@ -202,6 +202,22 @@ Long-running review, stress, and benchmark wrappers now emit timestamped heartbe
 
 Use a smaller synthetic dataset while iterating, then move to the benchmark and Azure validation entrypoints once the local hot phases improve.
 
+## Routine semantic review
+
+Run the routine medium-dataset semantic lane with:
+
+```powershell
+pwsh -NoProfile -File .\tests\Invoke-RoutineSemanticReview.ps1
+```
+
+That command:
+- ensures the durable `benchmark-medium-v1` dataset is present
+- runs `Invoke-HotPhaseReview.ps1` against that dataset in `semantic` mode with `-ForceFullValidation`
+- writes the review artifacts under `.local\routine-semantic-review\<timestamp>\`
+- gives you a repeatable semantic review path that is materially cheaper than the `synthetic-50k-1_5m` full sign-off lane
+
+Use this workflow for routine semantic or validation review during iteration, then keep the full `synthetic-50k-1_5m` semantic gate for release sign-off and high-risk normalization changes.
+
 ## Validation mode comparison
 
 Split packaging, full validation, and attested validation into separate measured runs with:
@@ -295,6 +311,7 @@ Recommendations:
 - keep raw benchmark outputs under `.local/`
 - use `.local\benchmark-history\benchmark-history.jsonl` plus `.local\benchmark-history\latest-summary.md` for repeated review and Azure acceptance captures that you want to compare over time
 - prefer `benchmark-medium-v1` plus `Invoke-BenchmarkSeries.ps1` when you need the durable, merge-tracked benchmark cadence instead of an ad hoc review capture
+- prefer `benchmark-medium-v1` plus `Invoke-RoutineSemanticReview.ps1` when you need repeatable semantic review coverage without paying for the 50k/1.5m local replay
 - prefer `benchmark-large-50k-v1` plus `New-SyntheticSnapshotDelta.ps1` when you need a reusable large Azure seed with a fresh incoming snapshot date
 - use the staged local copy behavior in `Measure-BranchVsMainBenchmark.ps1` when benchmarking raw datasets without sidecars
 - use `docs/performance-baselines.md` only for accepted durable datasets that should remain merge-tracked as baseline documentation


### PR DESCRIPTION
## Summary
- add `tests/Invoke-RoutineSemanticReview.ps1` as a thin wrapper that materializes `benchmark-medium-v1` and runs `Invoke-HotPhaseReview.ps1` in full semantic mode
- smoke the new wrapper from `build/Invoke-RegressionValidation.ps1` with `-WhatIf` so the entrypoint stays covered in deterministic preflight
- document the new medium semantic lane in the test and performance playbooks and update the validation review notes

## Validation
- `pwsh -NoProfile -File .\build\Invoke-RegressionValidation.ps1`
- `pwsh -NoProfile -File .\tests\Invoke-RoutineSemanticReview.ps1 -OutputRoot .\.local\routine-semantic-review\smoke-20260506-170119`

## Notes
- the routine semantic review run completed successfully and wrote `hot-phase-review.json` under `.local\routine-semantic-review\smoke-20260506-170119`
- observed medium-dataset semantic hot phases were dominated by validation replay (`Validate dashboard` about `878.91s`, `Source signatures` about `529.81s`, `Payload signatures` about `337.48s`)