### PR TITLE
Improve setup idempotency and modal responsiveness

### DIFF
--- a/Setup-AzureResources.ps1
+++ b/Setup-AzureResources.ps1
@@ -582,6 +582,56 @@ if (-not $provisioningHelperPath) {
 
 . $provisioningHelperPath
 
+function Get-OptionalArmResource {
+    [CmdletBinding()]
+    [OutputType([pscustomobject])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Path,
+
+        [Parameter(Mandatory = $true)]
+        [string]$Description
+    )
+
+    try {
+        return [PSCustomObject]@{
+            Exists = $true
+            Resource = (Invoke-ArmApi -Path $Path -Method GET -Description $Description)
+        }
+    }
+    catch {
+        if (Test-IsArmNotFoundError -ErrorRecord $_) {
+            return [PSCustomObject]@{
+                Exists = $false
+                Resource = $null
+            }
+        }
+
+        throw
+    }
+}
+
+function Get-CreateOnlyProvisioningPayload {
+    [CmdletBinding()]
+    [OutputType([System.Collections.IDictionary])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [System.Collections.IDictionary]$Payload,
+
+        [Parameter(Mandatory = $true)]
+        [bool]$IsNewResource
+    )
+
+    if ($IsNewResource) {
+        $Payload['tags'] = $Script:ProvisioningTags
+    }
+    elseif ($Payload.Contains('tags')) {
+        [void]$Payload.Remove('tags')
+    }
+
+    return $Payload
+}
+
 # =============================================================================
 # MAIN SCRIPT
 # =============================================================================
@@ -710,31 +760,17 @@ try {
         }
     }
 
-    $rgAction = if ($rgExists) { 'Update resource group tags' } else { 'Create resource group' }
-    if ($PSCmdlet.ShouldProcess($ResourceGroupName, $rgAction)) {
-        $rgTags = @{}
-        $existingTags = if ($rgExists -and $null -ne $rg) { $rg.PSObject.Properties['tags']?.Value } else { $null }
-        if ($rgExists -and $null -ne $existingTags) {
-            foreach ($property in $existingTags.PSObject.Properties) {
-                $rgTags[$property.Name] = [string]$property.Value
-            }
-        }
-        foreach ($tagKey in $Script:ProvisioningTags.Keys) {
-            $rgTags[$tagKey] = $Script:ProvisioningTags[$tagKey]
-        }
-
+    if ($rgExists) {
+        Write-Host "  Leaving existing resource group tags unchanged" -ForegroundColor Gray
+    }
+    elseif ($PSCmdlet.ShouldProcess($ResourceGroupName, 'Create resource group')) {
         $rgPayload = @{
-            location = if ($rgExists) { $rg.location } else { $Location }
-            tags     = $rgTags
+            location = $Location
+            tags     = $Script:ProvisioningTags
         } | ConvertTo-Json -Depth 5
 
-        Invoke-ArmApi -Path $rgPath -Method PUT -Payload $rgPayload -Description "Create/update resource group" | Out-Null
-        if ($rgExists) {
-            Write-Host "  Resource group tags updated" -ForegroundColor Green
-        }
-        else {
-            Write-Host "  Resource group created" -ForegroundColor Green
-        }
+        Invoke-ArmApi -Path $rgPath -Method PUT -Payload $rgPayload -Description 'Create resource group' | Out-Null
+        Write-Host "  Resource group created" -ForegroundColor Green
     }
 
     # -------------------------------------------------------------------------
@@ -744,10 +780,10 @@ try {
         Write-Host "`nStep 3: Automation Account '$AutomationAccountName'..." -ForegroundColor Cyan
 
         $aaPath = "$subPath/resourceGroups/$ResourceGroupName/providers/Microsoft.Automation/automationAccounts/${AutomationAccountName}?api-version=$($Script:ArmApiVersions.AutomationAccount)"
+        $aaState = Get-OptionalArmResource -Path $aaPath -Description 'Check automation account'
 
-        $aaPayload = @{
+        $aaPayload = Get-CreateOnlyProvisioningPayload -Payload ([ordered]@{
             location   = $Location
-            tags       = $Script:ProvisioningTags
             identity   = @{
                 type = "SystemAssigned"
             }
@@ -755,7 +791,7 @@ try {
                 sku              = @{ name = "Basic" }
                 disableLocalAuth = $true
             }
-        } | ConvertTo-Json -Depth 5
+        }) -IsNewResource (-not $aaState.Exists) | ConvertTo-Json -Depth 5
 
         if ($PSCmdlet.ShouldProcess($AutomationAccountName, "Create/update automation account")) {
             $null = Invoke-ArmApi -Path $aaPath -Method PUT -Payload $aaPayload -Description "Create/update automation account"
@@ -786,10 +822,10 @@ try {
         # 3a: Create Flex Consumption App Service Plan
         $planName = "$FunctionAppName-plan"
         $planPath = "$subPath/resourceGroups/$ResourceGroupName/providers/Microsoft.Web/serverfarms/${planName}?api-version=$($Script:ArmApiVersions.WebApp)"
+        $planState = Get-OptionalArmResource -Path $planPath -Description 'Check Flex Consumption plan'
 
-        $planPayload = @{
+        $planPayload = Get-CreateOnlyProvisioningPayload -Payload ([ordered]@{
             location   = $Location
-            tags       = $Script:ProvisioningTags
             kind       = "functionapp"
             sku        = @{
                 name = "FC1"
@@ -798,7 +834,7 @@ try {
             properties = @{
                 reserved = $true
             }
-        } | ConvertTo-Json -Depth 5
+        }) -IsNewResource (-not $planState.Exists) | ConvertTo-Json -Depth 5
 
         if ($PSCmdlet.ShouldProcess($planName, "Create/update Flex Consumption plan")) {
             $null = Invoke-ArmApi -Path $planPath -Method PUT -Payload $planPayload -Description "Create/update Flex Consumption plan"
@@ -807,10 +843,10 @@ try {
 
         # 3b: Create Function App with system-assigned Managed Identity
         $functionAppPath = "$subPath/resourceGroups/$ResourceGroupName/providers/Microsoft.Web/sites/${FunctionAppName}?api-version=$($Script:ArmApiVersions.WebApp)"
+        $functionAppState = Get-OptionalArmResource -Path $functionAppPath -Description 'Check Function App'
 
-        $functionAppPayload = @{
+        $functionAppPayload = Get-CreateOnlyProvisioningPayload -Payload ([ordered]@{
             location   = $Location
-            tags       = $Script:ProvisioningTags
             kind       = "functionapp,linux"
             identity   = @{
                 type = "SystemAssigned"
@@ -846,7 +882,7 @@ try {
                     }
                 }
             }
-        } | ConvertTo-Json -Depth 10
+        }) -IsNewResource (-not $functionAppState.Exists) | ConvertTo-Json -Depth 10
 
         if ($PSCmdlet.ShouldProcess($FunctionAppName, "Create/update Function App")) {
             $null = Invoke-ArmApi -Path $functionAppPath -Method PUT -Payload $functionAppPayload -Description "Create/update Function App"
@@ -961,10 +997,9 @@ try {
 
     $saPath = "$subPath/resourceGroups/$ResourceGroupName/providers/Microsoft.Storage/storageAccounts/${StorageAccountName}?api-version=$($Script:ArmApiVersions.StorageAccount)"
 
-    $saPayload = @{
+    $saPayload = Get-CreateOnlyProvisioningPayload -Payload ([ordered]@{
         location   = $Location
         kind       = "StorageV2"
-        tags       = $Script:ProvisioningTags
         sku        = @{ name = "Standard_LRS" }
         properties = @{
             minimumTlsVersion          = "TLS1_2"
@@ -976,7 +1011,7 @@ try {
                 defaultAction = "Allow"
             }
         }
-    } | ConvertTo-Json -Depth 5
+    }) -IsNewResource (-not $existingStorageFound) | ConvertTo-Json -Depth 5
 
     if ($PSCmdlet.ShouldProcess($StorageAccountName, "Create/update storage account")) {
         Invoke-ArmApi -Path $saPath -Method PUT -Payload $saPayload -Description "Create/update storage account" | Out-Null
@@ -1257,10 +1292,10 @@ try {
     Write-Host "`nStep 9: Creating custom runtime environment..." -ForegroundColor Cyan
 
     $runtimeEnvPath = "$subPath/resourceGroups/$ResourceGroupName/providers/Microsoft.Automation/automationAccounts/$AutomationAccountName/runtimeEnvironments/$($Script:RuntimeEnvName)?api-version=$($Script:ArmApiVersions.RuntimeEnvironment)"
+    $runtimeEnvState = Get-OptionalArmResource -Path $runtimeEnvPath -Description 'Check runtime environment'
 
-    $runtimeEnvPayload = @{
+    $runtimeEnvPayload = Get-CreateOnlyProvisioningPayload -Payload ([ordered]@{
         location   = $Location
-        tags       = $Script:ProvisioningTags
         properties = @{
             runtime         = @{
                 language = 'PowerShell'
@@ -1269,7 +1304,7 @@ try {
             defaultPackages = @{}
             description     = 'PowerShell 7.4 with Az.Accounts only (no full Az module or Az CLI)'
         }
-    } | ConvertTo-Json -Depth 5
+    }) -IsNewResource (-not $runtimeEnvState.Exists) | ConvertTo-Json -Depth 5
 
     if ($PSCmdlet.ShouldProcess($Script:RuntimeEnvName, "Create runtime environment")) {
         Invoke-ArmApi -Path $runtimeEnvPath -Method PUT -Payload $runtimeEnvPayload -Description "Create runtime environment" | Out-Null
@@ -1308,10 +1343,10 @@ try {
 
     $runbookName = "Invoke-DashboardPipeline"
     $runbookPath = "$subPath/resourceGroups/$ResourceGroupName/providers/Microsoft.Automation/automationAccounts/$AutomationAccountName/runbooks/${runbookName}?api-version=$($Script:ArmApiVersions.RuntimeEnvironment)"
+    $runbookState = Get-OptionalArmResource -Path $runbookPath -Description 'Check runbook'
 
-    $runbookPayload = @{
+    $runbookPayload = Get-CreateOnlyProvisioningPayload -Payload ([ordered]@{
         location   = $Location
-        tags       = $Script:ProvisioningTags
         properties = @{
             runbookType        = "PowerShell"
             runtimeEnvironment = $Script:RuntimeEnvName
@@ -1319,7 +1354,7 @@ try {
             logVerbose         = $false
             description        = "Exports MDE vulnerability data, generates the HTML dashboard, and uploads results to blob storage."
         }
-    } | ConvertTo-Json -Depth 5
+    }) -IsNewResource (-not $runbookState.Exists) | ConvertTo-Json -Depth 5
 
     if ($PSCmdlet.ShouldProcess($runbookName, "Create runbook")) {
         Invoke-ArmApi -Path $runbookPath -Method PUT -Payload $runbookPayload -Description "Create runbook" | Out-Null
@@ -1878,10 +1913,10 @@ try {
         Write-Host "`nStep 16: Creating Container Apps Environment '$ContainerAppEnvName'..." -ForegroundColor Cyan
 
         $caEnvPath = "$subPath/resourceGroups/$ResourceGroupName/providers/Microsoft.App/managedEnvironments/${ContainerAppEnvName}?api-version=$($Script:ArmApiVersions.ContainerAppEnvironment)"
+        $caEnvState = Get-OptionalArmResource -Path $caEnvPath -Description 'Check Container Apps Environment'
 
-        $caEnvPayload = @{
+        $caEnvPayload = Get-CreateOnlyProvisioningPayload -Payload ([ordered]@{
             location   = $Location
-            tags       = $Script:ProvisioningTags
             properties = @{
                 appLogsConfiguration = @{
                     destination = ''
@@ -1894,7 +1929,7 @@ try {
                     }
                 )
             }
-        } | ConvertTo-Json -Depth 5
+        }) -IsNewResource (-not $caEnvState.Exists) | ConvertTo-Json -Depth 5
 
         if ($PSCmdlet.ShouldProcess($ContainerAppEnvName, "Create Container Apps Environment")) {
             Invoke-ArmApi -Path $caEnvPath -Method PUT -Payload $caEnvPayload -Description "Create Container Apps Environment" | Out-Null
@@ -1932,6 +1967,7 @@ try {
         Write-Host "`nStep 17: Creating Container App '$ContainerAppName'..." -ForegroundColor Cyan
 
         $caPath = "$subPath/resourceGroups/$ResourceGroupName/providers/Microsoft.App/containerApps/${ContainerAppName}?api-version=$($Script:ArmApiVersions.ContainerApp)"
+        $caState = Get-OptionalArmResource -Path $caPath -Description 'Check Container App'
 
         # Build a startup script that downloads the dashboard blob using managed identity,
         # then starts Caddy to serve it. The script is base64-encoded to avoid JSON/shell
@@ -2036,7 +2072,6 @@ exec caddy file-server --root /data --listen :80
         # stripping args with special characters)
         $caObj = [ordered]@{
             location   = $Location
-            tags       = $Script:ProvisioningTags
             identity   = @{ type = 'SystemAssigned' }
             properties = [ordered]@{
                 managedEnvironmentId = $caEnvResourceId
@@ -2082,6 +2117,7 @@ exec caddy file-server --root /data --listen :80
                 }
             }
         }
+        $caObj = Get-CreateOnlyProvisioningPayload -Payload $caObj -IsNewResource (-not $caState.Exists)
         $caPayloadBytes = [System.Text.Json.JsonSerializer]::SerializeToUtf8Bytes($caObj, [System.Text.Json.JsonSerializerOptions]@{ WriteIndented = $false })
         $caPayload = [System.Text.Encoding]::UTF8.GetString($caPayloadBytes)
 

--- a/src/powershell/Provisioning/Azure/AzureProvisioning.ps1
+++ b/src/powershell/Provisioning/Azure/AzureProvisioning.ps1
@@ -57,7 +57,7 @@ function Wait-WithPolling {
 function Invoke-ArmApi {
     <#
     .SYNOPSIS
-        Wrapper for Invoke-AzRestMethod with standardized error handling.
+        Thin ARM wrapper that prefers Invoke-AzRestMethod and falls back to an explicit bearer token when the current Az session cannot refresh ARM tokens.
     #>
     [CmdletBinding()]
     param(
@@ -86,18 +86,49 @@ function Invoke-ArmApi {
     $params = @{
         Uri = $requestUri
         Method = $Method
-        Headers = @{
-            Authorization = "Bearer $(Get-ArmToken)"
-        }
         ErrorAction = 'Stop'
-        SkipHttpErrorCheck = $true
     }
     if ($Payload) {
-        $params.ContentType = 'application/json'
-        $params.Body = $Payload
+        $params.Payload = $Payload
     }
 
-    $response = Invoke-WebRequest @params
+    $response = $null
+    $shouldFallbackToExplicitToken = $false
+    try {
+        $response = Invoke-AzRestMethod @params
+    }
+    catch {
+        Write-Verbose ("Invoke-AzRestMethod could not complete '{0}': {1}" -f $Description, $_.Exception.Message)
+        $shouldFallbackToExplicitToken = $true
+    }
+
+    if ($null -eq $response) {
+        Write-Verbose ("Invoke-AzRestMethod returned no response for '{0}'. Falling back to explicit token acquisition." -f $Description)
+        $shouldFallbackToExplicitToken = $true
+    }
+
+    if ($null -ne $response -and [int]$response.StatusCode -eq 401) {
+        Write-Verbose ("Invoke-AzRestMethod returned HTTP 401 for '{0}'. Falling back to explicit token acquisition." -f $Description)
+        $shouldFallbackToExplicitToken = $true
+    }
+
+    if ($shouldFallbackToExplicitToken) {
+        $fallbackParams = @{
+            Uri = $requestUri
+            Method = $Method
+            Headers = @{
+                Authorization = "Bearer $(Get-ArmToken)"
+            }
+            ErrorAction = 'Stop'
+            SkipHttpErrorCheck = $true
+        }
+        if ($Payload) {
+            $fallbackParams.ContentType = 'application/json'
+            $fallbackParams.Body = $Payload
+        }
+
+        $response = Invoke-WebRequest @fallbackParams
+    }
 
     if ($response.StatusCode -ge 200 -and $response.StatusCode -lt 300) {
         if ($response.Content) {

--- a/templates/dashboard.js
+++ b/templates/dashboard.js
@@ -9383,6 +9383,24 @@ function buildRemediationDetailsModalSections(remediationData) {
         : buildGroupedRemediationDetailsModalSections(remediationData, modalCache);
 }
 
+function deferModalContentRender(modal, renderContent) {
+    const scheduleFrame = (typeof window !== 'undefined' && typeof window.requestAnimationFrame === 'function')
+        ? window.requestAnimationFrame.bind(window)
+        : (typeof requestAnimationFrame === 'function'
+            ? requestAnimationFrame
+            : callback => window.setTimeout(callback, 0));
+
+    scheduleFrame(() => {
+        scheduleFrame(() => {
+            if (!modal || !modal.classList || !modal.classList.contains('active')) {
+                return;
+            }
+
+            renderContent();
+        });
+    });
+}
+
 function focusModalCloseButton() {
     const closeButton = document.getElementById('closeModalButton');
     if (closeButton) {
@@ -9425,8 +9443,7 @@ function showDetails(remediationData) {
         initCveTooltips();
     }
 
-    // Defer heavy work so the modal + loading indicator render first
-    requestAnimationFrame(() => {
+    deferModalContentRender(modal, () => {
         const { parts, vtRowData } = buildDetailsModalSections(remediationData);
         modalBody.innerHTML = parts.join('');
         const scrollContainer = modalBody.closest('.modal-content');
@@ -9455,7 +9472,7 @@ function showRemediationDetails(data) {
         initCveTooltips();
     }
 
-    requestAnimationFrame(() => {
+    deferModalContentRender(modal, () => {
         const modalSections = buildRemediationDetailsModalSections(data);
         const updateEntries = data.updateEntries && data.updateEntries.length > 0
             ? data.updateEntries
@@ -9492,61 +9509,65 @@ function showImpactAnalysisDetails(item) {
     const modalBody = document.getElementById('modalBody');
     
     modalTitle.textContent = `Remediation Details: ${item.name}`;
+    modalBody.innerHTML = '<p class="loading">Loading details...</p>';
+    lastFocusedElementBeforeModal = (typeof HTMLElement !== 'undefined' && document.activeElement instanceof HTMLElement) ? document.activeElement : null;
+    modal.classList.add('active');
+    modal.setAttribute('aria-hidden', 'false');
+    hideGlobalTooltip();
+    focusModalCloseButton();
 
     if (!document.getElementById('cve-global-tooltip')) {
         initCveTooltips();
     }
-    
-    // Group vulnerabilities by device (using DeviceId as key)
-    const deviceMap = {};
-    item.vulnerabilities.forEach(v => {
-        const deviceKey = getDeviceIdentityKey(v);
-        if (!deviceMap[deviceKey]) {
-            deviceMap[deviceKey] = {
-                name: v.DeviceName,
-                id: v.DeviceId,
-                cves: new Set()
-            };
-        }
-        deviceMap[deviceKey].cves.add(v.CveId);
-    });
 
-    const updateLinksHtml = buildRemediationModalUpdateLinksHtml(
-        item.updateEntries && item.updateEntries.length > 0
-            ? item.updateEntries
-            : buildRemediationUpdateEntriesFromDetails(item.vulnerabilities)
-    );
-    
-    let html = '<h3>Affected Devices</h3>';
-    if (updateLinksHtml) {
-        html = updateLinksHtml + html;
-    }
-    html += '<div class="modal-table-container"><table class="detail-table"><thead><tr>';
-    html += '<th>Device Name</th><th>Device ID</th><th>CVE Count</th><th>CVE IDs</th>';
-    html += '</tr></thead><tbody>';
-    
-    // Sort devices by CVE count descending
-    const sortedDevices = Object.values(deviceMap).sort((a, b) => b.cves.size - a.cves.size);
-    
-    sortedDevices.forEach(device => {
-        const cveList = Array.from(device.cves).sort().join(', ');
-        const deviceIdShort = device.id ? device.id.substring(0, 12) + '...' : '-';
-        
-        html += `<tr>
+    deferModalContentRender(modal, () => {
+        // Group vulnerabilities by device (using DeviceId as key)
+        const deviceMap = {};
+        item.vulnerabilities.forEach(v => {
+            const deviceKey = getDeviceIdentityKey(v);
+            if (!deviceMap[deviceKey]) {
+                deviceMap[deviceKey] = {
+                    name: v.DeviceName,
+                    id: v.DeviceId,
+                    cves: new Set()
+                };
+            }
+            deviceMap[deviceKey].cves.add(v.CveId);
+        });
+
+        const updateLinksHtml = buildRemediationModalUpdateLinksHtml(
+            item.updateEntries && item.updateEntries.length > 0
+                ? item.updateEntries
+                : buildRemediationUpdateEntriesFromDetails(item.vulnerabilities)
+        );
+
+        let html = '<h3>Affected Devices</h3>';
+        if (updateLinksHtml) {
+            html = updateLinksHtml + html;
+        }
+        html += '<div class="modal-table-container"><table class="detail-table"><thead><tr>';
+        html += '<th>Device Name</th><th>Device ID</th><th>CVE Count</th><th>CVE IDs</th>';
+        html += '</tr></thead><tbody>';
+
+        // Sort devices by CVE count descending
+        const sortedDevices = Object.values(deviceMap).sort((a, b) => b.cves.size - a.cves.size);
+
+        sortedDevices.forEach(device => {
+            const cveList = Array.from(device.cves).sort().join(', ');
+            const deviceIdShort = device.id ? device.id.substring(0, 12) + '...' : '-';
+
+            html += `<tr>
             <td>${escapeHtml(device.name)}</td>
             <td title="${escapeHtml(device.id || '')}">${escapeHtml(deviceIdShort)}</td>
             <td>${device.cves.size}</td>
             <td class="modal-cve-list-cell">${escapeHtml(cveList)}</td>
         </tr>`;
+        });
+
+        html += '</tbody></table></div>';
+
+        modalBody.innerHTML = html;
     });
-    
-    html += '</tbody></table></div>';
-    
-    modalBody.innerHTML = html;
-    lastFocusedElementBeforeModal = (typeof HTMLElement !== 'undefined' && document.activeElement instanceof HTMLElement) ? document.activeElement : null;
-    modal.classList.add('active');
-    modal.setAttribute('aria-hidden', 'false');
-    focusModalCloseButton();
 }
 
 /**

--- a/tests/Assert-DashboardModalOpenScheduling.js
+++ b/tests/Assert-DashboardModalOpenScheduling.js
@@ -1,0 +1,201 @@
+const assert = require('assert');
+const {
+    createDocumentStub,
+    createStubElement,
+    loadDashboardHarness
+} = require('./helpers/dashboard-test-harness');
+
+function createClassList() {
+    const classes = new Set();
+
+    return {
+        add(value) {
+            classes.add(value);
+        },
+        remove(value) {
+            classes.delete(value);
+        },
+        toggle(value) {
+            if (classes.has(value)) {
+                classes.delete(value);
+                return false;
+            }
+
+            classes.add(value);
+            return true;
+        },
+        contains(value) {
+            return classes.has(value);
+        }
+    };
+}
+
+function createDetail(index, overrides = {}) {
+    const suffix = String(index).padStart(4, '0');
+
+    return {
+        DeviceId: `device-${suffix}`,
+        DeviceName: `device-${suffix}.contoso.com`,
+        CveId: `CVE-2026-${suffix}`,
+        SoftwareVersion: `10.0.${index}`,
+        VulnerabilitySeverityLevel: 'High',
+        CvssScore: 7.1,
+        EpssScore: 0.00042,
+        ExploitabilityLevel: 'ExploitIsNotPubliclyKnown',
+        PublishedDate: '2026-04-14',
+        FirstSeenTimestamp: '2026-04-15',
+        LastSeenTimestamp: '2026-04-16',
+        MachineInfo: {
+            ip: `10.0.0.${(index % 250) + 1}`,
+            ls: '2026-04-16'
+        },
+        ...overrides
+    };
+}
+
+function createDashboardForSchedulingTest() {
+    const documentStub = createDocumentStub();
+    const rafQueue = [];
+    const modal = createStubElement({
+        classList: createClassList(),
+        attributes: {},
+        setAttribute(name, value) {
+            this.attributes[name] = value;
+        }
+    });
+    const modalTitle = createStubElement();
+    const modalTbody = createStubElement();
+    const scrollContainer = createStubElement({
+        querySelector() {
+            return modalTbody;
+        }
+    });
+    const modalBody = createStubElement({
+        closest() {
+            return scrollContainer;
+        }
+    });
+    const closeButton = createStubElement({
+        focus() {
+            this.focused = true;
+        }
+    });
+
+    documentStub.activeElement = createStubElement();
+    documentStub.contains = () => true;
+    documentStub.elements.set('detailModal', modal);
+    documentStub.elements.set('modalTitle', modalTitle);
+    documentStub.elements.set('modalBody', modalBody);
+    documentStub.elements.set('closeModalButton', closeButton);
+    documentStub.elements.set('cve-global-tooltip', createStubElement());
+
+    const scheduleRaf = callback => {
+        rafQueue.push(callback);
+        return rafQueue.length;
+    };
+
+    const dashboard = loadDashboardHarness(`
+module.exports = {
+    showDetails,
+    showRemediationDetails,
+    showImpactAnalysisDetails
+};
+`, {
+        document: documentStub,
+        window: {
+            addEventListener() {},
+            removeEventListener() {},
+            confirm() { return true; },
+            setTimeout,
+            clearTimeout,
+            innerHeight: 1080,
+            innerWidth: 1920,
+            requestAnimationFrame: scheduleRaf
+        },
+        requestAnimationFrame: scheduleRaf,
+        HTMLElement: Object
+    });
+
+    return {
+        dashboard,
+        modal,
+        modalBody,
+        modalTitle,
+        closeButton,
+        rafQueue
+    };
+}
+
+function runNextAnimationFrame(rafQueue) {
+    assert.ok(rafQueue.length > 0, 'Expected a queued animation frame callback.');
+    const callback = rafQueue.shift();
+    callback();
+}
+
+function assertDeferredModalRender(trigger, expectedFinalContent) {
+    const context = createDashboardForSchedulingTest();
+    const {
+        modal,
+        modalBody,
+        closeButton,
+        rafQueue
+    } = context;
+
+    trigger(context.dashboard);
+
+    assert.strictEqual(modalBody.innerHTML, '<p class="loading">Loading details...</p>');
+    assert.ok(modal.classList.contains('active'));
+    assert.ok(closeButton.focused, 'Expected the modal close button to receive focus immediately.');
+    assert.strictEqual(rafQueue.length, 1, 'Expected the first animation frame to be queued.');
+
+    runNextAnimationFrame(rafQueue);
+
+    assert.strictEqual(modalBody.innerHTML, '<p class="loading">Loading details...</p>');
+    assert.strictEqual(rafQueue.length, 1, 'Expected rendering to wait until a second animation frame.');
+
+    runNextAnimationFrame(rafQueue);
+
+    assert.ok(
+        modalBody.innerHTML.includes(expectedFinalContent),
+        `Expected modal content to include '${expectedFinalContent}' after deferred rendering.`
+    );
+}
+
+function main() {
+    const detailRecord = createDetail(1);
+
+    assertDeferredModalRender(dashboard => {
+        dashboard.showDetails({
+            modalTitle: 'Windows 11: April 2026 Security Updates',
+            remediation: 'Windows 11: April 2026 Security Updates',
+            details: [detailRecord],
+            devices: new Set([detailRecord.DeviceId]),
+            vulnerabilities: new Set([detailRecord.CveId]),
+            updateEntries: []
+        });
+    }, 'Affected Devices and Vulnerabilities');
+
+    assertDeferredModalRender(dashboard => {
+        dashboard.showRemediationDetails({
+            date: '2026-04-16',
+            remediation: 'Windows 11: April 2026 Security Updates',
+            details: [detailRecord],
+            devices: new Set([detailRecord.DeviceId]),
+            vulnerabilities: new Set([detailRecord.CveId]),
+            updateEntries: []
+        });
+    }, 'Summary');
+
+    assertDeferredModalRender(dashboard => {
+        dashboard.showImpactAnalysisDetails({
+            name: 'Windows 11: April 2026 Security Updates',
+            vulnerabilities: [detailRecord],
+            updateEntries: []
+        });
+    }, 'Affected Devices');
+
+    console.log('Dashboard modal open scheduling assertions passed.');
+}
+
+main();
+


### PR DESCRIPTION
## Summary
- make Azure setup resource tagging create-only for existing resources and resource groups to avoid rerun tag collisions
- prefer Invoke-AzRestMethod for ARM calls with explicit-token fallback when the Az session cannot refresh ARM tokens
- defer heavy modal body rendering by two animation frames and add a regression test that locks in the loading-first behavior
- harden the ARM helper against null Invoke-AzRestMethod responses

## Validation
- `pwsh -NoProfile -File .\tests\Invoke-LargeDatasetValidation.ps1 -SkipSyntheticGeneration -SyntheticOutputPath .\.local\large-datasets\synthetic-50k-1_5m -Validate -ValidationMode artifacts`
- `pwsh -NoProfile -File .\tests\Invoke-LargeDatasetValidation.ps1 -SkipSyntheticGeneration -SyntheticOutputPath .\.local\large-datasets\synthetic-50k-1_5m -Validate -ValidationMode semantic -AllowLargeSemanticValidation`
- `node .\tests\Assert-DashboardModalOpenScheduling.js`
- full dashboard JS suite and `pwsh -NoProfile -File .\build\Invoke-RegressionValidation.ps1` completed earlier in this branch before commit
- hosted browser validation on the large `synthetic-50k-1_5m` artifact confirmed the top `Active Vulnerabilities` modal showed the loading state first and fully rendered in ~53ms for a 6840-device / 122-CVE row, and the top `Impact Analysis` modal showed the loading state first and fully rendered in ~3756ms

## Notes
- leaving existing resource group tags unchanged is intentional for this branch and matches the requested idempotent rerun behavior
- the initial active-report render can appear stalled on hidden browser tabs because the report render path depends on `requestAnimationFrame`; foreground browser validation completed normally