### PR TITLE
Improve normalization pipeline validation and hosted reliability

### DIFF
--- a/Generate-VulnerabilityDashboard.ps1
+++ b/Generate-VulnerabilityDashboard.ps1
@@ -839,7 +839,8 @@ try {
             else {
                 $normalizedResult.Quality
             }
-            Write-CombinedPayloadGzip -Lookups $normalizedResult.Lookups -VulnsPath $normalizedResult.VulnsPath -VulnColumnPaths $normalizedResult.VulnColumnPaths -OutputPath $tempPayloadPath
+            $canConsumeLookupsDuringPayloadWrite = ($null -ne $normalizedResult.VulnColumnPaths -and $normalizedResult.VulnColumnPaths.Count -gt 0)
+            Write-CombinedPayloadGzip -Lookups $normalizedResult.Lookups -VulnsPath $normalizedResult.VulnsPath -VulnColumnPaths $normalizedResult.VulnColumnPaths -OutputPath $tempPayloadPath -ConsumeLookups:$canConsumeLookupsDuringPayloadWrite
             $payloadVulnCount = Get-CompressedPayloadVulnCount -Path $tempPayloadPath
             if ($payloadVulnCount -ne $vulnCount) {
                 if (-not [string]::IsNullOrWhiteSpace($normalizedResult.VulnsPath) -and (Test-Path -LiteralPath $normalizedResult.VulnsPath -PathType Leaf)) {
@@ -851,6 +852,15 @@ try {
                 if ($payloadVulnCount -ne $vulnCount) {
                     throw ("Combined payload row count mismatch after fallback rewrite. Expected {0}, found {1} in '{2}'." -f $vulnCount, $payloadVulnCount, $tempPayloadPath)
                 }
+            }
+            if ($canConsumeLookupsDuringPayloadWrite) {
+                if ($normalizedResult -is [System.Collections.IDictionary]) {
+                    $normalizedResult['Lookups'] = $null
+                }
+                else {
+                    $normalizedResult.Lookups = $null
+                }
+                Invoke-FullGarbageCollection
             }
             $normalizedResult = $null
             if (Test-Path -LiteralPath $tempVulnsPath -PathType Leaf) {

--- a/azure/Invoke-DashboardPipeline.ps1
+++ b/azure/Invoke-DashboardPipeline.ps1
@@ -406,6 +406,34 @@ function New-ProgressMarkerState {
     }
 }
 
+function Format-ProgressRemainingTime {
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [double]$Seconds
+    )
+
+    if ($Seconds -lt 1) {
+        return '<1s'
+    }
+
+    $remaining = [TimeSpan]::FromSeconds([Math]::Ceiling($Seconds))
+    if ($remaining.TotalDays -ge 1) {
+        return ('{0}d {1}h {2}m' -f [int]$remaining.TotalDays, $remaining.Hours, $remaining.Minutes)
+    }
+
+    if ($remaining.TotalHours -ge 1) {
+        return ('{0}h {1}m {2}s' -f [int]$remaining.TotalHours, $remaining.Minutes, $remaining.Seconds)
+    }
+
+    if ($remaining.TotalMinutes -ge 1) {
+        return ('{0}m {1}s' -f [int]$remaining.TotalMinutes, $remaining.Seconds)
+    }
+
+    return ('{0}s' -f [int]$remaining.TotalSeconds)
+}
+
 function Write-ProgressMarker {
     [CmdletBinding()]
     param(
@@ -438,13 +466,27 @@ function Write-ProgressMarker {
     }
 
     $elapsedSeconds = [Math]::Max(0.001, $State.Stopwatch.Elapsed.TotalSeconds)
-    $rate = [Math]::Round(($Count / $elapsedSeconds), 0)
+    $rawRate = ($Count / $elapsedSeconds)
+    $rate = [Math]::Round($rawRate, 0)
     $markerSuffix = if ($markerType -eq 'heartbeat') { ' [heartbeat]' } else { '' }
     $totalCount = if ($State.PSObject.Properties['TotalCount']) { [long]$State.TotalCount } else { 0L }
     if ($totalCount -gt 0) {
         $boundedCount = [Math]::Min([long]$Count, $totalCount)
         $percentComplete = [Math]::Round(($boundedCount / [double]$totalCount) * 100.0, 1)
-        Write-Information ("  {0}: {1:N0}/{2:N0} {3} processed in {4:N1}s ({5:N0}/s, {6:N1}% complete){7}" -f $State.ActivityName, $boundedCount, $totalCount, $UnitLabel, [Math]::Round($elapsedSeconds, 1), $rate, $percentComplete, $markerSuffix) -InformationAction Continue
+        $remainingCount = [Math]::Max(0L, ($totalCount - $boundedCount))
+        $etaText = if ($remainingCount -gt 0 -and $rawRate -gt 0) {
+            Format-ProgressRemainingTime -Seconds ($remainingCount / $rawRate)
+        }
+        else {
+            $null
+        }
+
+        if ([string]::IsNullOrWhiteSpace($etaText)) {
+            Write-Information ("  {0}: {1:N0}/{2:N0} {3} processed in {4:N1}s ({5:N0}/s, {6:N1}% complete){7}" -f $State.ActivityName, $boundedCount, $totalCount, $UnitLabel, [Math]::Round($elapsedSeconds, 1), $rate, $percentComplete, $markerSuffix) -InformationAction Continue
+        }
+        else {
+            Write-Information ("  {0}: {1:N0}/{2:N0} {3} processed in {4:N1}s ({5:N0}/s, {6:N1}% complete, ETA {7}){8}" -f $State.ActivityName, $boundedCount, $totalCount, $UnitLabel, [Math]::Round($elapsedSeconds, 1), $rate, $percentComplete, $etaText, $markerSuffix) -InformationAction Continue
+        }
     }
     else {
         Write-Information ("  {0}: {1:N0} {2} processed in {3:N1}s ({4:N0}/s){5}" -f $State.ActivityName, $Count, $UnitLabel, [Math]::Round($elapsedSeconds, 1), $rate, $markerSuffix) -InformationAction Continue
@@ -11042,20 +11084,236 @@ function Get-DashboardHtmlScriptContent {
     return $match.Groups['content'].Value.Trim()
 }
 
-function Get-DashboardEmbeddedPayloadTempPath {
+function Write-DecodedBase64TextToStream {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [AllowEmptyString()]
+        [string]$Text,
+
+        [Parameter(Mandatory = $true)]
+        [ref]$Carry,
+
+        [Parameter(Mandatory = $true)]
+        [System.IO.Stream]$OutputStream
+    )
+
+    $cleanText = if ([string]::IsNullOrWhiteSpace($Text)) {
+        ''
+    }
+    elseif ($Text.IndexOfAny(@([char]' ', [char]"`t", [char]"`r", [char]"`n")) -ge 0) {
+        [regex]::Replace($Text, '\s+', '')
+    }
+    else {
+        $Text
+    }
+
+    if ([string]::IsNullOrEmpty($cleanText) -and [string]::IsNullOrEmpty([string]$Carry.Value)) {
+        return
+    }
+
+    $combined = ([string]$Carry.Value) + $cleanText
+    $blockCharCount = 16384
+    $fullCharCount = $combined.Length - ($combined.Length % 4)
+    $offset = 0
+    while ($offset -lt $fullCharCount) {
+        $charsToDecode = [System.Math]::Min($blockCharCount, ($fullCharCount - $offset))
+        if (($charsToDecode % 4) -ne 0) {
+            $charsToDecode -= ($charsToDecode % 4)
+        }
+
+        $bytes = [System.Convert]::FromBase64String($combined.Substring($offset, $charsToDecode))
+        $OutputStream.Write($bytes, 0, $bytes.Length)
+        $offset += $charsToDecode
+    }
+
+    $Carry.Value = if ($fullCharCount -lt $combined.Length) {
+        $combined.Substring($fullCharCount)
+    }
+    else {
+        ''
+    }
+}
+
+function Write-EmbeddedDashboardPayloadGzipFile {
+    [CmdletBinding()]
+    [OutputType([bool])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$HtmlPath,
+
+        [Parameter(Mandatory = $true)]
+        [string]$OutputPath
+    )
+
+    $startMarker = '<script id="vulnsData" type="application/json">'
+    $endMarker = '</script>'
+    $reader = $null
+    $inputStream = $null
+    $outputStream = $null
+    $startFound = $false
+    $endFound = $false
+    $carryText = ''
+    $base64Carry = ''
+
+    try {
+        $inputStream = [System.IO.FileStream]::new(
+            $HtmlPath,
+            [System.IO.FileMode]::Open,
+            [System.IO.FileAccess]::Read,
+            [System.IO.FileShare]::Read,
+            4096,
+            [System.IO.FileOptions]::SequentialScan)
+        $reader = [System.IO.StreamReader]::new($inputStream, [System.Text.UTF8Encoding]::new($false), $true, 65536, $false)
+        $charBuffer = [char[]]::new(65536)
+
+        while (($charsRead = $reader.Read($charBuffer, 0, $charBuffer.Length)) -gt 0) {
+            $chunkText = $carryText + [string]::new($charBuffer, 0, $charsRead)
+            $carryText = ''
+
+            if (-not $startFound) {
+                $startIndex = $chunkText.IndexOf($startMarker, [System.StringComparison]::Ordinal)
+                if ($startIndex -lt 0) {
+                    $overlapLength = [System.Math]::Min(($startMarker.Length - 1), $chunkText.Length)
+                    if ($overlapLength -gt 0) {
+                        $carryText = $chunkText.Substring($chunkText.Length - $overlapLength)
+                    }
+                    continue
+                }
+
+                $startFound = $true
+                $outputStream = [System.IO.FileStream]::new(
+                    $OutputPath,
+                    [System.IO.FileMode]::Create,
+                    [System.IO.FileAccess]::Write,
+                    [System.IO.FileShare]::Read,
+                    4096,
+                    [System.IO.FileOptions]::SequentialScan)
+                $chunkText = $chunkText.Substring($startIndex + $startMarker.Length)
+            }
+
+            $endIndex = $chunkText.IndexOf($endMarker, [System.StringComparison]::Ordinal)
+            if ($endIndex -ge 0) {
+                Write-DecodedBase64TextToStream -Text $chunkText.Substring(0, $endIndex) -Carry ([ref]$base64Carry) -OutputStream $outputStream
+                $endFound = $true
+                break
+            }
+
+            $overlapLength = [System.Math]::Min(($endMarker.Length - 1), $chunkText.Length)
+            if ($chunkText.Length -gt $overlapLength) {
+                Write-DecodedBase64TextToStream -Text $chunkText.Substring(0, ($chunkText.Length - $overlapLength)) -Carry ([ref]$base64Carry) -OutputStream $outputStream
+            }
+            if ($overlapLength -gt 0) {
+                $carryText = $chunkText.Substring($chunkText.Length - $overlapLength)
+            }
+        }
+
+        if ($startFound -and -not $endFound) {
+            $endIndex = $carryText.IndexOf($endMarker, [System.StringComparison]::Ordinal)
+            if ($endIndex -ge 0) {
+                Write-DecodedBase64TextToStream -Text $carryText.Substring(0, $endIndex) -Carry ([ref]$base64Carry) -OutputStream $outputStream
+                $endFound = $true
+            }
+        }
+
+        if (-not $startFound) {
+            return $false
+        }
+
+        if (-not $endFound) {
+            throw "Unable to locate payload terminator in '$HtmlPath'."
+        }
+
+        if (-not [string]::IsNullOrEmpty($base64Carry)) {
+            if (($base64Carry.Length % 4) -ne 0) {
+                throw "Embedded payload base64 in '$HtmlPath' ended on an invalid boundary."
+            }
+
+            $bytes = [System.Convert]::FromBase64String($base64Carry)
+            $outputStream.Write($bytes, 0, $bytes.Length)
+        }
+
+        if ($outputStream -and $outputStream.Length -le 0) {
+            throw "Embedded payload in '$HtmlPath' is empty."
+        }
+
+        $outputStream.Flush()
+        return $true
+    }
+    finally {
+        if ($reader) {
+            $reader.Dispose()
+        }
+        elseif ($inputStream) {
+            $inputStream.Dispose()
+        }
+
+        if ($outputStream) {
+            $outputStream.Dispose()
+        }
+    }
+}
+
+function Get-DashboardHtmlPrefixContent {
     [CmdletBinding()]
     [OutputType([string])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Path,
+
+        [Parameter(Mandatory = $false)]
+        [ValidateRange(1024, 1048576)]
+        [int]$MaxChars = 131072
+    )
+
+    $inputStream = $null
+    $reader = $null
+    try {
+        $inputStream = [System.IO.FileStream]::new(
+            $Path,
+            [System.IO.FileMode]::Open,
+            [System.IO.FileAccess]::Read,
+            [System.IO.FileShare]::Read,
+            4096,
+            [System.IO.FileOptions]::SequentialScan)
+        $reader = [System.IO.StreamReader]::new($inputStream, [System.Text.UTF8Encoding]::new($false), $true, 4096, $false)
+        $buffer = [char[]]::new($MaxChars)
+        $charsRead = $reader.Read($buffer, 0, $buffer.Length)
+        if ($charsRead -le 0) {
+            return ''
+        }
+
+        return [string]::new($buffer, 0, $charsRead)
+    }
+    finally {
+        if ($reader) {
+            $reader.Dispose()
+        }
+        elseif ($inputStream) {
+            $inputStream.Dispose()
+        }
+    }
+}
+
+function Resolve-DashboardEmbeddedPayloadSource {
+    [CmdletBinding()]
+    [OutputType([pscustomobject])]
     param(
         [Parameter(Mandatory = $true)]
         [string]$HtmlPath
     )
 
     $resolvedPath = [System.IO.Path]::GetFullPath($HtmlPath)
-    $content = [System.IO.File]::ReadAllText($resolvedPath, [System.Text.Encoding]::UTF8)
-    $dataFormat = Get-DashboardHtmlScriptContent -Html $content -ScriptId 'dataFormat'
+    $metadataContent = Get-DashboardHtmlPrefixContent -Path $resolvedPath
+    $dataFormat = Get-DashboardHtmlScriptContent -Html $metadataContent -ScriptId 'dataFormat'
 
     if ($dataFormat -eq 'external-compressed') {
-        $dashboardConfigJson = Get-DashboardHtmlScriptContent -Html $content -ScriptId 'dashboardConfig'
+        $dashboardConfigJson = Get-DashboardHtmlScriptContent -Html $metadataContent -ScriptId 'dashboardConfig'
+        if ([string]::IsNullOrWhiteSpace($dashboardConfigJson)) {
+            $metadataContent = [System.IO.File]::ReadAllText($resolvedPath, [System.Text.Encoding]::UTF8)
+            $dashboardConfigJson = Get-DashboardHtmlScriptContent -Html $metadataContent -ScriptId 'dashboardConfig'
+        }
+
         if ([string]::IsNullOrWhiteSpace($dashboardConfigJson)) {
             throw "Unable to locate dashboardConfig metadata in '$HtmlPath'."
         }
@@ -11068,27 +11326,69 @@ function Get-DashboardEmbeddedPayloadTempPath {
 
         $htmlDirectory = Split-Path -Path $resolvedPath -Parent
         $payloadRelativePath = $payloadUrl.Replace('/', '\')
-        return [System.IO.Path]::GetFullPath((Join-Path $htmlDirectory $payloadRelativePath))
+        return [PSCustomObject]@{
+            DataFormat = $dataFormat
+            PayloadPath = [System.IO.Path]::GetFullPath((Join-Path $htmlDirectory $payloadRelativePath))
+            DeleteAfterRead = $false
+        }
     }
 
-    $startMarker = '<script id="vulnsData" type="application/json">'
-    $endMarker = '</script>'
-    $startIndex = $content.IndexOf($startMarker)
-    if ($startIndex -lt 0) {
+    $tempPayloadPath = Join-Path ([System.IO.Path]::GetTempPath()) ('dashboard-embedded-payload-' + [guid]::NewGuid().ToString('N') + '.json.gz')
+
+    if (Write-EmbeddedDashboardPayloadGzipFile -HtmlPath $resolvedPath -OutputPath $tempPayloadPath) {
+        return [PSCustomObject]@{
+            DataFormat = 'compressed'
+            PayloadPath = $tempPayloadPath
+            DeleteAfterRead = $true
+        }
+    }
+
+    if (Test-Path -LiteralPath $tempPayloadPath -PathType Leaf) {
+        Remove-Item -LiteralPath $tempPayloadPath -Force -ErrorAction SilentlyContinue
+    }
+
+    if ([string]::IsNullOrWhiteSpace($dataFormat)) {
+        $metadataContent = [System.IO.File]::ReadAllText($resolvedPath, [System.Text.Encoding]::UTF8)
+        $dataFormat = Get-DashboardHtmlScriptContent -Html $metadataContent -ScriptId 'dataFormat'
+    }
+
+    if ($dataFormat -eq 'external-compressed') {
+        $dashboardConfigJson = Get-DashboardHtmlScriptContent -Html $metadataContent -ScriptId 'dashboardConfig'
+        if ([string]::IsNullOrWhiteSpace($dashboardConfigJson)) {
+            throw "Unable to locate dashboardConfig metadata in '$HtmlPath'."
+        }
+
+        $dashboardConfig = $dashboardConfigJson | ConvertFrom-Json -Depth 20
+        $payloadUrl = [string]$dashboardConfig.payloadUrl
+        if ([string]::IsNullOrWhiteSpace($payloadUrl)) {
+            throw "dashboardConfig in '$HtmlPath' does not define payloadUrl."
+        }
+
+        $htmlDirectory = Split-Path -Path $resolvedPath -Parent
+        $payloadRelativePath = $payloadUrl.Replace('/', '\')
+        return [PSCustomObject]@{
+            DataFormat = $dataFormat
+            PayloadPath = [System.IO.Path]::GetFullPath((Join-Path $htmlDirectory $payloadRelativePath))
+            DeleteAfterRead = $false
+        }
+    }
+
+    if ([string]::IsNullOrWhiteSpace($dataFormat) -or $dataFormat -eq 'compressed') {
         throw "Unable to locate embedded vulnerability payload in '$HtmlPath'."
     }
 
-    $payloadStart = $startIndex + $startMarker.Length
-    $payloadEnd = $content.IndexOf($endMarker, $payloadStart)
-    if ($payloadEnd -lt 0) {
-        throw "Unable to locate payload terminator in '$HtmlPath'."
-    }
+    throw "Unsupported dashboard payload format '$dataFormat' in '$HtmlPath'."
+}
 
-    $base64 = ($content.Substring($payloadStart, $payloadEnd - $payloadStart) -replace '\s+', '')
-    $bytes = [Convert]::FromBase64String($base64)
-    $tempPayloadPath = Join-Path ([System.IO.Path]::GetTempPath()) ('dashboard-embedded-payload-' + [guid]::NewGuid().ToString('N') + '.json.gz')
-    [System.IO.File]::WriteAllBytes($tempPayloadPath, $bytes)
-    return $tempPayloadPath
+function Get-DashboardEmbeddedPayloadTempPath {
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$HtmlPath
+    )
+
+    return [string](Resolve-DashboardEmbeddedPayloadSource -HtmlPath $HtmlPath).PayloadPath
 }
 
 function Get-DashboardEmbeddedPayloadInspection {
@@ -11099,73 +11399,21 @@ function Get-DashboardEmbeddedPayloadInspection {
         [string]$Path
     )
 
-    $resolvedPath = [System.IO.Path]::GetFullPath($Path)
-    $content = [System.IO.File]::ReadAllText($resolvedPath, [System.Text.Encoding]::UTF8)
-    $dataFormat = Get-DashboardHtmlScriptContent -Html $content -ScriptId 'dataFormat'
+    $payloadSource = Resolve-DashboardEmbeddedPayloadSource -HtmlPath $Path
+    $payloadPath = [string]$payloadSource.PayloadPath
 
-    if ($dataFormat -eq 'external-compressed') {
-        $dashboardConfigJson = Get-DashboardHtmlScriptContent -Html $content -ScriptId 'dashboardConfig'
-        if ([string]::IsNullOrWhiteSpace($dashboardConfigJson)) {
-            throw "Unable to locate dashboardConfig metadata in '$Path'."
-        }
-
-        $dashboardConfig = $dashboardConfigJson | ConvertFrom-Json -Depth 20
-        $payloadUrl = [string]$dashboardConfig.payloadUrl
-        if ([string]::IsNullOrWhiteSpace($payloadUrl)) {
-            throw "dashboardConfig in '$Path' does not define payloadUrl."
-        }
-
-        $htmlDirectory = Split-Path -Path $resolvedPath -Parent
-        $payloadRelativePath = $payloadUrl.Replace('/', '\')
-        $payloadPath = [System.IO.Path]::GetFullPath((Join-Path $htmlDirectory $payloadRelativePath))
+    try {
         return [PSCustomObject]@{
-            DataFormat = $dataFormat
+            DataFormat = [string]$payloadSource.DataFormat
             PayloadPath = $payloadPath
             PayloadRowCount = (Get-CompressedPayloadVulnCount -Path $payloadPath)
             PayloadSha256 = (Get-FileSha256Hex -Path $payloadPath)
         }
     }
-
-    $startMarker = '<script id="vulnsData" type="application/json">'
-    $endMarker = '</script>'
-    $startIndex = $content.IndexOf($startMarker)
-    if ($startIndex -lt 0) {
-        throw "Unable to locate embedded vulnerability payload in '$Path'."
-    }
-
-    $payloadStart = $startIndex + $startMarker.Length
-    $payloadEnd = $content.IndexOf($endMarker, $payloadStart)
-    if ($payloadEnd -lt 0) {
-        throw "Unable to locate payload terminator in '$Path'."
-    }
-
-    $base64 = ($content.Substring($payloadStart, $payloadEnd - $payloadStart) -replace '\s+', '')
-    $bytes = [Convert]::FromBase64String($base64)
-    $stream = $null
-    $gzip = $null
-    $reader = $null
-    $jsonReader = $null
-
-    try {
-        $stream = [System.IO.MemoryStream]::new($bytes, $false)
-        $gzip = [System.IO.Compression.GZipStream]::new($stream, [System.IO.Compression.CompressionMode]::Decompress)
-        $reader = [System.IO.StreamReader]::new($gzip, [System.Text.Encoding]::UTF8)
-        $jsonReader = [Newtonsoft.Json.JsonTextReader]::new($reader)
-        $payloadRowCount = Get-PayloadVulnCountFromJsonReader -Reader $jsonReader -Path $Path
-    }
     finally {
-        if ($jsonReader) { $jsonReader.Close() }
-        elseif ($reader) { $reader.Dispose() }
-        elseif ($gzip) { $gzip.Dispose() }
-        elseif ($stream) { $stream.Dispose() }
-    }
-
-    $payloadSha256 = ([System.BitConverter]::ToString([System.Security.Cryptography.SHA256]::HashData($bytes))).Replace('-', '').ToLowerInvariant()
-    return [PSCustomObject]@{
-        DataFormat = $dataFormat
-        PayloadPath = $null
-        PayloadRowCount = $payloadRowCount
-        PayloadSha256 = $payloadSha256
+        if ($payloadSource -and $payloadSource.DeleteAfterRead -and -not [string]::IsNullOrWhiteSpace($payloadPath) -and (Test-Path -LiteralPath $payloadPath -PathType Leaf)) {
+            Remove-Item -LiteralPath $payloadPath -Force -ErrorAction SilentlyContinue
+        }
     }
 }
 
@@ -11694,7 +11942,10 @@ function Write-CombinedPayloadGzip {
         [hashtable]$VulnColumnPaths,
 
         [Parameter(Mandatory = $true)]
-        [string]$OutputPath
+        [string]$OutputPath,
+
+        [Parameter(Mandatory = $false)]
+        [switch]$ConsumeLookups
     )
 
     $payloadWriter = $null
@@ -11731,7 +11982,7 @@ function Write-CombinedPayloadGzip {
             $jsonWriter.WriteToken($vulnsJsonReader)
         }
 
-        Close-CombinedPayloadWriter -WriterState $payloadWriter -Lookups $Lookups
+        Close-CombinedPayloadWriter -WriterState $payloadWriter -Lookups $Lookups -ConsumeLookups:$ConsumeLookups
         $payloadWriter = $null
     }
     finally {
@@ -15659,6 +15910,26 @@ function Invoke-ContentStoreNormalization {
         }
 
         foreach ($refPath in $refPaths) {
+            $refPhaseName = if ([string]$refPath.Label -like 'VulnHistoryRefs_*') {
+                'StreamContentStoreHistoryRefs'
+            }
+            elseif ([string]$refPath.Label -like 'VulnCurrentRefs*') {
+                'StreamContentStoreCurrentRefs'
+            }
+            else {
+                'StreamContentStoreMergedRefs'
+            }
+
+            Invoke-NormalizationCallbackEvent -Callback $NormalizationProgressCallback -EventData ([PSCustomObject]@{
+                    Kind = 'phase'
+                    Phase = $refPhaseName
+                    Message = ("Streaming content-store vulnerability refs from '{0}' into the normalized payload." -f $refPath.Label)
+                })
+
+            if (Get-Command -Name Write-MemoryUsage -ErrorAction SilentlyContinue) {
+                $null = Write-MemoryUsage -Label ("ContentStoreRefs " + $refPath.Label + " Start")
+            }
+
             # Inline streaming — eliminates 1.5M scriptblock invocations from
             # Invoke-VulnNdjsonLineAction. Uses direct .NET GZip + buffer scan.
             $refFileStream = [System.IO.File]::OpenRead([string]$refPath.Path)
@@ -15986,6 +16257,15 @@ function Invoke-ContentStoreNormalization {
                 if ($refContentStream -ne $refFileStream) { $refContentStream.Dispose() }
                 $refFileStream.Dispose()
             }
+
+            if (Get-Command -Name Write-MemoryUsage -ErrorAction SilentlyContinue) {
+                $null = Write-MemoryUsage -Label ("ContentStoreRefs " + $refPath.Label + " End")
+            }
+
+            if ($refPath -ne $refPaths[-1]) {
+                Sync-NormalizedVulnWriter -WriterState $writerState
+                Invoke-FullGarbageCollection
+            }
         }
 
         Sync-NormalizedVulnWriter -WriterState $writerState
@@ -16162,7 +16442,7 @@ function Invoke-RawStoreNormalization {
 
             foreach ($storePath in $storePaths) {
                 if (Get-Command -Name Write-MemoryUsage -ErrorAction SilentlyContinue) {
-                    Write-MemoryUsage -Label ("VulnStore " + $storePath.Label + " Start")
+                    $null = Write-MemoryUsage -Label ("VulnStore " + $storePath.Label + " Start")
                 }
 
                 Invoke-VulnNdjsonJsonRootAction -Path ([string]$storePath.Path) -Action {
@@ -16485,7 +16765,7 @@ function Invoke-RawStoreNormalization {
                 }
 
                 if (Get-Command -Name Write-MemoryUsage -ErrorAction SilentlyContinue) {
-                    Write-MemoryUsage -Label ("VulnStore " + $storePath.Label + " End")
+                    $null = Write-MemoryUsage -Label ("VulnStore " + $storePath.Label + " End")
                 }
             }
         } | Out-Null

--- a/azure/Invoke-DashboardPipeline.ps1
+++ b/azure/Invoke-DashboardPipeline.ps1
@@ -11303,6 +11303,28 @@ function Resolve-DashboardEmbeddedPayloadSource {
         [string]$HtmlPath
     )
 
+    function Resolve-DashboardAssetPathFromUrl {
+        param(
+            [Parameter(Mandatory = $true)]
+            [string]$HtmlDirectory,
+
+            [Parameter(Mandatory = $true)]
+            [string]$AssetUrl
+        )
+
+        $assetPath = $HtmlDirectory
+        $assetSegments = @($AssetUrl -split '[\\/]' | Where-Object { -not [string]::IsNullOrWhiteSpace($_) -and $_ -ne '.' })
+        if ($assetSegments.Count -eq 0) {
+            throw "dashboardConfig in '$HtmlPath' does not define a valid payloadUrl path."
+        }
+
+        foreach ($assetSegment in $assetSegments) {
+            $assetPath = Join-Path $assetPath $assetSegment
+        }
+
+        return [System.IO.Path]::GetFullPath($assetPath)
+    }
+
     $resolvedPath = [System.IO.Path]::GetFullPath($HtmlPath)
     $metadataContent = Get-DashboardHtmlPrefixContent -Path $resolvedPath
     $dataFormat = Get-DashboardHtmlScriptContent -Html $metadataContent -ScriptId 'dataFormat'
@@ -11325,10 +11347,9 @@ function Resolve-DashboardEmbeddedPayloadSource {
         }
 
         $htmlDirectory = Split-Path -Path $resolvedPath -Parent
-        $payloadRelativePath = $payloadUrl.Replace('/', '\')
         return [PSCustomObject]@{
             DataFormat = $dataFormat
-            PayloadPath = [System.IO.Path]::GetFullPath((Join-Path $htmlDirectory $payloadRelativePath))
+            PayloadPath = Resolve-DashboardAssetPathFromUrl -HtmlDirectory $htmlDirectory -AssetUrl $payloadUrl
             DeleteAfterRead = $false
         }
     }
@@ -11365,10 +11386,9 @@ function Resolve-DashboardEmbeddedPayloadSource {
         }
 
         $htmlDirectory = Split-Path -Path $resolvedPath -Parent
-        $payloadRelativePath = $payloadUrl.Replace('/', '\')
         return [PSCustomObject]@{
             DataFormat = $dataFormat
-            PayloadPath = [System.IO.Path]::GetFullPath((Join-Path $htmlDirectory $payloadRelativePath))
+            PayloadPath = Resolve-DashboardAssetPathFromUrl -HtmlDirectory $htmlDirectory -AssetUrl $payloadUrl
             DeleteAfterRead = $false
         }
     }

--- a/src/powershell/Shared/Core/Core.ps1
+++ b/src/powershell/Shared/Core/Core.ps1
@@ -207,6 +207,34 @@ function New-ProgressMarkerState {
     }
 }
 
+function Format-ProgressRemainingTime {
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [double]$Seconds
+    )
+
+    if ($Seconds -lt 1) {
+        return '<1s'
+    }
+
+    $remaining = [TimeSpan]::FromSeconds([Math]::Ceiling($Seconds))
+    if ($remaining.TotalDays -ge 1) {
+        return ('{0}d {1}h {2}m' -f [int]$remaining.TotalDays, $remaining.Hours, $remaining.Minutes)
+    }
+
+    if ($remaining.TotalHours -ge 1) {
+        return ('{0}h {1}m {2}s' -f [int]$remaining.TotalHours, $remaining.Minutes, $remaining.Seconds)
+    }
+
+    if ($remaining.TotalMinutes -ge 1) {
+        return ('{0}m {1}s' -f [int]$remaining.TotalMinutes, $remaining.Seconds)
+    }
+
+    return ('{0}s' -f [int]$remaining.TotalSeconds)
+}
+
 function Write-ProgressMarker {
     [CmdletBinding()]
     param(
@@ -239,13 +267,27 @@ function Write-ProgressMarker {
     }
 
     $elapsedSeconds = [Math]::Max(0.001, $State.Stopwatch.Elapsed.TotalSeconds)
-    $rate = [Math]::Round(($Count / $elapsedSeconds), 0)
+    $rawRate = ($Count / $elapsedSeconds)
+    $rate = [Math]::Round($rawRate, 0)
     $markerSuffix = if ($markerType -eq 'heartbeat') { ' [heartbeat]' } else { '' }
     $totalCount = if ($State.PSObject.Properties['TotalCount']) { [long]$State.TotalCount } else { 0L }
     if ($totalCount -gt 0) {
         $boundedCount = [Math]::Min([long]$Count, $totalCount)
         $percentComplete = [Math]::Round(($boundedCount / [double]$totalCount) * 100.0, 1)
-        Write-Information ("  {0}: {1:N0}/{2:N0} {3} processed in {4:N1}s ({5:N0}/s, {6:N1}% complete){7}" -f $State.ActivityName, $boundedCount, $totalCount, $UnitLabel, [Math]::Round($elapsedSeconds, 1), $rate, $percentComplete, $markerSuffix) -InformationAction Continue
+        $remainingCount = [Math]::Max(0L, ($totalCount - $boundedCount))
+        $etaText = if ($remainingCount -gt 0 -and $rawRate -gt 0) {
+            Format-ProgressRemainingTime -Seconds ($remainingCount / $rawRate)
+        }
+        else {
+            $null
+        }
+
+        if ([string]::IsNullOrWhiteSpace($etaText)) {
+            Write-Information ("  {0}: {1:N0}/{2:N0} {3} processed in {4:N1}s ({5:N0}/s, {6:N1}% complete){7}" -f $State.ActivityName, $boundedCount, $totalCount, $UnitLabel, [Math]::Round($elapsedSeconds, 1), $rate, $percentComplete, $markerSuffix) -InformationAction Continue
+        }
+        else {
+            Write-Information ("  {0}: {1:N0}/{2:N0} {3} processed in {4:N1}s ({5:N0}/s, {6:N1}% complete, ETA {7}){8}" -f $State.ActivityName, $boundedCount, $totalCount, $UnitLabel, [Math]::Round($elapsedSeconds, 1), $rate, $percentComplete, $etaText, $markerSuffix) -InformationAction Continue
+        }
     }
     else {
         Write-Information ("  {0}: {1:N0} {2} processed in {3:N1}s ({4:N0}/s){5}" -f $State.ActivityName, $Count, $UnitLabel, [Math]::Round($elapsedSeconds, 1), $rate, $markerSuffix) -InformationAction Continue

--- a/src/powershell/Shared/Dashboard/DashboardGeneration.ps1
+++ b/src/powershell/Shared/Dashboard/DashboardGeneration.ps1
@@ -1471,6 +1471,28 @@ function Resolve-DashboardEmbeddedPayloadSource {
         [string]$HtmlPath
     )
 
+    function Resolve-DashboardAssetPathFromUrl {
+        param(
+            [Parameter(Mandatory = $true)]
+            [string]$HtmlDirectory,
+
+            [Parameter(Mandatory = $true)]
+            [string]$AssetUrl
+        )
+
+        $assetPath = $HtmlDirectory
+        $assetSegments = @($AssetUrl -split '[\\/]' | Where-Object { -not [string]::IsNullOrWhiteSpace($_) -and $_ -ne '.' })
+        if ($assetSegments.Count -eq 0) {
+            throw "dashboardConfig in '$HtmlPath' does not define a valid payloadUrl path."
+        }
+
+        foreach ($assetSegment in $assetSegments) {
+            $assetPath = Join-Path $assetPath $assetSegment
+        }
+
+        return [System.IO.Path]::GetFullPath($assetPath)
+    }
+
     $resolvedPath = [System.IO.Path]::GetFullPath($HtmlPath)
     $metadataContent = Get-DashboardHtmlPrefixContent -Path $resolvedPath
     $dataFormat = Get-DashboardHtmlScriptContent -Html $metadataContent -ScriptId 'dataFormat'
@@ -1493,10 +1515,9 @@ function Resolve-DashboardEmbeddedPayloadSource {
         }
 
         $htmlDirectory = Split-Path -Path $resolvedPath -Parent
-        $payloadRelativePath = $payloadUrl.Replace('/', '\')
         return [PSCustomObject]@{
             DataFormat = $dataFormat
-            PayloadPath = [System.IO.Path]::GetFullPath((Join-Path $htmlDirectory $payloadRelativePath))
+            PayloadPath = Resolve-DashboardAssetPathFromUrl -HtmlDirectory $htmlDirectory -AssetUrl $payloadUrl
             DeleteAfterRead = $false
         }
     }
@@ -1533,10 +1554,9 @@ function Resolve-DashboardEmbeddedPayloadSource {
         }
 
         $htmlDirectory = Split-Path -Path $resolvedPath -Parent
-        $payloadRelativePath = $payloadUrl.Replace('/', '\')
         return [PSCustomObject]@{
             DataFormat = $dataFormat
-            PayloadPath = [System.IO.Path]::GetFullPath((Join-Path $htmlDirectory $payloadRelativePath))
+            PayloadPath = Resolve-DashboardAssetPathFromUrl -HtmlDirectory $htmlDirectory -AssetUrl $payloadUrl
             DeleteAfterRead = $false
         }
     }

--- a/src/powershell/Shared/Dashboard/DashboardGeneration.ps1
+++ b/src/powershell/Shared/Dashboard/DashboardGeneration.ps1
@@ -1252,20 +1252,236 @@ function Get-DashboardHtmlScriptContent {
     return $match.Groups['content'].Value.Trim()
 }
 
-function Get-DashboardEmbeddedPayloadTempPath {
+function Write-DecodedBase64TextToStream {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [AllowEmptyString()]
+        [string]$Text,
+
+        [Parameter(Mandatory = $true)]
+        [ref]$Carry,
+
+        [Parameter(Mandatory = $true)]
+        [System.IO.Stream]$OutputStream
+    )
+
+    $cleanText = if ([string]::IsNullOrWhiteSpace($Text)) {
+        ''
+    }
+    elseif ($Text.IndexOfAny(@([char]' ', [char]"`t", [char]"`r", [char]"`n")) -ge 0) {
+        [regex]::Replace($Text, '\s+', '')
+    }
+    else {
+        $Text
+    }
+
+    if ([string]::IsNullOrEmpty($cleanText) -and [string]::IsNullOrEmpty([string]$Carry.Value)) {
+        return
+    }
+
+    $combined = ([string]$Carry.Value) + $cleanText
+    $blockCharCount = 16384
+    $fullCharCount = $combined.Length - ($combined.Length % 4)
+    $offset = 0
+    while ($offset -lt $fullCharCount) {
+        $charsToDecode = [System.Math]::Min($blockCharCount, ($fullCharCount - $offset))
+        if (($charsToDecode % 4) -ne 0) {
+            $charsToDecode -= ($charsToDecode % 4)
+        }
+
+        $bytes = [System.Convert]::FromBase64String($combined.Substring($offset, $charsToDecode))
+        $OutputStream.Write($bytes, 0, $bytes.Length)
+        $offset += $charsToDecode
+    }
+
+    $Carry.Value = if ($fullCharCount -lt $combined.Length) {
+        $combined.Substring($fullCharCount)
+    }
+    else {
+        ''
+    }
+}
+
+function Write-EmbeddedDashboardPayloadGzipFile {
+    [CmdletBinding()]
+    [OutputType([bool])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$HtmlPath,
+
+        [Parameter(Mandatory = $true)]
+        [string]$OutputPath
+    )
+
+    $startMarker = '<script id="vulnsData" type="application/json">'
+    $endMarker = '</script>'
+    $reader = $null
+    $inputStream = $null
+    $outputStream = $null
+    $startFound = $false
+    $endFound = $false
+    $carryText = ''
+    $base64Carry = ''
+
+    try {
+        $inputStream = [System.IO.FileStream]::new(
+            $HtmlPath,
+            [System.IO.FileMode]::Open,
+            [System.IO.FileAccess]::Read,
+            [System.IO.FileShare]::Read,
+            4096,
+            [System.IO.FileOptions]::SequentialScan)
+        $reader = [System.IO.StreamReader]::new($inputStream, [System.Text.UTF8Encoding]::new($false), $true, 65536, $false)
+        $charBuffer = [char[]]::new(65536)
+
+        while (($charsRead = $reader.Read($charBuffer, 0, $charBuffer.Length)) -gt 0) {
+            $chunkText = $carryText + [string]::new($charBuffer, 0, $charsRead)
+            $carryText = ''
+
+            if (-not $startFound) {
+                $startIndex = $chunkText.IndexOf($startMarker, [System.StringComparison]::Ordinal)
+                if ($startIndex -lt 0) {
+                    $overlapLength = [System.Math]::Min(($startMarker.Length - 1), $chunkText.Length)
+                    if ($overlapLength -gt 0) {
+                        $carryText = $chunkText.Substring($chunkText.Length - $overlapLength)
+                    }
+                    continue
+                }
+
+                $startFound = $true
+                $outputStream = [System.IO.FileStream]::new(
+                    $OutputPath,
+                    [System.IO.FileMode]::Create,
+                    [System.IO.FileAccess]::Write,
+                    [System.IO.FileShare]::Read,
+                    4096,
+                    [System.IO.FileOptions]::SequentialScan)
+                $chunkText = $chunkText.Substring($startIndex + $startMarker.Length)
+            }
+
+            $endIndex = $chunkText.IndexOf($endMarker, [System.StringComparison]::Ordinal)
+            if ($endIndex -ge 0) {
+                Write-DecodedBase64TextToStream -Text $chunkText.Substring(0, $endIndex) -Carry ([ref]$base64Carry) -OutputStream $outputStream
+                $endFound = $true
+                break
+            }
+
+            $overlapLength = [System.Math]::Min(($endMarker.Length - 1), $chunkText.Length)
+            if ($chunkText.Length -gt $overlapLength) {
+                Write-DecodedBase64TextToStream -Text $chunkText.Substring(0, ($chunkText.Length - $overlapLength)) -Carry ([ref]$base64Carry) -OutputStream $outputStream
+            }
+            if ($overlapLength -gt 0) {
+                $carryText = $chunkText.Substring($chunkText.Length - $overlapLength)
+            }
+        }
+
+        if ($startFound -and -not $endFound) {
+            $endIndex = $carryText.IndexOf($endMarker, [System.StringComparison]::Ordinal)
+            if ($endIndex -ge 0) {
+                Write-DecodedBase64TextToStream -Text $carryText.Substring(0, $endIndex) -Carry ([ref]$base64Carry) -OutputStream $outputStream
+                $endFound = $true
+            }
+        }
+
+        if (-not $startFound) {
+            return $false
+        }
+
+        if (-not $endFound) {
+            throw "Unable to locate payload terminator in '$HtmlPath'."
+        }
+
+        if (-not [string]::IsNullOrEmpty($base64Carry)) {
+            if (($base64Carry.Length % 4) -ne 0) {
+                throw "Embedded payload base64 in '$HtmlPath' ended on an invalid boundary."
+            }
+
+            $bytes = [System.Convert]::FromBase64String($base64Carry)
+            $outputStream.Write($bytes, 0, $bytes.Length)
+        }
+
+        if ($outputStream -and $outputStream.Length -le 0) {
+            throw "Embedded payload in '$HtmlPath' is empty."
+        }
+
+        $outputStream.Flush()
+        return $true
+    }
+    finally {
+        if ($reader) {
+            $reader.Dispose()
+        }
+        elseif ($inputStream) {
+            $inputStream.Dispose()
+        }
+
+        if ($outputStream) {
+            $outputStream.Dispose()
+        }
+    }
+}
+
+function Get-DashboardHtmlPrefixContent {
     [CmdletBinding()]
     [OutputType([string])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Path,
+
+        [Parameter(Mandatory = $false)]
+        [ValidateRange(1024, 1048576)]
+        [int]$MaxChars = 131072
+    )
+
+    $inputStream = $null
+    $reader = $null
+    try {
+        $inputStream = [System.IO.FileStream]::new(
+            $Path,
+            [System.IO.FileMode]::Open,
+            [System.IO.FileAccess]::Read,
+            [System.IO.FileShare]::Read,
+            4096,
+            [System.IO.FileOptions]::SequentialScan)
+        $reader = [System.IO.StreamReader]::new($inputStream, [System.Text.UTF8Encoding]::new($false), $true, 4096, $false)
+        $buffer = [char[]]::new($MaxChars)
+        $charsRead = $reader.Read($buffer, 0, $buffer.Length)
+        if ($charsRead -le 0) {
+            return ''
+        }
+
+        return [string]::new($buffer, 0, $charsRead)
+    }
+    finally {
+        if ($reader) {
+            $reader.Dispose()
+        }
+        elseif ($inputStream) {
+            $inputStream.Dispose()
+        }
+    }
+}
+
+function Resolve-DashboardEmbeddedPayloadSource {
+    [CmdletBinding()]
+    [OutputType([pscustomobject])]
     param(
         [Parameter(Mandatory = $true)]
         [string]$HtmlPath
     )
 
     $resolvedPath = [System.IO.Path]::GetFullPath($HtmlPath)
-    $content = [System.IO.File]::ReadAllText($resolvedPath, [System.Text.Encoding]::UTF8)
-    $dataFormat = Get-DashboardHtmlScriptContent -Html $content -ScriptId 'dataFormat'
+    $metadataContent = Get-DashboardHtmlPrefixContent -Path $resolvedPath
+    $dataFormat = Get-DashboardHtmlScriptContent -Html $metadataContent -ScriptId 'dataFormat'
 
     if ($dataFormat -eq 'external-compressed') {
-        $dashboardConfigJson = Get-DashboardHtmlScriptContent -Html $content -ScriptId 'dashboardConfig'
+        $dashboardConfigJson = Get-DashboardHtmlScriptContent -Html $metadataContent -ScriptId 'dashboardConfig'
+        if ([string]::IsNullOrWhiteSpace($dashboardConfigJson)) {
+            $metadataContent = [System.IO.File]::ReadAllText($resolvedPath, [System.Text.Encoding]::UTF8)
+            $dashboardConfigJson = Get-DashboardHtmlScriptContent -Html $metadataContent -ScriptId 'dashboardConfig'
+        }
+
         if ([string]::IsNullOrWhiteSpace($dashboardConfigJson)) {
             throw "Unable to locate dashboardConfig metadata in '$HtmlPath'."
         }
@@ -1278,27 +1494,69 @@ function Get-DashboardEmbeddedPayloadTempPath {
 
         $htmlDirectory = Split-Path -Path $resolvedPath -Parent
         $payloadRelativePath = $payloadUrl.Replace('/', '\')
-        return [System.IO.Path]::GetFullPath((Join-Path $htmlDirectory $payloadRelativePath))
+        return [PSCustomObject]@{
+            DataFormat = $dataFormat
+            PayloadPath = [System.IO.Path]::GetFullPath((Join-Path $htmlDirectory $payloadRelativePath))
+            DeleteAfterRead = $false
+        }
     }
 
-    $startMarker = '<script id="vulnsData" type="application/json">'
-    $endMarker = '</script>'
-    $startIndex = $content.IndexOf($startMarker)
-    if ($startIndex -lt 0) {
+    $tempPayloadPath = Join-Path ([System.IO.Path]::GetTempPath()) ('dashboard-embedded-payload-' + [guid]::NewGuid().ToString('N') + '.json.gz')
+
+    if (Write-EmbeddedDashboardPayloadGzipFile -HtmlPath $resolvedPath -OutputPath $tempPayloadPath) {
+        return [PSCustomObject]@{
+            DataFormat = 'compressed'
+            PayloadPath = $tempPayloadPath
+            DeleteAfterRead = $true
+        }
+    }
+
+    if (Test-Path -LiteralPath $tempPayloadPath -PathType Leaf) {
+        Remove-Item -LiteralPath $tempPayloadPath -Force -ErrorAction SilentlyContinue
+    }
+
+    if ([string]::IsNullOrWhiteSpace($dataFormat)) {
+        $metadataContent = [System.IO.File]::ReadAllText($resolvedPath, [System.Text.Encoding]::UTF8)
+        $dataFormat = Get-DashboardHtmlScriptContent -Html $metadataContent -ScriptId 'dataFormat'
+    }
+
+    if ($dataFormat -eq 'external-compressed') {
+        $dashboardConfigJson = Get-DashboardHtmlScriptContent -Html $metadataContent -ScriptId 'dashboardConfig'
+        if ([string]::IsNullOrWhiteSpace($dashboardConfigJson)) {
+            throw "Unable to locate dashboardConfig metadata in '$HtmlPath'."
+        }
+
+        $dashboardConfig = $dashboardConfigJson | ConvertFrom-Json -Depth 20
+        $payloadUrl = [string]$dashboardConfig.payloadUrl
+        if ([string]::IsNullOrWhiteSpace($payloadUrl)) {
+            throw "dashboardConfig in '$HtmlPath' does not define payloadUrl."
+        }
+
+        $htmlDirectory = Split-Path -Path $resolvedPath -Parent
+        $payloadRelativePath = $payloadUrl.Replace('/', '\')
+        return [PSCustomObject]@{
+            DataFormat = $dataFormat
+            PayloadPath = [System.IO.Path]::GetFullPath((Join-Path $htmlDirectory $payloadRelativePath))
+            DeleteAfterRead = $false
+        }
+    }
+
+    if ([string]::IsNullOrWhiteSpace($dataFormat) -or $dataFormat -eq 'compressed') {
         throw "Unable to locate embedded vulnerability payload in '$HtmlPath'."
     }
 
-    $payloadStart = $startIndex + $startMarker.Length
-    $payloadEnd = $content.IndexOf($endMarker, $payloadStart)
-    if ($payloadEnd -lt 0) {
-        throw "Unable to locate payload terminator in '$HtmlPath'."
-    }
+    throw "Unsupported dashboard payload format '$dataFormat' in '$HtmlPath'."
+}
 
-    $base64 = ($content.Substring($payloadStart, $payloadEnd - $payloadStart) -replace '\s+', '')
-    $bytes = [Convert]::FromBase64String($base64)
-    $tempPayloadPath = Join-Path ([System.IO.Path]::GetTempPath()) ('dashboard-embedded-payload-' + [guid]::NewGuid().ToString('N') + '.json.gz')
-    [System.IO.File]::WriteAllBytes($tempPayloadPath, $bytes)
-    return $tempPayloadPath
+function Get-DashboardEmbeddedPayloadTempPath {
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$HtmlPath
+    )
+
+    return [string](Resolve-DashboardEmbeddedPayloadSource -HtmlPath $HtmlPath).PayloadPath
 }
 
 function Get-DashboardEmbeddedPayloadInspection {
@@ -1309,73 +1567,21 @@ function Get-DashboardEmbeddedPayloadInspection {
         [string]$Path
     )
 
-    $resolvedPath = [System.IO.Path]::GetFullPath($Path)
-    $content = [System.IO.File]::ReadAllText($resolvedPath, [System.Text.Encoding]::UTF8)
-    $dataFormat = Get-DashboardHtmlScriptContent -Html $content -ScriptId 'dataFormat'
+    $payloadSource = Resolve-DashboardEmbeddedPayloadSource -HtmlPath $Path
+    $payloadPath = [string]$payloadSource.PayloadPath
 
-    if ($dataFormat -eq 'external-compressed') {
-        $dashboardConfigJson = Get-DashboardHtmlScriptContent -Html $content -ScriptId 'dashboardConfig'
-        if ([string]::IsNullOrWhiteSpace($dashboardConfigJson)) {
-            throw "Unable to locate dashboardConfig metadata in '$Path'."
-        }
-
-        $dashboardConfig = $dashboardConfigJson | ConvertFrom-Json -Depth 20
-        $payloadUrl = [string]$dashboardConfig.payloadUrl
-        if ([string]::IsNullOrWhiteSpace($payloadUrl)) {
-            throw "dashboardConfig in '$Path' does not define payloadUrl."
-        }
-
-        $htmlDirectory = Split-Path -Path $resolvedPath -Parent
-        $payloadRelativePath = $payloadUrl.Replace('/', '\')
-        $payloadPath = [System.IO.Path]::GetFullPath((Join-Path $htmlDirectory $payloadRelativePath))
+    try {
         return [PSCustomObject]@{
-            DataFormat = $dataFormat
+            DataFormat = [string]$payloadSource.DataFormat
             PayloadPath = $payloadPath
             PayloadRowCount = (Get-CompressedPayloadVulnCount -Path $payloadPath)
             PayloadSha256 = (Get-FileSha256Hex -Path $payloadPath)
         }
     }
-
-    $startMarker = '<script id="vulnsData" type="application/json">'
-    $endMarker = '</script>'
-    $startIndex = $content.IndexOf($startMarker)
-    if ($startIndex -lt 0) {
-        throw "Unable to locate embedded vulnerability payload in '$Path'."
-    }
-
-    $payloadStart = $startIndex + $startMarker.Length
-    $payloadEnd = $content.IndexOf($endMarker, $payloadStart)
-    if ($payloadEnd -lt 0) {
-        throw "Unable to locate payload terminator in '$Path'."
-    }
-
-    $base64 = ($content.Substring($payloadStart, $payloadEnd - $payloadStart) -replace '\s+', '')
-    $bytes = [Convert]::FromBase64String($base64)
-    $stream = $null
-    $gzip = $null
-    $reader = $null
-    $jsonReader = $null
-
-    try {
-        $stream = [System.IO.MemoryStream]::new($bytes, $false)
-        $gzip = [System.IO.Compression.GZipStream]::new($stream, [System.IO.Compression.CompressionMode]::Decompress)
-        $reader = [System.IO.StreamReader]::new($gzip, [System.Text.Encoding]::UTF8)
-        $jsonReader = [Newtonsoft.Json.JsonTextReader]::new($reader)
-        $payloadRowCount = Get-PayloadVulnCountFromJsonReader -Reader $jsonReader -Path $Path
-    }
     finally {
-        if ($jsonReader) { $jsonReader.Close() }
-        elseif ($reader) { $reader.Dispose() }
-        elseif ($gzip) { $gzip.Dispose() }
-        elseif ($stream) { $stream.Dispose() }
-    }
-
-    $payloadSha256 = ([System.BitConverter]::ToString([System.Security.Cryptography.SHA256]::HashData($bytes))).Replace('-', '').ToLowerInvariant()
-    return [PSCustomObject]@{
-        DataFormat = $dataFormat
-        PayloadPath = $null
-        PayloadRowCount = $payloadRowCount
-        PayloadSha256 = $payloadSha256
+        if ($payloadSource -and $payloadSource.DeleteAfterRead -and -not [string]::IsNullOrWhiteSpace($payloadPath) -and (Test-Path -LiteralPath $payloadPath -PathType Leaf)) {
+            Remove-Item -LiteralPath $payloadPath -Force -ErrorAction SilentlyContinue
+        }
     }
 }
 
@@ -1904,7 +2110,10 @@ function Write-CombinedPayloadGzip {
         [hashtable]$VulnColumnPaths,
 
         [Parameter(Mandatory = $true)]
-        [string]$OutputPath
+        [string]$OutputPath,
+
+        [Parameter(Mandatory = $false)]
+        [switch]$ConsumeLookups
     )
 
     $payloadWriter = $null
@@ -1941,7 +2150,7 @@ function Write-CombinedPayloadGzip {
             $jsonWriter.WriteToken($vulnsJsonReader)
         }
 
-        Close-CombinedPayloadWriter -WriterState $payloadWriter -Lookups $Lookups
+        Close-CombinedPayloadWriter -WriterState $payloadWriter -Lookups $Lookups -ConsumeLookups:$ConsumeLookups
         $payloadWriter = $null
     }
     finally {
@@ -5869,6 +6078,26 @@ function Invoke-ContentStoreNormalization {
         }
 
         foreach ($refPath in $refPaths) {
+            $refPhaseName = if ([string]$refPath.Label -like 'VulnHistoryRefs_*') {
+                'StreamContentStoreHistoryRefs'
+            }
+            elseif ([string]$refPath.Label -like 'VulnCurrentRefs*') {
+                'StreamContentStoreCurrentRefs'
+            }
+            else {
+                'StreamContentStoreMergedRefs'
+            }
+
+            Invoke-NormalizationCallbackEvent -Callback $NormalizationProgressCallback -EventData ([PSCustomObject]@{
+                    Kind = 'phase'
+                    Phase = $refPhaseName
+                    Message = ("Streaming content-store vulnerability refs from '{0}' into the normalized payload." -f $refPath.Label)
+                })
+
+            if (Get-Command -Name Write-MemoryUsage -ErrorAction SilentlyContinue) {
+                $null = Write-MemoryUsage -Label ("ContentStoreRefs " + $refPath.Label + " Start")
+            }
+
             # Inline streaming — eliminates 1.5M scriptblock invocations from
             # Invoke-VulnNdjsonLineAction. Uses direct .NET GZip + buffer scan.
             $refFileStream = [System.IO.File]::OpenRead([string]$refPath.Path)
@@ -6196,6 +6425,15 @@ function Invoke-ContentStoreNormalization {
                 if ($refContentStream -ne $refFileStream) { $refContentStream.Dispose() }
                 $refFileStream.Dispose()
             }
+
+            if (Get-Command -Name Write-MemoryUsage -ErrorAction SilentlyContinue) {
+                $null = Write-MemoryUsage -Label ("ContentStoreRefs " + $refPath.Label + " End")
+            }
+
+            if ($refPath -ne $refPaths[-1]) {
+                Sync-NormalizedVulnWriter -WriterState $writerState
+                Invoke-FullGarbageCollection
+            }
         }
 
         Sync-NormalizedVulnWriter -WriterState $writerState
@@ -6372,7 +6610,7 @@ function Invoke-RawStoreNormalization {
 
             foreach ($storePath in $storePaths) {
                 if (Get-Command -Name Write-MemoryUsage -ErrorAction SilentlyContinue) {
-                    Write-MemoryUsage -Label ("VulnStore " + $storePath.Label + " Start")
+                    $null = Write-MemoryUsage -Label ("VulnStore " + $storePath.Label + " Start")
                 }
 
                 Invoke-VulnNdjsonJsonRootAction -Path ([string]$storePath.Path) -Action {
@@ -6695,7 +6933,7 @@ function Invoke-RawStoreNormalization {
                 }
 
                 if (Get-Command -Name Write-MemoryUsage -ErrorAction SilentlyContinue) {
-                    Write-MemoryUsage -Label ("VulnStore " + $storePath.Label + " End")
+                    $null = Write-MemoryUsage -Label ("VulnStore " + $storePath.Label + " End")
                 }
             }
         } | Out-Null

--- a/src/powershell/Validation/Audit/LargeDatasetAudit.ps1
+++ b/src/powershell/Validation/Audit/LargeDatasetAudit.ps1
@@ -852,7 +852,17 @@ function Get-SourceVendorSetForAudit {
 
     $vendorSet = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
     $processedCount = 0
-    $progressState = New-ProgressMarkerState -ActivityName 'Indexed source vendors' -ProgressInterval $Script:DashboardValidationProgressInterval -HeartbeatIntervalSeconds $Script:DashboardValidationHeartbeatSeconds -CheckInterval 10000 -TotalCount $ExpectedTotalCount
+    $progressStateArguments = @{
+        ActivityName = 'Indexed source vendors'
+        ProgressInterval = $Script:DashboardValidationProgressInterval
+        HeartbeatIntervalSeconds = $Script:DashboardValidationHeartbeatSeconds
+        CheckInterval = 10000
+    }
+    if ($ExpectedTotalCount -gt 0) {
+        $progressStateArguments['TotalCount'] = $ExpectedTotalCount
+    }
+
+    $progressState = New-ProgressMarkerState @progressStateArguments
     Read-SourceAuditRecordStream -ExportsPath $ExportsPath -SkipObservedWindowMerge:$SkipObservedWindowMerge | ForEach-Object {
         $record = $_
         if ((Get-VulnPropertyValue -InputObject $record -Name 'IsOnboarded') -eq $true) {
@@ -871,6 +881,10 @@ function Get-SourceVendorSetForAudit {
 }
 
 function Read-SourceCanonicalSignatureStream {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSReviewUnusedParameter', 'AdvancedHunting', Justification = 'Consumed by nested source projection helpers during streaming canonicalization.')]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSReviewUnusedParameter', 'AdvancedHuntingInventory', Justification = 'Consumed by nested source projection helpers during streaming canonicalization.')]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSReviewUnusedParameter', 'NvdCveData', Justification = 'Consumed by nested source projection helpers during streaming canonicalization.')]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSReviewUnusedParameter', 'VendorSet', Justification = 'Consumed by nested source projection helpers during streaming canonicalization.')]
     [CmdletBinding()]
     param(
         [Parameter(Mandatory = $true)]
@@ -906,9 +920,351 @@ function Read-SourceCanonicalSignatureStream {
     )
 
     $deviceProfiles = @{}
-    $cveEnrichmentCache = @{}
+    $cveProjectionCache = @{}
+    $inventoryProjectionCache = @{}
+    $seenWindowCache = @{}
+    $normalizedAuditDecimalCache = @{}
+    $cveUrlCache = @{}
     $processedCount = 0
-    $progressState = New-ProgressMarkerState -ActivityName 'Canonicalized source' -ProgressInterval $Script:DashboardValidationProgressInterval -HeartbeatIntervalSeconds $Script:DashboardValidationHeartbeatSeconds -CheckInterval 10000 -TotalCount $ExpectedTotalCount
+    $progressStateArguments = @{
+        ActivityName = 'Canonicalized source'
+        ProgressInterval = $Script:DashboardValidationProgressInterval
+        HeartbeatIntervalSeconds = $Script:DashboardValidationHeartbeatSeconds
+        CheckInterval = 10000
+    }
+    if ($ExpectedTotalCount -gt 0) {
+        $progressStateArguments['TotalCount'] = $ExpectedTotalCount
+    }
+
+    $progressState = New-ProgressMarkerState @progressStateArguments
+
+    function Get-CachedSourceSeenWindow {
+        param(
+            [Parameter(Mandatory = $false)]
+            [AllowNull()]
+            $FirstSeenValue,
+
+            [Parameter(Mandatory = $false)]
+            [AllowNull()]
+            $LastSeenValue
+        )
+
+        $cacheKey = ([string]$FirstSeenValue) + [string][char]0x001f + ([string]$LastSeenValue)
+        if ($seenWindowCache.ContainsKey($cacheKey)) {
+            return $seenWindowCache[$cacheKey]
+        }
+
+        $seenWindow = Get-NormalizedVulnSeenWindow -FirstSeenValue $FirstSeenValue -LastSeenValue $LastSeenValue
+        $seenWindowCache[$cacheKey] = $seenWindow
+        return $seenWindow
+    }
+
+    function Get-CachedSourceNormalizedAuditDecimalString {
+        param(
+            [Parameter(Mandatory = $false)]
+            [AllowNull()]
+            $Value
+        )
+
+        $cacheKey = [string]$Value
+        if ($normalizedAuditDecimalCache.ContainsKey($cacheKey)) {
+            return $normalizedAuditDecimalCache[$cacheKey]
+        }
+
+        $normalizedValue = [string](Get-NormalizedAuditDecimalString -Value $Value)
+        $normalizedAuditDecimalCache[$cacheKey] = $normalizedValue
+        return $normalizedValue
+    }
+
+    function Get-CachedSourceCveUrl {
+        param(
+            [Parameter(Mandatory = $false)]
+            [AllowNull()]
+            [string]$Url
+        )
+
+        $cacheKey = [string]$Url
+        if ($cveUrlCache.ContainsKey($cacheKey)) {
+            return $cveUrlCache[$cacheKey]
+        }
+
+        $normalizedUrl = [string](Convert-CveUrl -Url $Url)
+        $cveUrlCache[$cacheKey] = $normalizedUrl
+        return $normalizedUrl
+    }
+
+    function Get-SourceDeviceProjection {
+        param(
+            [Parameter(Mandatory = $true)]
+            [string]$DeviceKey,
+
+            [Parameter(Mandatory = $false)]
+            [AllowNull()]
+            $Machine,
+
+            [Parameter(Mandatory = $false)]
+            [AllowNull()]
+            [string]$FallbackDeviceName,
+
+            [Parameter(Mandatory = $false)]
+            [AllowNull()]
+            [string]$FallbackGroupName,
+
+            [Parameter(Mandatory = $false)]
+            [AllowNull()]
+            [string]$FallbackPlatform,
+
+            [Parameter(Mandatory = $false)]
+            [AllowNull()]
+            [string]$FallbackOsVersion,
+
+            [Parameter(Mandatory = $false)]
+            [AllowNull()]
+            [string[]]$FallbackMachineTags = @()
+        )
+
+        if ($deviceProfiles.ContainsKey($DeviceKey)) {
+            return $deviceProfiles[$DeviceKey]
+        }
+
+        $machineProjection = Get-MachineProjection -Machine $Machine
+        $groupName = if ($machineProjection) { [string]$machineProjection.RbacGroupName } else { $FallbackGroupName }
+        if ([string]::IsNullOrWhiteSpace($groupName)) {
+            $groupName = if ([string]::IsNullOrWhiteSpace($FallbackGroupName)) { '(none)' } else { $FallbackGroupName }
+        }
+
+        $projectedDeviceName = if ($machineProjection) { [string]$machineProjection.ComputerDnsName } else { $null }
+        $projectedOsPlatform = if ($machineProjection) { [string]$machineProjection.OSPlatform } else { $null }
+        $projectedOsVersion = if ($machineProjection) { [string]$machineProjection.OSVersion } else { $null }
+        $machineTags = if ($machineProjection -and @($machineProjection.MachineTags).Count -gt 0) {
+            @($machineProjection.MachineTags)
+        }
+        elseif (@($FallbackMachineTags).Count -gt 0) {
+            @($FallbackMachineTags)
+        }
+        else {
+            @()
+        }
+
+        $machineInfo = if ($machineProjection) { $machineProjection.MachineInfo } else { $null }
+        $projection = [PSCustomObject]@{
+            DeviceName = if (-not [string]::IsNullOrWhiteSpace($projectedDeviceName)) { $projectedDeviceName } elseif (-not [string]::IsNullOrWhiteSpace([string]$FallbackDeviceName)) { $FallbackDeviceName } else { '(no machine data)' }
+            RbacGroupName = $groupName
+            OSPlatform = if (-not [string]::IsNullOrWhiteSpace($projectedOsPlatform)) { $projectedOsPlatform } else { $FallbackPlatform }
+            OSVersion = if (-not [string]::IsNullOrWhiteSpace($projectedOsVersion)) { $projectedOsVersion } else { $FallbackOsVersion }
+            MachineTags = Convert-ToCanonicalValidationListString -Value $machineTags
+            MachineIp = if ($machineInfo) { [string]$machineInfo.ip } else { $null }
+            MachineExternalIp = if ($machineInfo) { [string]$machineInfo.eip } else { $null }
+            MachineHealthStatus = if ($machineInfo) { [string]$machineInfo.hs } else { $null }
+            MachineRiskScore = if ($machineInfo) { [string]$machineInfo.rs } else { $null }
+            MachineExposureLevel = if ($machineInfo) { [string]$machineInfo.el } else { $null }
+            MachineDeviceValue = if ($machineInfo) { [string]$machineInfo.dv } else { $null }
+            MachineManagedBy = if ($machineInfo) { [string]$machineInfo.mb } else { $null }
+            MachineAadJoined = [string]([bool]$(if ($machineInfo) { $machineInfo.aad -eq $true } else { $false }))
+            MachineLastSeen = [string](Convert-ToYmdDate -DateValue $(if ($machineInfo) { $machineInfo.ls } else { $null }))
+            MachineFirstSeen = [string](Convert-ToYmdDate -DateValue $(if ($machineInfo) { $machineInfo.fs } else { $null }))
+        }
+
+        $deviceProfiles[$DeviceKey] = $projection
+        return $projection
+    }
+
+    function Get-SourceCveProjection {
+        param(
+            [Parameter(Mandatory = $false)]
+            [AllowNull()]
+            [string]$CveId
+        )
+
+        if ([string]::IsNullOrWhiteSpace($CveId)) {
+            return $null
+        }
+
+        if ($cveProjectionCache.ContainsKey($CveId)) {
+            return $cveProjectionCache[$CveId]
+        }
+
+        $cveEnrichment = Get-SourceCveEnrichment -CveId $CveId -AdvancedHunting $AdvancedHunting -NvdCveData $NvdCveData -VendorSet $VendorSet
+        $exploitAvailable = $cveEnrichment.IsExploitAvailable
+        $projection = [PSCustomObject]@{
+            PublishedDate = [string](Convert-ToYmdDate -DateValue $cveEnrichment.PublishedDate)
+            VulnerabilityDescription = Get-NormalizedAuditText -Text ([string]$cveEnrichment.VulnerabilityDescription)
+            EpssScore = Get-NormalizedAuditDecimalString -Value $cveEnrichment.EpssScore
+            AffectedSoftware = Convert-ToCanonicalValidationListString -Value $cveEnrichment.AffectedSoftware
+            IsExploitAvailable = if ($null -eq $exploitAvailable) { '' } else { [string]([bool]$exploitAvailable) }
+            NvdLastModifiedDate = [string](Convert-ToYmdDate -DateValue $cveEnrichment.NvdLastModifiedDate)
+            NvdBaseScore = Get-NormalizedAuditDecimalString -Value $cveEnrichment.NvdBaseScore
+            NvdBaseSeverity = [string]$cveEnrichment.NvdBaseSeverity
+            NvdVector = [string]$cveEnrichment.NvdVector
+            NvdKevDate = [string](Convert-ToYmdDate -DateValue $cveEnrichment.NvdKevDate)
+            NvdActionDue = [string](Convert-ToYmdDate -DateValue $cveEnrichment.NvdActionDue)
+            NvdRequiredAction = Get-NormalizedAuditText -Text ([string]$cveEnrichment.NvdRequiredAction)
+            NvdWeaknesses = Convert-ToCanonicalValidationListString -Value $cveEnrichment.NvdWeaknesses
+        }
+        $cveProjectionCache[$CveId] = $projection
+        return $projection
+    }
+
+    function Get-SourceInventoryProjection {
+        param(
+            [Parameter(Mandatory = $false)]
+            [AllowNull()]
+            [string]$DeviceId,
+
+            [Parameter(Mandatory = $false)]
+            [AllowNull()]
+            [string]$SoftwareVendor,
+
+            [Parameter(Mandatory = $false)]
+            [AllowNull()]
+            [string]$SoftwareName,
+
+            [Parameter(Mandatory = $false)]
+            [AllowNull()]
+            [string]$SoftwareVersion
+        )
+
+        if ($null -eq $AdvancedHuntingInventory) {
+            return $null
+        }
+
+        $inventoryKey = Get-AdvancedHuntingInventoryMatchKey -DeviceId $DeviceId -SoftwareVendor $SoftwareVendor -SoftwareName $SoftwareName -SoftwareVersion $SoftwareVersion
+        if ([string]::IsNullOrWhiteSpace($inventoryKey)) {
+            return $null
+        }
+
+        if ($inventoryProjectionCache.ContainsKey($inventoryKey)) {
+            return $inventoryProjectionCache[$inventoryKey]
+        }
+
+        $inventoryRecord = $AdvancedHuntingInventory[$inventoryKey]
+        $projection = if ($null -eq $inventoryRecord) {
+            $null
+        }
+        else {
+            [PSCustomObject]@{
+                ProductCodeCpe = [string]$inventoryRecord.ProductCodeCpe
+                EndOfSupportStatus = [string]$inventoryRecord.EndOfSupportStatus
+                EndOfSupportDate = [string](Convert-ToYmdDate -DateValue $inventoryRecord.EndOfSupportDate)
+            }
+        }
+
+        $inventoryProjectionCache[$inventoryKey] = $projection
+        return $projection
+    }
+
+    function Get-SourceCanonicalValidationSignature {
+        param(
+            [Parameter(Mandatory = $true)]
+            $Record,
+
+            [Parameter(Mandatory = $false)]
+            [AllowNull()]
+            [string]$DeviceId,
+
+            [Parameter(Mandatory = $false)]
+            [AllowNull()]
+            $DeviceProjection,
+
+            [Parameter(Mandatory = $false)]
+            [AllowNull()]
+            [string]$CveId,
+
+            [Parameter(Mandatory = $false)]
+            [AllowNull()]
+            $CveProjection,
+
+            [Parameter(Mandatory = $false)]
+            [AllowNull()]
+            $InventoryProjection,
+
+            [Parameter(Mandatory = $false)]
+            [AllowNull()]
+            $FirstSeen,
+
+            [Parameter(Mandatory = $false)]
+            [AllowNull()]
+            $LastSeen,
+
+            [Parameter(Mandatory = $false)]
+            [AllowNull()]
+            [string]$SoftwareVendor,
+
+            [Parameter(Mandatory = $false)]
+            [AllowNull()]
+            [string]$SoftwareName,
+
+            [Parameter(Mandatory = $false)]
+            [AllowNull()]
+            [string]$SoftwareVersion,
+
+            [Parameter(Mandatory = $false)]
+            [AllowNull()]
+            [string]$RecommendedUpdate,
+
+            [Parameter(Mandatory = $false)]
+            [AllowNull()]
+            [string]$UpdateId,
+
+            [Parameter(Mandatory = $false)]
+            [AllowNull()]
+            [string]$UpdateUrl
+        )
+
+        $valueDelimiter = [string][char]0x001f
+        return @(
+            [string]$DeviceId
+            [string]$(if ($DeviceProjection) { $DeviceProjection.DeviceName } else { '(no machine data)' })
+            [string]$(if ($DeviceProjection) { $DeviceProjection.RbacGroupName } else { '(none)' })
+            [string]$(if ($DeviceProjection) { $DeviceProjection.OSPlatform } else { $null })
+            [string]$(if ($DeviceProjection) { $DeviceProjection.OSVersion } else { $null })
+            [string]$(if ($DeviceProjection) { $DeviceProjection.MachineTags } else { '' })
+            [string]$(if ($DeviceProjection) { $DeviceProjection.MachineIp } else { $null })
+            [string]$(if ($DeviceProjection) { $DeviceProjection.MachineExternalIp } else { $null })
+            [string]$(if ($DeviceProjection) { $DeviceProjection.MachineHealthStatus } else { $null })
+            [string]$(if ($DeviceProjection) { $DeviceProjection.MachineRiskScore } else { $null })
+            [string]$(if ($DeviceProjection) { $DeviceProjection.MachineExposureLevel } else { $null })
+            [string]$(if ($DeviceProjection) { $DeviceProjection.MachineDeviceValue } else { $null })
+            [string]$(if ($DeviceProjection) { $DeviceProjection.MachineManagedBy } else { $null })
+            [string]$(if ($DeviceProjection) { $DeviceProjection.MachineAadJoined } else { [string][bool]$false })
+            [string]$(if ($DeviceProjection) { $DeviceProjection.MachineLastSeen } else { $null })
+            [string]$(if ($DeviceProjection) { $DeviceProjection.MachineFirstSeen } else { $null })
+            [string]$CveId
+            (Get-CachedSourceNormalizedAuditDecimalString -Value (Get-VulnPropertyValue -InputObject $Record -Name 'CvssScore'))
+            [string](Get-VulnPropertyValue -InputObject $Record -Name 'VulnerabilitySeverityLevel')
+            [string](Get-VulnPropertyValue -InputObject $Record -Name 'ExploitabilityLevel')
+            [string](Get-CachedSourceCveUrl -Url ([string](Get-VulnPropertyValue -InputObject $Record -Name 'CveBatchUrl')))
+            [string](Get-VulnPropertyValue -InputObject $Record -Name 'CveBatchTitle')
+            [string]$(if ($CveProjection) { $CveProjection.PublishedDate } else { $null })
+            [string]$(if ($CveProjection) { $CveProjection.VulnerabilityDescription } else { '' })
+            [string]$(if ($CveProjection) { $CveProjection.EpssScore } else { '' })
+            [string]$(if ($CveProjection) { $CveProjection.AffectedSoftware } else { '' })
+            [string]$(if ($CveProjection) { $CveProjection.IsExploitAvailable } else { '' })
+            [string]$(if ($CveProjection) { $CveProjection.NvdLastModifiedDate } else { $null })
+            [string]$(if ($CveProjection) { $CveProjection.NvdBaseScore } else { '' })
+            [string]$(if ($CveProjection) { $CveProjection.NvdBaseSeverity } else { $null })
+            [string]$(if ($CveProjection) { $CveProjection.NvdVector } else { $null })
+            [string]$(if ($CveProjection) { $CveProjection.NvdKevDate } else { $null })
+            [string]$(if ($CveProjection) { $CveProjection.NvdActionDue } else { $null })
+            [string]$(if ($CveProjection) { $CveProjection.NvdRequiredAction } else { '' })
+            [string]$(if ($CveProjection) { $CveProjection.NvdWeaknesses } else { '' })
+            [string]$SoftwareVendor
+            [string]$SoftwareName
+            [string]$SoftwareVersion
+            [string](Get-VulnPropertyValue -InputObject $Record -Name 'RecommendationReference')
+            [string]$(if ($InventoryProjection) { $InventoryProjection.ProductCodeCpe } else { $null })
+            [string]$(if ($InventoryProjection) { $InventoryProjection.EndOfSupportStatus } else { $null })
+            [string]$(if ($InventoryProjection) { $InventoryProjection.EndOfSupportDate } else { $null })
+            [string](Convert-ToYmdDate -DateValue $FirstSeen)
+            [string](Convert-ToYmdDate -DateValue $LastSeen)
+            [string]([bool]((Get-VulnPropertyValue -InputObject $Record -Name 'SecurityUpdateAvailable') -eq $true))
+            [string]$RecommendedUpdate
+            [string]$UpdateId
+            [string]$UpdateUrl
+            (Convert-ToCanonicalValidationListString -Value (Get-StringArray -Value (Get-VulnPropertyValue -InputObject $Record -Name 'DiskPaths')))
+            (Convert-ToCanonicalValidationListString -Value (Get-StringArray -Value (Get-VulnPropertyValue -InputObject $Record -Name 'RegistryPaths')))
+        ) -join $valueDelimiter
+    }
 
     Read-SourceAuditRecordStream -ExportsPath $ExportsPath -SkipObservedWindowMerge:$SkipObservedWindowMerge | ForEach-Object {
         $record = $_
@@ -940,39 +1296,8 @@ function Read-SourceCanonicalSignatureStream {
             ) -join '|'
         }
 
-        if (-not $deviceProfiles.ContainsKey($deviceKey)) {
-            $machineProjection = Get-MachineProjection -Machine $machine
-            $groupName = if ($machineProjection) { [string]$machineProjection.RbacGroupName } else { $fallbackGroupName }
-            if ([string]::IsNullOrWhiteSpace($groupName)) {
-                $groupName = if ([string]::IsNullOrWhiteSpace($fallbackGroupName)) { '(none)' } else { $fallbackGroupName }
-            }
-
-            $projectedDeviceName = if ($machineProjection) { [string]$machineProjection.ComputerDnsName } else { $null }
-            $projectedOsPlatform = if ($machineProjection) { [string]$machineProjection.OSPlatform } else { $null }
-            $projectedOsVersion = if ($machineProjection) { [string]$machineProjection.OSVersion } else { $null }
-
-            $machineTags = if ($machineProjection -and @($machineProjection.MachineTags).Count -gt 0) {
-                @($machineProjection.MachineTags)
-            }
-            elseif (@($fallbackMachineTags).Count -gt 0) {
-                @($fallbackMachineTags)
-            }
-            else {
-                @()
-            }
-
-            $deviceProfiles[$deviceKey] = [PSCustomObject]@{
-                DeviceName = if (-not [string]::IsNullOrWhiteSpace($projectedDeviceName)) { $projectedDeviceName } elseif (-not [string]::IsNullOrWhiteSpace([string]$fallbackDeviceName)) { $fallbackDeviceName } else { '(no machine data)' }
-                RbacGroupName = $groupName
-                OSPlatform = if (-not [string]::IsNullOrWhiteSpace($projectedOsPlatform)) { $projectedOsPlatform } else { $fallbackPlatform }
-                OSVersion = if (-not [string]::IsNullOrWhiteSpace($projectedOsVersion)) { $projectedOsVersion } else { $fallbackOsVersion }
-                MachineTags = $machineTags
-                MachineInfo = if ($machineProjection) { $machineProjection.MachineInfo } else { $null }
-            }
-        }
-
-        $deviceProfile = $deviceProfiles[$deviceKey]
-        $seenWindow = Get-NormalizedVulnSeenWindow `
+        $deviceProfile = Get-SourceDeviceProjection -DeviceKey $deviceKey -Machine $machine -FallbackDeviceName $fallbackDeviceName -FallbackGroupName $fallbackGroupName -FallbackPlatform $fallbackPlatform -FallbackOsVersion $fallbackOsVersion -FallbackMachineTags $fallbackMachineTags
+        $seenWindow = Get-CachedSourceSeenWindow `
             -FirstSeenValue (Get-VulnPropertyValue -InputObject $record -Name 'FirstSeenTimestamp') `
             -LastSeenValue (Get-VulnPropertyValue -InputObject $record -Name 'LastSeenTimestamp')
         $firstSeen = $seenWindow.FirstSeenTimestamp
@@ -984,18 +1309,11 @@ function Read-SourceCanonicalSignatureStream {
         if (-not $lastSeen) { $lastSeen = '' }
 
         $cveId = [string](Get-VulnPropertyValue -InputObject $record -Name 'CveId')
-        $cveEnrichment = if (-not [string]::IsNullOrWhiteSpace($cveId) -and $cveEnrichmentCache.ContainsKey($cveId)) {
-            $cveEnrichmentCache[$cveId]
-        }
-        else {
-            $resolvedCveEnrichment = Get-SourceCveEnrichment -CveId $cveId -AdvancedHunting $AdvancedHunting -NvdCveData $NvdCveData -VendorSet $VendorSet
-            if (-not [string]::IsNullOrWhiteSpace($cveId)) {
-                $cveEnrichmentCache[$cveId] = $resolvedCveEnrichment
-            }
-
-            $resolvedCveEnrichment
-        }
-        $inventoryEnrichment = Get-SourceInventoryEnrichment -Record $record -AdvancedHuntingInventory $AdvancedHuntingInventory
+        $cveProjection = Get-SourceCveProjection -CveId $cveId
+        $softwareVendor = [string](Get-VulnPropertyValue -InputObject $record -Name 'SoftwareVendor')
+        $softwareName = [string](Get-VulnPropertyValue -InputObject $record -Name 'SoftwareName')
+        $softwareVersion = [string](Get-VulnPropertyValue -InputObject $record -Name 'SoftwareVersion')
+        $inventoryProjection = Get-SourceInventoryProjection -DeviceId $deviceId -SoftwareVendor $softwareVendor -SoftwareName $softwareName -SoftwareVersion $softwareVersion
 
         $recommendedUpdate = [string](Get-VulnPropertyValue -InputObject $record -Name 'RecommendedSecurityUpdate')
         if ([string]::IsNullOrWhiteSpace($recommendedUpdate) -or $recommendedUpdate -eq '--') {
@@ -1005,54 +1323,10 @@ function Read-SourceCanonicalSignatureStream {
         $updateId = if ($recommendedUpdate) { [string](Get-VulnPropertyValue -InputObject $record -Name 'RecommendedSecurityUpdateId') } else { $null }
         $updateUrl = if ($recommendedUpdate) { [string](Get-VulnPropertyValue -InputObject $record -Name 'RecommendedSecurityUpdateUrl') } else { $null }
 
-        $row = [PSCustomObject]@{
-            DeviceId = $deviceId
-            DeviceName = [string]$deviceProfile.DeviceName
-            RbacGroupName = [string]$deviceProfile.RbacGroupName
-            OSPlatform = [string]$deviceProfile.OSPlatform
-            OSVersion = [string]$deviceProfile.OSVersion
-            MachineTags = @($deviceProfile.MachineTags)
-            MachineInfo = $deviceProfile.MachineInfo
-            CveId = $cveId
-            CvssScore = Get-VulnPropertyValue -InputObject $record -Name 'CvssScore'
-            VulnerabilitySeverityLevel = [string](Get-VulnPropertyValue -InputObject $record -Name 'VulnerabilitySeverityLevel')
-            ExploitabilityLevel = [string](Get-VulnPropertyValue -InputObject $record -Name 'ExploitabilityLevel')
-            CveBatchUrl = Convert-CveUrl -Url ([string](Get-VulnPropertyValue -InputObject $record -Name 'CveBatchUrl'))
-            CveBatchTitle = [string](Get-VulnPropertyValue -InputObject $record -Name 'CveBatchTitle')
-            PublishedDate = $cveEnrichment.PublishedDate
-            VulnerabilityDescription = $cveEnrichment.VulnerabilityDescription
-            EpssScore = $cveEnrichment.EpssScore
-            AffectedSoftware = $cveEnrichment.AffectedSoftware
-            IsExploitAvailable = $cveEnrichment.IsExploitAvailable
-            NvdLastModifiedDate = $cveEnrichment.NvdLastModifiedDate
-            NvdBaseScore = $cveEnrichment.NvdBaseScore
-            NvdBaseSeverity = $cveEnrichment.NvdBaseSeverity
-            NvdVector = $cveEnrichment.NvdVector
-            NvdKevDate = $cveEnrichment.NvdKevDate
-            NvdActionDue = $cveEnrichment.NvdActionDue
-            NvdRequiredAction = $cveEnrichment.NvdRequiredAction
-            NvdWeaknesses = $cveEnrichment.NvdWeaknesses
-            SoftwareVendor = [string](Get-VulnPropertyValue -InputObject $record -Name 'SoftwareVendor')
-            SoftwareName = [string](Get-VulnPropertyValue -InputObject $record -Name 'SoftwareName')
-            SoftwareVersion = [string](Get-VulnPropertyValue -InputObject $record -Name 'SoftwareVersion')
-            RecommendationReference = [string](Get-VulnPropertyValue -InputObject $record -Name 'RecommendationReference')
-            ProductCodeCpe = $inventoryEnrichment.ProductCodeCpe
-            EndOfSupportStatus = $inventoryEnrichment.EndOfSupportStatus
-            EndOfSupportDate = $inventoryEnrichment.EndOfSupportDate
-            FirstSeenTimestamp = $firstSeen
-            LastSeenTimestamp = $lastSeen
-            SecurityUpdateAvailable = ((Get-VulnPropertyValue -InputObject $record -Name 'SecurityUpdateAvailable') -eq $true)
-            RecommendedSecurityUpdate = $recommendedUpdate
-            RecommendedSecurityUpdateId = $updateId
-            RecommendedSecurityUpdateUrl = $updateUrl
-            DiskPaths = Get-StringArray -Value (Get-VulnPropertyValue -InputObject $record -Name 'DiskPaths')
-            RegistryPaths = Get-StringArray -Value (Get-VulnPropertyValue -InputObject $record -Name 'RegistryPaths')
-        }
-
         $processedCount++
         Write-ProgressMarker -State $progressState -Count $processedCount -UnitLabel 'row(s)'
 
-        Get-CanonicalValidationRowSignature -Row $row
+        Get-SourceCanonicalValidationSignature -Record $record -DeviceId $deviceId -DeviceProjection $deviceProfile -CveId $cveId -CveProjection $cveProjection -InventoryProjection $inventoryProjection -FirstSeen $firstSeen -LastSeen $lastSeen -SoftwareVendor $softwareVendor -SoftwareName $softwareName -SoftwareVersion $softwareVersion -RecommendedUpdate $recommendedUpdate -UpdateId $updateId -UpdateUrl $updateUrl
     }
 }
 
@@ -1472,136 +1746,334 @@ function Read-PayloadCanonicalSignatureStream {
     }
 
     Invoke-FullGarbageCollection
-    $progressState = New-ProgressMarkerState -ActivityName 'Canonicalized payload' -ProgressInterval $Script:DashboardValidationProgressInterval -HeartbeatIntervalSeconds $Script:DashboardValidationHeartbeatSeconds -CheckInterval 10000
+    $deviceProjectionCache = @{}
+    $cveProjectionCache = @{}
+    $softwareProjectionCache = @{}
+    $updateProjectionCache = @{}
+    $inventoryProjectionCache = @{}
+    $lookupInventoryValues = Get-VulnPropertyValue -InputObject $lookups -Name 'inventory'
+    $progressTotalCount = if ($vulnsFormat -eq 'columns-v1' -and $null -ne $columnDeviceIndices) { $columnDeviceIndices.Length } else { 0 }
+    $progressState = if ($progressTotalCount -gt 0) {
+        New-ProgressMarkerState -ActivityName 'Canonicalized payload' -ProgressInterval $Script:DashboardValidationProgressInterval -HeartbeatIntervalSeconds $Script:DashboardValidationHeartbeatSeconds -CheckInterval 10000 -TotalCount $progressTotalCount
+    }
+    else {
+        New-ProgressMarkerState -ActivityName 'Canonicalized payload' -ProgressInterval $Script:DashboardValidationProgressInterval -HeartbeatIntervalSeconds $Script:DashboardValidationHeartbeatSeconds -CheckInterval 10000
+    }
 
-    function Get-PayloadCanonicalValidationRow {
+    function Get-PayloadLookupCanonicalListString {
         param(
             [Parameter(Mandatory = $true)]
-            $VulnRecord
+            $LookupValues,
+
+            [Parameter(Mandatory = $false)]
+            [AllowNull()]
+            $Indices
         )
 
-        $device = Get-PayloadLookupItem -LookupValues $lookups.devices -Index $VulnRecord[0]
-        $cve = Get-PayloadLookupItem -LookupValues $lookups.cves -Index $VulnRecord[1]
-        $software = Get-PayloadLookupItem -LookupValues $lookups.software -Index $VulnRecord[2]
+        $resolvedValues = [System.Collections.Generic.List[string]]::new()
+        foreach ($index in @($Indices)) {
+            if ($null -eq $index) {
+                continue
+            }
+
+            $resolvedText = Get-PayloadLookupText -LookupValues $LookupValues -Index $index
+            if ($null -ne $resolvedText) {
+                $resolvedValues.Add($resolvedText)
+            }
+        }
+
+        if ($resolvedValues.Count -eq 0) {
+            return ''
+        }
+
+        return (Convert-ToCanonicalValidationListString -Value $resolvedValues)
+    }
+
+    function Get-PayloadDeviceProjection {
+        param(
+            [Parameter(Mandatory = $true)]
+            [int]$DeviceIndex
+        )
+
+        if ($DeviceIndex -lt 0) {
+            return $null
+        }
+
+        if ($deviceProjectionCache.ContainsKey($DeviceIndex)) {
+            return $deviceProjectionCache[$DeviceIndex]
+        }
+
+        $device = Get-PayloadLookupItem -LookupValues $lookups.devices -Index $DeviceIndex
+        if ($null -eq $device) {
+            return $null
+        }
+
         $machineInfo = Get-VulnPropertyValue -InputObject $device -Name 'm'
-
-        $resolvedMachineTags = [System.Collections.Generic.List[string]]::new()
-        foreach ($tagIndex in @((Get-VulnPropertyValue -InputObject $device -Name 't'))) {
-            if ($null -eq $tagIndex) { continue }
-            $tagText = Get-PayloadLookupText -LookupValues $lookups.tags -Index $tagIndex
-            if ($null -ne $tagText) {
-                $resolvedMachineTags.Add($tagText)
-            }
-        }
-
-        $resolvedDiskPaths = [System.Collections.Generic.List[string]]::new()
-        foreach ($pathIndex in @($VulnRecord[8])) {
-            if ($null -eq $pathIndex -or [int]$pathIndex -lt 0) { continue }
-            $pathText = Get-PayloadLookupText -LookupValues $lookups.diskPaths -Index $pathIndex
-            if ($null -ne $pathText) {
-                $resolvedDiskPaths.Add($pathText)
-            }
-        }
-
-        $resolvedRegistryPaths = [System.Collections.Generic.List[string]]::new()
-        foreach ($pathIndex in @($VulnRecord[9])) {
-            if ($null -eq $pathIndex -or [int]$pathIndex -lt 0) { continue }
-            $pathText = Get-PayloadLookupText -LookupValues $lookups.regPaths -Index $pathIndex
-            if ($null -ne $pathText) {
-                $resolvedRegistryPaths.Add($pathText)
-            }
-        }
-
-        $resolvedAffectedSoftware = [System.Collections.Generic.List[string]]::new()
-        foreach ($softwareIndex in @((Get-VulnPropertyValue -InputObject $cve -Name 'as'))) {
-            if ($null -eq $softwareIndex) { continue }
-            $softwareText = Get-PayloadLookupText -LookupValues $lookups.affSoftware -Index $softwareIndex
-            if ($null -ne $softwareText) {
-                $resolvedAffectedSoftware.Add($softwareText)
-            }
-        }
-
         $groupName = Get-PayloadLookupText -LookupValues $lookups.groups -Index (Get-VulnPropertyValue -InputObject $device -Name 'g')
         $platformName = Get-PayloadLookupText -LookupValues $lookups.platforms -Index (Get-VulnPropertyValue -InputObject $device -Name 'o')
-        $severityName = Get-PayloadLookupText -LookupValues $lookups.severities -Index (Get-VulnPropertyValue -InputObject $cve -Name 'sv')
-        $exploitabilityName = Get-PayloadLookupText -LookupValues $lookups.exploitLevels -Index (Get-VulnPropertyValue -InputObject $cve -Name 'ex')
-        $batchTitle = Get-PayloadLookupText -LookupValues $lookups.batchTitles -Index (Get-VulnPropertyValue -InputObject $cve -Name 'bt')
-        $softwareVendor = Get-PayloadLookupText -LookupValues $lookups.vendors -Index (Get-VulnPropertyValue -InputObject $software -Name 'v')
-        $softwareVersion = Get-PayloadLookupText -LookupValues $lookups.versions -Index $VulnRecord[3]
-        $firstSeenDate = Get-PayloadLookupText -LookupValues $lookups.dates -Index $VulnRecord[4]
-        $lastSeenDate = Get-PayloadLookupText -LookupValues $lookups.dates -Index $VulnRecord[5]
-        $updateObject = if ($VulnRecord[7] -ge 0) { Get-PayloadLookupItem -LookupValues $lookups.updates -Index $VulnRecord[7] } else { $null }
-        $updateName = if ($updateObject) { Get-VulnPropertyValue -InputObject $updateObject -Name 'n' } else { $null }
-        $updateId = if ($updateObject) { Get-VulnPropertyValue -InputObject $updateObject -Name 'id' } else { $null }
-        $updateUrl = if ($updateObject) { Get-VulnPropertyValue -InputObject $updateObject -Name 'url' } else { $null }
-        $inventoryLookupValues = Get-VulnPropertyValue -InputObject $lookups -Name 'inventory'
-        $inventoryObject = if ($null -ne $inventoryLookupValues -and $VulnRecord.Count -gt 10 -and [int]$VulnRecord[10] -ge 0) {
-            Get-PayloadLookupItem -LookupValues $inventoryLookupValues -Index $VulnRecord[10]
-        }
-        else {
-            $null
-        }
-        $nvdWeaknesses = @(Get-StringArray -Value (Get-VulnPropertyValue -InputObject $cve -Name 'nw'))
-
-        return [PSCustomObject]@{
+        $projection = [PSCustomObject]@{
             DeviceId = [string](Get-VulnPropertyValue -InputObject $device -Name 'id')
             DeviceName = [string](Get-VulnPropertyValue -InputObject $device -Name 'n')
             RbacGroupName = if ($groupName -and -not [string]::IsNullOrWhiteSpace([string]$groupName)) { [string]$groupName } else { '(none)' }
             OSPlatform = if ($null -ne $platformName) { [string]$platformName } else { $null }
             OSVersion = [string](Get-VulnPropertyValue -InputObject $device -Name 'ov')
-            MachineTags = if ($resolvedMachineTags.Count -gt 0) { @($resolvedMachineTags) } else { $null }
-            MachineInfo = if ($machineInfo) {
-                [PSCustomObject]@{
-                    ip = [string](Get-VulnPropertyValue -InputObject $machineInfo -Name 'ip')
-                    eip = [string](Get-VulnPropertyValue -InputObject $machineInfo -Name 'eip')
-                    hs = [string](Get-VulnPropertyValue -InputObject $machineInfo -Name 'hs')
-                    rs = [string](Get-VulnPropertyValue -InputObject $machineInfo -Name 'rs')
-                    el = [string](Get-VulnPropertyValue -InputObject $machineInfo -Name 'el')
-                    dv = [string](Get-VulnPropertyValue -InputObject $machineInfo -Name 'dv')
-                    mb = [string](Get-VulnPropertyValue -InputObject $machineInfo -Name 'mb')
-                    aad = ((Get-VulnPropertyValue -InputObject $machineInfo -Name 'aad') -eq $true)
-                    ls = Convert-ToYmdDate -DateValue (Get-VulnPropertyValue -InputObject $machineInfo -Name 'ls')
-                    fs = Convert-ToYmdDate -DateValue (Get-VulnPropertyValue -InputObject $machineInfo -Name 'fs')
-                }
-            }
-            else {
-                $null
-            }
+            MachineTags = Get-PayloadLookupCanonicalListString -LookupValues $lookups.tags -Indices (Get-VulnPropertyValue -InputObject $device -Name 't')
+            MachineIp = if ($machineInfo) { [string](Get-VulnPropertyValue -InputObject $machineInfo -Name 'ip') } else { $null }
+            MachineExternalIp = if ($machineInfo) { [string](Get-VulnPropertyValue -InputObject $machineInfo -Name 'eip') } else { $null }
+            MachineHealthStatus = if ($machineInfo) { [string](Get-VulnPropertyValue -InputObject $machineInfo -Name 'hs') } else { $null }
+            MachineRiskScore = if ($machineInfo) { [string](Get-VulnPropertyValue -InputObject $machineInfo -Name 'rs') } else { $null }
+            MachineExposureLevel = if ($machineInfo) { [string](Get-VulnPropertyValue -InputObject $machineInfo -Name 'el') } else { $null }
+            MachineDeviceValue = if ($machineInfo) { [string](Get-VulnPropertyValue -InputObject $machineInfo -Name 'dv') } else { $null }
+            MachineManagedBy = if ($machineInfo) { [string](Get-VulnPropertyValue -InputObject $machineInfo -Name 'mb') } else { $null }
+            MachineAadJoined = [string]([bool]$(if ($machineInfo) { (Get-VulnPropertyValue -InputObject $machineInfo -Name 'aad') -eq $true } else { $false }))
+            MachineLastSeen = [string](Convert-ToYmdDate -DateValue $(if ($machineInfo) { Get-VulnPropertyValue -InputObject $machineInfo -Name 'ls' } else { $null }))
+            MachineFirstSeen = [string](Convert-ToYmdDate -DateValue $(if ($machineInfo) { Get-VulnPropertyValue -InputObject $machineInfo -Name 'fs' } else { $null }))
+        }
+
+        $deviceProjectionCache[$DeviceIndex] = $projection
+        return $projection
+    }
+
+    function Get-PayloadCveProjection {
+        param(
+            [Parameter(Mandatory = $true)]
+            [int]$CveIndex
+        )
+
+        if ($CveIndex -lt 0) {
+            return $null
+        }
+
+        if ($cveProjectionCache.ContainsKey($CveIndex)) {
+            return $cveProjectionCache[$CveIndex]
+        }
+
+        $cve = Get-PayloadLookupItem -LookupValues $lookups.cves -Index $CveIndex
+        if ($null -eq $cve) {
+            return $null
+        }
+
+        $severityName = Get-PayloadLookupText -LookupValues $lookups.severities -Index (Get-VulnPropertyValue -InputObject $cve -Name 'sv')
+        $exploitabilityName = Get-PayloadLookupText -LookupValues $lookups.exploitLevels -Index (Get-VulnPropertyValue -InputObject $cve -Name 'ex')
+        $batchTitle = Get-PayloadLookupText -LookupValues $lookups.batchTitles -Index (Get-VulnPropertyValue -InputObject $cve -Name 'bt')
+        $exploitAvailable = Get-VulnPropertyValue -InputObject $cve -Name 'ea'
+        $projection = [PSCustomObject]@{
             CveId = [string](Get-VulnPropertyValue -InputObject $cve -Name 'id')
-            CvssScore = Get-VulnPropertyValue -InputObject $cve -Name 'sc'
+            CvssScore = Get-NormalizedAuditDecimalString -Value (Get-VulnPropertyValue -InputObject $cve -Name 'sc')
             VulnerabilitySeverityLevel = if ($null -ne $severityName) { [string]$severityName } else { $null }
             ExploitabilityLevel = if ($null -ne $exploitabilityName) { [string]$exploitabilityName } else { $null }
             CveBatchUrl = [string](Get-VulnPropertyValue -InputObject $cve -Name 'u')
             CveBatchTitle = if ($null -ne $batchTitle) { [string]$batchTitle } else { $null }
-            PublishedDate = Convert-ToYmdDate -DateValue (Get-VulnPropertyValue -InputObject $cve -Name 'pd')
-            VulnerabilityDescription = [string](Get-VulnPropertyValue -InputObject $cve -Name 'desc')
-            EpssScore = Get-VulnPropertyValue -InputObject $cve -Name 'ep'
-            AffectedSoftware = if ($resolvedAffectedSoftware.Count -gt 0) { @($resolvedAffectedSoftware) } else { $null }
-            IsExploitAvailable = if ($null -eq (Get-VulnPropertyValue -InputObject $cve -Name 'ea')) { $null } else { ((Get-VulnPropertyValue -InputObject $cve -Name 'ea') -eq $true) }
-            NvdLastModifiedDate = Convert-ToYmdDate -DateValue (Get-VulnPropertyValue -InputObject $cve -Name 'nlm')
-            NvdBaseScore = Get-VulnPropertyValue -InputObject $cve -Name 'nbs'
+            PublishedDate = [string](Convert-ToYmdDate -DateValue (Get-VulnPropertyValue -InputObject $cve -Name 'pd'))
+            VulnerabilityDescription = Get-NormalizedAuditText -Text ([string](Get-VulnPropertyValue -InputObject $cve -Name 'desc'))
+            EpssScore = Get-NormalizedAuditDecimalString -Value (Get-VulnPropertyValue -InputObject $cve -Name 'ep')
+            AffectedSoftware = Get-PayloadLookupCanonicalListString -LookupValues $lookups.affSoftware -Indices (Get-VulnPropertyValue -InputObject $cve -Name 'as')
+            IsExploitAvailable = if ($null -eq $exploitAvailable) { '' } else { [string]($exploitAvailable -eq $true) }
+            NvdLastModifiedDate = [string](Convert-ToYmdDate -DateValue (Get-VulnPropertyValue -InputObject $cve -Name 'nlm'))
+            NvdBaseScore = Get-NormalizedAuditDecimalString -Value (Get-VulnPropertyValue -InputObject $cve -Name 'nbs')
             NvdBaseSeverity = [string](Get-VulnPropertyValue -InputObject $cve -Name 'nsv')
             NvdVector = [string](Get-VulnPropertyValue -InputObject $cve -Name 'nvec')
-            NvdKevDate = Convert-ToYmdDate -DateValue (Get-VulnPropertyValue -InputObject $cve -Name 'nkev')
-            NvdActionDue = Convert-ToYmdDate -DateValue (Get-VulnPropertyValue -InputObject $cve -Name 'ndu')
-            NvdRequiredAction = [string](Get-VulnPropertyValue -InputObject $cve -Name 'nact')
-            NvdWeaknesses = if ($nvdWeaknesses.Count -gt 0) { $nvdWeaknesses } else { $null }
+            NvdKevDate = [string](Convert-ToYmdDate -DateValue (Get-VulnPropertyValue -InputObject $cve -Name 'nkev'))
+            NvdActionDue = [string](Convert-ToYmdDate -DateValue (Get-VulnPropertyValue -InputObject $cve -Name 'ndu'))
+            NvdRequiredAction = Get-NormalizedAuditText -Text ([string](Get-VulnPropertyValue -InputObject $cve -Name 'nact'))
+            NvdWeaknesses = Convert-ToCanonicalValidationListString -Value (Get-StringArray -Value (Get-VulnPropertyValue -InputObject $cve -Name 'nw'))
+        }
+
+        $cveProjectionCache[$CveIndex] = $projection
+        return $projection
+    }
+
+    function Get-PayloadSoftwareProjection {
+        param(
+            [Parameter(Mandatory = $true)]
+            [int]$SoftwareIndex
+        )
+
+        if ($SoftwareIndex -lt 0) {
+            return $null
+        }
+
+        if ($softwareProjectionCache.ContainsKey($SoftwareIndex)) {
+            return $softwareProjectionCache[$SoftwareIndex]
+        }
+
+        $software = Get-PayloadLookupItem -LookupValues $lookups.software -Index $SoftwareIndex
+        if ($null -eq $software) {
+            return $null
+        }
+
+        $softwareVendor = Get-PayloadLookupText -LookupValues $lookups.vendors -Index (Get-VulnPropertyValue -InputObject $software -Name 'v')
+        $projection = [PSCustomObject]@{
             SoftwareVendor = if ($null -ne $softwareVendor) { [string]$softwareVendor } else { $null }
             SoftwareName = [string](Get-VulnPropertyValue -InputObject $software -Name 'n')
-            SoftwareVersion = if ($null -ne $softwareVersion) { [string]$softwareVersion } else { $null }
             RecommendationReference = [string](Get-VulnPropertyValue -InputObject $software -Name 'r')
-            ProductCodeCpe = if ($inventoryObject) { [string](Get-VulnPropertyValue -InputObject $inventoryObject -Name 'cpe') } else { $null }
-            EndOfSupportStatus = if ($inventoryObject) { [string](Get-VulnPropertyValue -InputObject $inventoryObject -Name 'eos') } else { $null }
-            EndOfSupportDate = if ($inventoryObject) { (Convert-ToYmdDate -DateValue (Get-VulnPropertyValue -InputObject $inventoryObject -Name 'eod')) } else { $null }
-            FirstSeenTimestamp = if ($null -ne $firstSeenDate) { (Convert-ToYmdDate -DateValue $firstSeenDate) ?? '' } else { '' }
-            LastSeenTimestamp = if ($null -ne $lastSeenDate) { (Convert-ToYmdDate -DateValue $lastSeenDate) ?? '' } else { '' }
-            SecurityUpdateAvailable = ($VulnRecord[6] -eq 1)
-            RecommendedSecurityUpdate = if ($updateObject) { [string]$(if ($null -ne $updateName) { $updateName } else { $updateObject }) } else { $null }
-            RecommendedSecurityUpdateId = if ($updateObject -and $null -ne $updateId) { [string]$updateId } else { $null }
-            RecommendedSecurityUpdateUrl = if ($updateObject -and $null -ne $updateUrl) { [string]$updateUrl } else { $null }
-            DiskPaths = if ($resolvedDiskPaths.Count -gt 0) { @($resolvedDiskPaths) } else { $null }
-            RegistryPaths = if ($resolvedRegistryPaths.Count -gt 0) { @($resolvedRegistryPaths) } else { $null }
         }
+
+        $softwareProjectionCache[$SoftwareIndex] = $projection
+        return $projection
+    }
+
+    function Get-PayloadUpdateProjection {
+        param(
+            [Parameter(Mandatory = $true)]
+            [int]$UpdateIndex
+        )
+
+        if ($UpdateIndex -lt 0) {
+            return $null
+        }
+
+        if ($updateProjectionCache.ContainsKey($UpdateIndex)) {
+            return $updateProjectionCache[$UpdateIndex]
+        }
+
+        $updateObject = Get-PayloadLookupItem -LookupValues $lookups.updates -Index $UpdateIndex
+        if ($null -eq $updateObject) {
+            return $null
+        }
+
+        $updateName = Get-VulnPropertyValue -InputObject $updateObject -Name 'n'
+        $updateId = Get-VulnPropertyValue -InputObject $updateObject -Name 'id'
+        $updateUrl = Get-VulnPropertyValue -InputObject $updateObject -Name 'url'
+        $projection = [PSCustomObject]@{
+            RecommendedSecurityUpdate = [string]$(if ($null -ne $updateName) { $updateName } else { $updateObject })
+            RecommendedSecurityUpdateId = if ($null -ne $updateId) { [string]$updateId } else { $null }
+            RecommendedSecurityUpdateUrl = if ($null -ne $updateUrl) { [string]$updateUrl } else { $null }
+        }
+
+        $updateProjectionCache[$UpdateIndex] = $projection
+        return $projection
+    }
+
+    function Get-PayloadInventoryProjection {
+        param(
+            [Parameter(Mandatory = $true)]
+            [int]$InventoryIndex
+        )
+
+        if ($InventoryIndex -lt 0 -or $null -eq $lookupInventoryValues) {
+            return $null
+        }
+
+        if ($inventoryProjectionCache.ContainsKey($InventoryIndex)) {
+            return $inventoryProjectionCache[$InventoryIndex]
+        }
+
+        $inventoryObject = Get-PayloadLookupItem -LookupValues $lookupInventoryValues -Index $InventoryIndex
+        if ($null -eq $inventoryObject) {
+            return $null
+        }
+
+        $projection = [PSCustomObject]@{
+            ProductCodeCpe = [string](Get-VulnPropertyValue -InputObject $inventoryObject -Name 'cpe')
+            EndOfSupportStatus = [string](Get-VulnPropertyValue -InputObject $inventoryObject -Name 'eos')
+            EndOfSupportDate = [string](Convert-ToYmdDate -DateValue (Get-VulnPropertyValue -InputObject $inventoryObject -Name 'eod'))
+        }
+
+        $inventoryProjectionCache[$InventoryIndex] = $projection
+        return $projection
+    }
+
+    function Get-PayloadCanonicalValidationSignature {
+        param(
+            [Parameter(Mandatory = $true)]
+            [int]$DeviceIndex,
+
+            [Parameter(Mandatory = $true)]
+            [int]$CveIndex,
+
+            [Parameter(Mandatory = $true)]
+            [int]$SoftwareIndex,
+
+            [Parameter(Mandatory = $true)]
+            [int]$VersionIndex,
+
+            [Parameter(Mandatory = $true)]
+            [int]$FirstSeenIndex,
+
+            [Parameter(Mandatory = $true)]
+            [int]$LastSeenIndex,
+
+            [Parameter(Mandatory = $true)]
+            [int]$UpdateAvailabilityFlag,
+
+            [Parameter(Mandatory = $true)]
+            [int]$UpdateIndex,
+
+            [Parameter(Mandatory = $false)]
+            [AllowNull()]
+            $DiskPathIndices,
+
+            [Parameter(Mandatory = $false)]
+            [AllowNull()]
+            $RegistryPathIndices,
+
+            [Parameter(Mandatory = $false)]
+            [int]$InventoryIndex = -1
+        )
+
+        $valueDelimiter = [string][char]0x001f
+        $deviceProjection = Get-PayloadDeviceProjection -DeviceIndex $DeviceIndex
+        $cveProjection = Get-PayloadCveProjection -CveIndex $CveIndex
+        $softwareProjection = Get-PayloadSoftwareProjection -SoftwareIndex $SoftwareIndex
+        $updateProjection = if ($UpdateIndex -ge 0) { Get-PayloadUpdateProjection -UpdateIndex $UpdateIndex } else { $null }
+        $inventoryProjection = if ($InventoryIndex -ge 0) { Get-PayloadInventoryProjection -InventoryIndex $InventoryIndex } else { $null }
+        $softwareVersion = Get-PayloadLookupText -LookupValues $lookups.versions -Index $VersionIndex
+        $firstSeenDate = Get-PayloadLookupText -LookupValues $lookups.dates -Index $FirstSeenIndex
+        $lastSeenDate = Get-PayloadLookupText -LookupValues $lookups.dates -Index $LastSeenIndex
+
+        return @(
+            [string]$(if ($deviceProjection) { $deviceProjection.DeviceId } else { $null })
+            [string]$(if ($deviceProjection) { $deviceProjection.DeviceName } else { $null })
+            [string]$(if ($deviceProjection) { $deviceProjection.RbacGroupName } else { '(none)' })
+            [string]$(if ($deviceProjection) { $deviceProjection.OSPlatform } else { $null })
+            [string]$(if ($deviceProjection) { $deviceProjection.OSVersion } else { $null })
+            [string]$(if ($deviceProjection) { $deviceProjection.MachineTags } else { '' })
+            [string]$(if ($deviceProjection) { $deviceProjection.MachineIp } else { $null })
+            [string]$(if ($deviceProjection) { $deviceProjection.MachineExternalIp } else { $null })
+            [string]$(if ($deviceProjection) { $deviceProjection.MachineHealthStatus } else { $null })
+            [string]$(if ($deviceProjection) { $deviceProjection.MachineRiskScore } else { $null })
+            [string]$(if ($deviceProjection) { $deviceProjection.MachineExposureLevel } else { $null })
+            [string]$(if ($deviceProjection) { $deviceProjection.MachineDeviceValue } else { $null })
+            [string]$(if ($deviceProjection) { $deviceProjection.MachineManagedBy } else { $null })
+            [string]$(if ($deviceProjection) { $deviceProjection.MachineAadJoined } else { [string][bool]$false })
+            [string]$(if ($deviceProjection) { $deviceProjection.MachineLastSeen } else { $null })
+            [string]$(if ($deviceProjection) { $deviceProjection.MachineFirstSeen } else { $null })
+            [string]$(if ($cveProjection) { $cveProjection.CveId } else { $null })
+            [string]$(if ($cveProjection) { $cveProjection.CvssScore } else { '' })
+            [string]$(if ($cveProjection) { $cveProjection.VulnerabilitySeverityLevel } else { $null })
+            [string]$(if ($cveProjection) { $cveProjection.ExploitabilityLevel } else { $null })
+            [string]$(if ($cveProjection) { $cveProjection.CveBatchUrl } else { $null })
+            [string]$(if ($cveProjection) { $cveProjection.CveBatchTitle } else { $null })
+            [string]$(if ($cveProjection) { $cveProjection.PublishedDate } else { $null })
+            [string]$(if ($cveProjection) { $cveProjection.VulnerabilityDescription } else { '' })
+            [string]$(if ($cveProjection) { $cveProjection.EpssScore } else { '' })
+            [string]$(if ($cveProjection) { $cveProjection.AffectedSoftware } else { '' })
+            [string]$(if ($cveProjection) { $cveProjection.IsExploitAvailable } else { '' })
+            [string]$(if ($cveProjection) { $cveProjection.NvdLastModifiedDate } else { $null })
+            [string]$(if ($cveProjection) { $cveProjection.NvdBaseScore } else { '' })
+            [string]$(if ($cveProjection) { $cveProjection.NvdBaseSeverity } else { $null })
+            [string]$(if ($cveProjection) { $cveProjection.NvdVector } else { $null })
+            [string]$(if ($cveProjection) { $cveProjection.NvdKevDate } else { $null })
+            [string]$(if ($cveProjection) { $cveProjection.NvdActionDue } else { $null })
+            [string]$(if ($cveProjection) { $cveProjection.NvdRequiredAction } else { '' })
+            [string]$(if ($cveProjection) { $cveProjection.NvdWeaknesses } else { '' })
+            [string]$(if ($softwareProjection) { $softwareProjection.SoftwareVendor } else { $null })
+            [string]$(if ($softwareProjection) { $softwareProjection.SoftwareName } else { $null })
+            [string]$softwareVersion
+            [string]$(if ($softwareProjection) { $softwareProjection.RecommendationReference } else { $null })
+            [string]$(if ($inventoryProjection) { $inventoryProjection.ProductCodeCpe } else { $null })
+            [string]$(if ($inventoryProjection) { $inventoryProjection.EndOfSupportStatus } else { $null })
+            [string]$(if ($inventoryProjection) { $inventoryProjection.EndOfSupportDate } else { $null })
+            [string]$(if ($null -ne $firstSeenDate) { (Convert-ToYmdDate -DateValue $firstSeenDate) ?? '' } else { '' })
+            [string]$(if ($null -ne $lastSeenDate) { (Convert-ToYmdDate -DateValue $lastSeenDate) ?? '' } else { '' })
+            [string]([bool]($UpdateAvailabilityFlag -eq 1))
+            [string]$(if ($updateProjection) { $updateProjection.RecommendedSecurityUpdate } else { $null })
+            [string]$(if ($updateProjection) { $updateProjection.RecommendedSecurityUpdateId } else { $null })
+            [string]$(if ($updateProjection) { $updateProjection.RecommendedSecurityUpdateUrl } else { $null })
+            [string](Get-PayloadLookupCanonicalListString -LookupValues $lookups.diskPaths -Indices $DiskPathIndices)
+            [string](Get-PayloadLookupCanonicalListString -LookupValues $lookups.regPaths -Indices $RegistryPathIndices)
+        ) -join $valueDelimiter
     }
 
     if ($vulnsFormat -eq 'rows-v1') {
@@ -1614,13 +2086,25 @@ function Read-PayloadCanonicalSignatureStream {
             }
         }
 
+        $progressState.TotalCount = $payloadRows.Count
         $processedCount = 0
         foreach ($v in $payloadRows) {
             if ($null -eq $v) { continue }
             $processedCount++
             Write-ProgressMarker -State $progressState -Count $processedCount -UnitLabel 'row(s)'
 
-            Get-CanonicalValidationRowSignature -Row (Get-PayloadCanonicalValidationRow -VulnRecord $v)
+            Get-PayloadCanonicalValidationSignature `
+                -DeviceIndex ([int]$v[0]) `
+                -CveIndex ([int]$v[1]) `
+                -SoftwareIndex ([int]$v[2]) `
+                -VersionIndex ([int]$v[3]) `
+                -FirstSeenIndex ([int]$v[4]) `
+                -LastSeenIndex ([int]$v[5]) `
+                -UpdateAvailabilityFlag ([int]$v[6]) `
+                -UpdateIndex ([int]$v[7]) `
+                -DiskPathIndices $v[8] `
+                -RegistryPathIndices $v[9] `
+                -InventoryIndex $(if ($v.Count -gt 10) { [int]$v[10] } else { -1 })
         }
         return
     }
@@ -1644,21 +2128,18 @@ function Read-PayloadCanonicalSignatureStream {
     for ($i = 0; $i -lt $vulnCount; $i++) {
         Write-ProgressMarker -State $progressState -Count ($i + 1) -UnitLabel 'row(s)'
 
-        $payloadRecord = @(
-            $columnDeviceIndices[$i]
-            $columnCveIndices[$i]
-            $columnSoftwareIndices[$i]
-            $columnVersionIndices[$i]
-            $columnFirstSeenIndices[$i]
-            $columnLastSeenIndices[$i]
-            $columnUpdateAvailability[$i]
-            $columnUpdateIndices[$i]
-            ,$columnDiskPathIndices[$i]
-            ,$columnRegistryPathIndices[$i]
-            $(if ($null -ne $columnInventoryIndices -and $i -lt $columnInventoryIndices.Length) { $columnInventoryIndices[$i] } else { -1 })
-        )
-
-        Get-CanonicalValidationRowSignature -Row (Get-PayloadCanonicalValidationRow -VulnRecord $payloadRecord)
+        Get-PayloadCanonicalValidationSignature `
+            -DeviceIndex $columnDeviceIndices[$i] `
+            -CveIndex $columnCveIndices[$i] `
+            -SoftwareIndex $columnSoftwareIndices[$i] `
+            -VersionIndex $columnVersionIndices[$i] `
+            -FirstSeenIndex $columnFirstSeenIndices[$i] `
+            -LastSeenIndex $columnLastSeenIndices[$i] `
+            -UpdateAvailabilityFlag $columnUpdateAvailability[$i] `
+            -UpdateIndex $columnUpdateIndices[$i] `
+            -DiskPathIndices $columnDiskPathIndices[$i] `
+            -RegistryPathIndices $columnRegistryPathIndices[$i] `
+            -InventoryIndex $(if ($null -ne $columnInventoryIndices -and $i -lt $columnInventoryIndices.Length) { $columnInventoryIndices[$i] } else { -1 })
     }
 }
 
@@ -1908,7 +2389,7 @@ function Get-StreamingDashboardAuditResult {
     $vendorIndexElapsedSeconds = 0
     $comparisonStorage = 'partitioned-hash-files'
     $comparisonPayloadSource = 'dashboard-payload'
-    $dashboardPayloadPath = $null
+    $dashboardPayloadSource = $null
     $comparisonPayloadPath = $null
     $comparisonPayloadLabel = 'dashboard'
     $machines = $null
@@ -1938,8 +2419,8 @@ function Get-StreamingDashboardAuditResult {
             Write-Information '  Dashboard payload matches the normalized payload cache; reusing cached payload for semantic comparison.' -InformationAction Continue
         }
         else {
-            $dashboardPayloadPath = Get-DashboardEmbeddedPayloadTempPath -HtmlPath $ResolvedHtmlPath
-            $comparisonPayloadPath = $dashboardPayloadPath
+            $dashboardPayloadSource = Resolve-DashboardEmbeddedPayloadSource -HtmlPath $ResolvedHtmlPath
+            $comparisonPayloadPath = [string]$dashboardPayloadSource.PayloadPath
             Write-Information '  Dashboard payload differs from the normalized payload cache; comparing dashboard payload directly against source exports.' -InformationAction Continue
         }
 
@@ -2050,8 +2531,8 @@ function Get-StreamingDashboardAuditResult {
             $rowComparison | Add-Member -NotePropertyName ComparisonStorage -NotePropertyValue 'partitioned-hash-files'
         }
         finally {
-            if (-not [string]::IsNullOrWhiteSpace($dashboardPayloadPath) -and (Test-Path -LiteralPath $dashboardPayloadPath -PathType Leaf)) {
-                Remove-Item -LiteralPath $dashboardPayloadPath -Force -ErrorAction SilentlyContinue
+            if ($null -ne $dashboardPayloadSource -and $dashboardPayloadSource.DeleteAfterRead -and -not [string]::IsNullOrWhiteSpace([string]$dashboardPayloadSource.PayloadPath) -and (Test-Path -LiteralPath ([string]$dashboardPayloadSource.PayloadPath) -PathType Leaf)) {
+                Remove-Item -LiteralPath ([string]$dashboardPayloadSource.PayloadPath) -Force -ErrorAction SilentlyContinue
             }
         }
     }

--- a/tests/Invoke-BenchmarkSeries.ps1
+++ b/tests/Invoke-BenchmarkSeries.ps1
@@ -20,6 +20,9 @@ param(
     [double]$MinimumAvailableMemoryGB = 3,
 
     [Parameter(Mandatory = $false)]
+    [switch]$IncludeLocalBenchmark,
+
+    [Parameter(Mandatory = $false)]
     [switch]$LocalOnly,
 
     [Parameter(Mandatory = $false)]
@@ -55,6 +58,7 @@ $historyScriptPath = Join-Path $PSScriptRoot 'Record-BenchmarkHistory.ps1'
 
 $runResults = [System.Collections.Generic.List[object]]::new()
 $resultPaths = [System.Collections.Generic.List[string]]::new()
+$effectiveIncludeLocalBenchmark = ($LocalOnly -or $IncludeLocalBenchmark -or $IncludePersistentLocalWorkflow)
 
 for ($iteration = 1; $iteration -le $Iterations; $iteration++) {
     $resultPath = Join-Path $resolvedResultsRoot ('run-{0:00}.json' -f $iteration)
@@ -69,6 +73,9 @@ for ($iteration = 1; $iteration -le $Iterations; $iteration++) {
     }
     if ($LocalOnly) {
         $measureArguments.LocalOnly = $true
+    }
+    elseif ($effectiveIncludeLocalBenchmark) {
+        $measureArguments.IncludeLocalBenchmark = $true
     }
     if ($IncludePersistentLocalWorkflow) {
         $measureArguments.IncludePersistentLocalWorkflow = $true
@@ -87,11 +94,16 @@ $summaryProperties = [ordered]@{
     benchmark_dataset_path = $datasetPath
     iteration_count = $Iterations
     local_only = ($LocalOnly -eq $true)
+    include_local_benchmark = $effectiveIncludeLocalBenchmark
     persistent_local_workflow = ($IncludePersistentLocalWorkflow -eq $true)
     result_paths = @($resultPaths)
 }
 
-$metricSummary = Get-BenchmarkSeriesMetricSummary -RunResults @($runResults) -LocalOnly ($LocalOnly -eq $true) -IncludePersistentLocalWorkflow ($IncludePersistentLocalWorkflow -eq $true)
+if ($runResults.Count -gt 0) {
+    $summaryProperties.benchmark_mode = [string]$runResults[0].benchmark_mode
+}
+
+$metricSummary = Get-BenchmarkSeriesMetricSummary -RunResults @($runResults) -LocalOnly ($LocalOnly -eq $true) -IncludeLocalBenchmark $effectiveIncludeLocalBenchmark -IncludePersistentLocalWorkflow ($IncludePersistentLocalWorkflow -eq $true)
 foreach ($property in $metricSummary.PSObject.Properties) {
     $summaryProperties[$property.Name] = $property.Value
 }

--- a/tests/Measure-BranchVsMainBenchmark.ps1
+++ b/tests/Measure-BranchVsMainBenchmark.ps1
@@ -67,6 +67,9 @@ param(
     [switch]$CurrentOnly,
 
     [Parameter(Mandatory = $false)]
+    [switch]$IncludeLocalBenchmark,
+
+    [Parameter(Mandatory = $false)]
     [switch]$LocalOnly,
 
     [Parameter(Mandatory = $false)]
@@ -224,6 +227,7 @@ function Write-AdHocBenchmarkSeriesSummary {
     $datasetDefinition = Get-ObjectPropertyValue -InputObject $dataset -Name 'definition'
     $currentBaseline = Get-ObjectPropertyValue -InputObject (Get-ObjectPropertyValue -InputObject $firstResult -Name 'current') -Name 'baseline'
     $localOnly = [bool](Get-ObjectPropertyValue -InputObject $firstResult -Name 'local_only')
+    $includeLocalBenchmark = Test-BenchmarkIncludesLocalRun -BenchmarkObject $firstResult
     $persistentLocalWorkflow = [bool](Get-ObjectPropertyValue -InputObject $firstResult -Name 'persistent_local_workflow')
 
     $summaryProperties = [ordered]@{
@@ -233,12 +237,13 @@ function Write-AdHocBenchmarkSeriesSummary {
         benchmark_dataset_path = [string](Get-ObjectPropertyValue -InputObject $dataset -Name 'path')
         iteration_count = $runResults.Count
         local_only = $localOnly
+        include_local_benchmark = $includeLocalBenchmark
         persistent_local_workflow = $persistentLocalWorkflow
         current_baseline_name = [string]$currentBaseline
         result_paths = @($resultPaths)
     }
 
-    $metricSummary = Get-BenchmarkSeriesMetricSummary -RunResults @($runResults) -LocalOnly $localOnly -IncludePersistentLocalWorkflow $persistentLocalWorkflow
+    $metricSummary = Get-BenchmarkSeriesMetricSummary -RunResults @($runResults) -LocalOnly $localOnly -IncludeLocalBenchmark $includeLocalBenchmark -IncludePersistentLocalWorkflow $persistentLocalWorkflow
     foreach ($property in $metricSummary.PSObject.Properties) {
         $summaryProperties[$property.Name] = $property.Value
     }
@@ -581,7 +586,8 @@ function Write-BaselineBenchmarkHeartbeat {
         [Parameter(Mandatory = $true)]
         [string]$BaselineName,
 
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory = $false)]
+        [AllowNull()]
         [System.Collections.IDictionary]$LocalState,
 
         [Parameter(Mandatory = $false)]
@@ -599,24 +605,37 @@ function Write-BaselineBenchmarkHeartbeat {
         $FunctionExecutionActivity
     )
 
-    $localElapsedSeconds = [math]::Round($LocalState.stopwatch.Elapsed.TotalSeconds, 2)
-    $localStatus = if ($LocalState.completed) { 'Completed' } else { 'Running' }
-    $localPeakRssGb = [math]::Round(($LocalState.peakRssBytes / 1GB), 3)
     $runbookStatus = if ($null -ne $RunbookJob -and $RunbookJob.PSObject.Properties['status']) { [string]$RunbookJob.status } else { 'Pending' }
     $functionElapsedSeconds = [math]::Round((New-TimeSpan -Start $FunctionInvokeStartedUtc -End ([datetime]::UtcNow)).TotalSeconds, 2)
     $functionExecutionCount = if ($null -ne $FunctionExecutionActivity -and $FunctionExecutionActivity.PSObject.Properties['total_count']) { [int]$FunctionExecutionActivity.total_count } else { 0 }
 
-    $message = "[{0}] {1} heartbeat: local={2} elapsed={3:N0}s peak-rss={4}GB; runbook={5}; function={6} elapsed={7:N0}s exec-count={8}" -f @(
-        (Get-HeartbeatTimestampText)
-        $BaselineName
-        $localStatus
-        $localElapsedSeconds
-        $localPeakRssGb
-        $runbookStatus
-        $FunctionStatus
-        $functionElapsedSeconds
-        $functionExecutionCount
-    )
+    if ($null -ne $LocalState) {
+        $localElapsedSeconds = [math]::Round($LocalState.stopwatch.Elapsed.TotalSeconds, 2)
+        $localStatus = if ($LocalState.completed) { 'Completed' } else { 'Running' }
+        $localPeakRssGb = [math]::Round(($LocalState.peakRssBytes / 1GB), 3)
+        $message = "[{0}] {1} heartbeat: local={2} elapsed={3:N0}s peak-rss={4}GB; runbook={5}; function={6} elapsed={7:N0}s exec-count={8}" -f @(
+            (Get-HeartbeatTimestampText)
+            $BaselineName
+            $localStatus
+            $localElapsedSeconds
+            $localPeakRssGb
+            $runbookStatus
+            $FunctionStatus
+            $functionElapsedSeconds
+            $functionExecutionCount
+        )
+    }
+    else {
+        $message = "[{0}] {1} heartbeat: runbook={2}; function={3} elapsed={4:N0}s exec-count={5}" -f @(
+            (Get-HeartbeatTimestampText)
+            $BaselineName
+            $runbookStatus
+            $FunctionStatus
+            $functionElapsedSeconds
+            $functionExecutionCount
+        )
+    }
+
     Write-Host $message
 }
 
@@ -2296,6 +2315,9 @@ function Invoke-BaselineBenchmark {
         [int]$TotalRows,
 
         [Parameter(Mandatory = $false)]
+        [switch]$IncludeLocalBenchmark,
+
+        [Parameter(Mandatory = $false)]
         [switch]$LocalOnly,
 
         [Parameter(Mandatory = $false)]
@@ -2356,11 +2378,21 @@ function Invoke-BaselineBenchmark {
     Wait-FunctionHostReady -HostName $FunctionHostName -MasterKey $effectiveFunctionMasterKey
     Remove-FunctionTraceFiles -HostName $FunctionHostName -MasterKey $effectiveFunctionMasterKey
 
-    $localState = Start-LocalBenchmark -RepoPath $RepoPath -Name $BaselineName -BenchmarkDatasetPath $DatasetRoot -OutputDirectory $baselineOutputDirectory
+    $localState = if ($IncludeLocalBenchmark) {
+        Start-LocalBenchmark -RepoPath $RepoPath -Name $BaselineName -BenchmarkDatasetPath $DatasetRoot -OutputDirectory $baselineOutputDirectory
+    }
+    else {
+        $null
+    }
     $runbookState = Start-RunbookBenchmark
     $functionInvokeStartedUtc = [datetime]::UtcNow
     $null = Invoke-FunctionAdminRequest -Method Post -HostName $FunctionHostName -MasterKey $effectiveFunctionMasterKey -Path 'admin/functions/ExportAndGenerate' -Body '{}'
-    Write-Host 'Local, runbook, and Function App runs started.'
+    if ($null -ne $localState) {
+        Write-Host 'Local, runbook, and Function App runs started.'
+    }
+    else {
+        Write-Host 'Runbook and Function App runs started.'
+    }
 
     $runbookCompleted = $false
     $runbookJob = $null
@@ -2381,8 +2413,10 @@ function Invoke-BaselineBenchmark {
     $functionDashboardCompletedUtc = $null
     $functionCompletionSource = $null
 
-    while (-not ($localState.completed -and $runbookCompleted -and $functionCompleted)) {
-        Update-LocalBenchmark -State $localState
+    while ($true) {
+        if ($null -ne $localState) {
+            Update-LocalBenchmark -State $localState
+        }
 
         if (-not $runbookCompleted) {
             $runbookJob = Get-RunbookJobStatus -JobName $runbookState.name
@@ -2486,16 +2520,18 @@ function Invoke-BaselineBenchmark {
             }
         }
 
-        if (-not ($localState.completed -and $runbookCompleted -and $functionCompleted)) {
-            Write-BaselineBenchmarkHeartbeat -BaselineName $BaselineName -LocalState $localState -RunbookJob $runbookJob -FunctionStatus $functionStatus -FunctionInvokeStartedUtc $functionInvokeStartedUtc -FunctionExecutionActivity $functionExecutionActivity
+        $localCompleted = ($null -eq $localState -or $localState.completed)
+        if ($localCompleted -and $runbookCompleted -and $functionCompleted) {
+            break
         }
 
-        if (-not ($localState.completed -and $runbookCompleted -and $functionCompleted)) {
-            Start-Sleep -Seconds $PollIntervalSeconds
-        }
+        Write-BaselineBenchmarkHeartbeat -BaselineName $BaselineName -LocalState $localState -RunbookJob $runbookJob -FunctionStatus $functionStatus -FunctionInvokeStartedUtc $functionInvokeStartedUtc -FunctionExecutionActivity $functionExecutionActivity
+        Start-Sleep -Seconds $PollIntervalSeconds
     }
 
-    Update-LocalBenchmark -State $localState
+    if ($null -ne $localState) {
+        Update-LocalBenchmark -State $localState
+    }
 
     $runbookElapsedSeconds = if ($null -ne $runbookJob -and $null -ne $runbookJob.startTime -and $null -ne $runbookJob.endTime) {
         [math]::Round((New-TimeSpan -Start ([datetimeoffset]$runbookJob.startTime).UtcDateTime -End ([datetimeoffset]$runbookJob.endTime).UtcDateTime).TotalSeconds, 2)
@@ -2558,7 +2594,12 @@ function Invoke-BaselineBenchmark {
     $functionEvents = @(Get-FunctionTraceEvents -HostName $FunctionHostName -MasterKey $effectiveFunctionMasterKey -NotBeforeUtc $functionInvokeStartedUtc)
     $functionMetricSummary = Get-FunctionMetricSummary -ResourceId $FunctionResourceId -StartTimeUtc $functionMetricStartUtc -EndTimeUtc $functionMetricEndUtc
 
-    $localResult = Get-LocalBenchmarkResult -State $localState -TotalRows $TotalRows
+    $localResult = if ($null -ne $localState) {
+        Get-LocalBenchmarkResult -State $localState -TotalRows $TotalRows
+    }
+    else {
+        $null
+    }
     $runbookResult = Get-PipelineEventSummary -Events $runbookEvents -TotalElapsedSeconds $runbookElapsedSeconds -DashboardBytes (Get-BlobLengthBytes -AccountName $RunbookStorageAccountName -ContainerName 'dashboards' -BlobName 'VulnerabilityDashboard.html') -TotalRows $TotalRows -TerminalStatus ([string]$runbookJob.status)
     $functionDashboardBytes = Get-BlobLengthBytes -AccountName $FunctionStorageAccountName -ContainerName 'dashboards' -BlobName 'VulnerabilityDashboard.html'
     $functionResult = [PSCustomObject]@{
@@ -2659,12 +2700,17 @@ function Get-ComparisonBlock {
     )
 
     return [PSCustomObject]@{
-        local = [PSCustomObject]@{
-            elapsed_seconds_delta = [math]::Round(($Current.local.elapsed_seconds - $Main.local.elapsed_seconds), 2)
-            peak_rss_gb_delta = [math]::Round(($Current.local.peak_tree_rss_gb - $Main.local.peak_tree_rss_gb), 3)
-            peak_private_gb_delta = [math]::Round(($Current.local.peak_tree_private_gb - $Main.local.peak_tree_private_gb), 3)
-            phase_elapsed_seconds_delta = Get-PhaseElapsedSecondsDeltaSummary -CurrentResult $Current.local -MainResult $Main.local
-            environment_snapshot_delta = Get-EnvironmentSnapshotDeltaSummary -CurrentResult $Current.local -MainResult $Main.local
+        local = if ($null -ne $Current.local -and $null -ne $Main.local) {
+            [PSCustomObject]@{
+                elapsed_seconds_delta = [math]::Round(($Current.local.elapsed_seconds - $Main.local.elapsed_seconds), 2)
+                peak_rss_gb_delta = [math]::Round(($Current.local.peak_tree_rss_gb - $Main.local.peak_tree_rss_gb), 3)
+                peak_private_gb_delta = [math]::Round(($Current.local.peak_tree_private_gb - $Main.local.peak_tree_private_gb), 3)
+                phase_elapsed_seconds_delta = Get-PhaseElapsedSecondsDeltaSummary -CurrentResult $Current.local -MainResult $Main.local
+                environment_snapshot_delta = Get-EnvironmentSnapshotDeltaSummary -CurrentResult $Current.local -MainResult $Main.local
+            }
+        }
+        else {
+            $null
         }
         local_persistent_cache = if ($Current.PSObject.Properties['local_persistent_cache'] -and $Main.PSObject.Properties['local_persistent_cache'] -and $null -ne $Current.local_persistent_cache -and $null -ne $Main.local_persistent_cache) {
             [PSCustomObject]@{
@@ -2778,6 +2824,7 @@ if ($null -ne $datasetDefinition -and -not $datasetDefinitionMatch) {
 
 $datasetDefinitionMetadata = Get-BenchmarkDatasetResultMetadata -DatasetPath $resolvedDatasetPath -Manifest $datasetManifest -BenchmarkDatasetId $BenchmarkDatasetId -RepoRoot $repoRoot
 $totalRows = [int]$datasetPreflight.totalRows
+$effectiveIncludeLocalBenchmark = ($LocalOnly -or $IncludeLocalBenchmark -or $IncludePersistentLocalWorkflow)
 
 Write-Host ("Dataset preflight passed: {0} rows, {1:N2} GB on disk, {2} GB free memory, {3} GB free disk." -f $totalRows, ($datasetPreflight.datasetBytes / 1GB), $datasetPreflight.availableMemoryGB, $datasetPreflight.freeDiskGB)
 
@@ -2795,7 +2842,7 @@ try {
         Wait-FunctionHostReady -HostName $functionHostName -MasterKey $functionMasterKey
     }
 
-    $currentResult = @(Invoke-BaselineBenchmark -BaselineName $CurrentBaselineName -RepoPath $resolvedCurrentRepoPath -DatasetRoot $resolvedDatasetPath -OutputRoot $outputDirectory -FunctionHostName $functionHostName -FunctionResourceId $functionResourceId -SubscriptionId $(if ($LocalOnly) { '' } else { [string]$subscription.id }) -TotalRows $totalRows -LocalOnly:$LocalOnly -IncludePersistentLocalWorkflow:$IncludePersistentLocalWorkflow) | Select-Object -Last 1
+    $currentResult = @(Invoke-BaselineBenchmark -BaselineName $CurrentBaselineName -RepoPath $resolvedCurrentRepoPath -DatasetRoot $resolvedDatasetPath -OutputRoot $outputDirectory -FunctionHostName $functionHostName -FunctionResourceId $functionResourceId -SubscriptionId $(if ($LocalOnly) { '' } else { [string]$subscription.id }) -TotalRows $totalRows -IncludeLocalBenchmark:$effectiveIncludeLocalBenchmark -LocalOnly:$LocalOnly -IncludePersistentLocalWorkflow:$IncludePersistentLocalWorkflow) | Select-Object -Last 1
     $currentResult | ConvertTo-Json -Depth 10 | Set-Content -LiteralPath (Join-Path -Path $outputDirectory -ChildPath ($CurrentBaselineName + '.result.json')) -Encoding utf8
 
     if (-not $CurrentOnly) {
@@ -2804,7 +2851,7 @@ try {
             Wait-FunctionHostReady -HostName $functionHostName -MasterKey $functionMasterKey
         }
 
-        $mainResult = @(Invoke-BaselineBenchmark -BaselineName $MainBaselineName -RepoPath $resolvedMainRepoPath -DatasetRoot $resolvedDatasetPath -OutputRoot $outputDirectory -FunctionHostName $functionHostName -FunctionResourceId $functionResourceId -SubscriptionId $(if ($LocalOnly) { '' } else { [string]$subscription.id }) -TotalRows $totalRows -LocalOnly:$LocalOnly -IncludePersistentLocalWorkflow:$IncludePersistentLocalWorkflow) | Select-Object -Last 1
+        $mainResult = @(Invoke-BaselineBenchmark -BaselineName $MainBaselineName -RepoPath $resolvedMainRepoPath -DatasetRoot $resolvedDatasetPath -OutputRoot $outputDirectory -FunctionHostName $functionHostName -FunctionResourceId $functionResourceId -SubscriptionId $(if ($LocalOnly) { '' } else { [string]$subscription.id }) -TotalRows $totalRows -IncludeLocalBenchmark:$effectiveIncludeLocalBenchmark -LocalOnly:$LocalOnly -IncludePersistentLocalWorkflow:$IncludePersistentLocalWorkflow) | Select-Object -Last 1
         $mainResult | ConvertTo-Json -Depth 10 | Set-Content -LiteralPath (Join-Path -Path $outputDirectory -ChildPath ($MainBaselineName + '.result.json')) -Encoding utf8
     }
 }
@@ -2827,10 +2874,14 @@ $result = [PSCustomObject]@{
     benchmark_mode = if ($LocalOnly) {
         if ($CurrentOnly) { 'local-current-only' } else { 'local-branch-vs-main' }
     }
+    elseif ($effectiveIncludeLocalBenchmark) {
+        if ($CurrentOnly) { 'azure-plus-local-current-only' } else { 'azure-plus-local-branch-vs-main' }
+    }
     else {
-        if ($CurrentOnly) { 'current-only' } else { 'branch-vs-main' }
+        if ($CurrentOnly) { 'azure-current-only' } else { 'azure-branch-vs-main' }
     }
     local_only = ($LocalOnly -eq $true)
+    include_local_benchmark = ($effectiveIncludeLocalBenchmark -eq $true)
     persistent_local_workflow = ($IncludePersistentLocalWorkflow -eq $true)
     subscription = if ($null -ne $subscription) {
         [PSCustomObject]@{
@@ -2870,8 +2921,14 @@ if ($null -ne $currentResult) {
     if ($LocalOnly) {
         Write-Host ('{0} local elapsed: {1}s' -f $CurrentBaselineName, $currentResult.local.elapsed_seconds)
     }
-    else {
+    elseif ($effectiveIncludeLocalBenchmark) {
         Write-Host ('{0} local/runbook/function elapsed: {1}s / {2}s / {3}s ({4})' -f $CurrentBaselineName, $currentResult.local.elapsed_seconds, $currentResult.runbook.elapsed_seconds, $currentResult.function_app.elapsed_seconds, $currentResult.function_app.timing_basis)
+        if ($null -ne $currentResult.function_app.end_to_end_elapsed_seconds) {
+            Write-Host ('{0} function end-to-end/pickup delay: {1}s / {2}s' -f $CurrentBaselineName, $currentResult.function_app.end_to_end_elapsed_seconds, $currentResult.function_app.pickup_delay_seconds)
+        }
+    }
+    else {
+        Write-Host ('{0} runbook/function elapsed: {1}s / {2}s ({3})' -f $CurrentBaselineName, $currentResult.runbook.elapsed_seconds, $currentResult.function_app.elapsed_seconds, $currentResult.function_app.timing_basis)
         if ($null -ne $currentResult.function_app.end_to_end_elapsed_seconds) {
             Write-Host ('{0} function end-to-end/pickup delay: {1}s / {2}s' -f $CurrentBaselineName, $currentResult.function_app.end_to_end_elapsed_seconds, $currentResult.function_app.pickup_delay_seconds)
         }
@@ -2884,8 +2941,14 @@ if ($null -ne $mainResult) {
     if ($LocalOnly) {
         Write-Host ('{0} local elapsed: {1}s' -f $MainBaselineName, $mainResult.local.elapsed_seconds)
     }
-    else {
+    elseif ($effectiveIncludeLocalBenchmark) {
         Write-Host ('{0} local/runbook/function elapsed: {1}s / {2}s / {3}s ({4})' -f $MainBaselineName, $mainResult.local.elapsed_seconds, $mainResult.runbook.elapsed_seconds, $mainResult.function_app.elapsed_seconds, $mainResult.function_app.timing_basis)
+        if ($null -ne $mainResult.function_app.end_to_end_elapsed_seconds) {
+            Write-Host ('{0} function end-to-end/pickup delay: {1}s / {2}s' -f $MainBaselineName, $mainResult.function_app.end_to_end_elapsed_seconds, $mainResult.function_app.pickup_delay_seconds)
+        }
+    }
+    else {
+        Write-Host ('{0} runbook/function elapsed: {1}s / {2}s ({3})' -f $MainBaselineName, $mainResult.runbook.elapsed_seconds, $mainResult.function_app.elapsed_seconds, $mainResult.function_app.timing_basis)
         if ($null -ne $mainResult.function_app.end_to_end_elapsed_seconds) {
             Write-Host ('{0} function end-to-end/pickup delay: {1}s / {2}s' -f $MainBaselineName, $mainResult.function_app.end_to_end_elapsed_seconds, $mainResult.function_app.pickup_delay_seconds)
         }

--- a/tests/Measure-StressRun.ps1
+++ b/tests/Measure-StressRun.ps1
@@ -82,6 +82,113 @@ function Get-HeartbeatFileStatus {
     }
 }
 
+function Get-StressReportObject {
+    [CmdletBinding()]
+    [OutputType([pscustomobject])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Name,
+
+        [Parameter(Mandatory = $true)]
+        [string[]]$Command,
+
+        [Parameter(Mandatory = $true)]
+        [bool]$Validate,
+
+        [Parameter(Mandatory = $true)]
+        [string]$ValidationMode,
+
+        [Parameter(Mandatory = $true)]
+        [bool]$AllowLargeSemanticValidation,
+
+        [Parameter(Mandatory = $true)]
+        [int]$SemanticValidationRowLimit,
+
+        [Parameter(Mandatory = $true)]
+        [string]$ResolvedDashboardPath,
+
+        [Parameter(Mandatory = $true)]
+        [string]$StdoutPath,
+
+        [Parameter(Mandatory = $true)]
+        [string]$StderrPath,
+
+        [Parameter(Mandatory = $true)]
+        [System.Diagnostics.Stopwatch]$Stopwatch,
+
+        [Parameter(Mandatory = $true)]
+        [int64]$PeakRssBytes,
+
+        [Parameter(Mandatory = $true)]
+        [double]$PeakRssAt,
+
+        [Parameter(Mandatory = $true)]
+        [int64]$PeakPrivateBytes,
+
+        [Parameter(Mandatory = $true)]
+        [double]$PeakPrivateAt,
+
+        [Parameter(Mandatory = $true)]
+        [System.Collections.Generic.List[object]]$Samples,
+
+        [Parameter(Mandatory = $true)]
+        [bool]$ChildExited,
+
+        [Parameter(Mandatory = $false)]
+        [AllowNull()]
+        [int]$ReturnCode
+    )
+
+    return [PSCustomObject]@{
+        name = $Name
+        report_state = if ($ChildExited) { 'completed' } else { 'running' }
+        command = $Command
+        validation = [PSCustomObject]@{
+            validate = $Validate
+            validationMode = if ($Validate) { $ValidationMode } else { 'none' }
+            allowLargeSemanticValidation = $AllowLargeSemanticValidation
+            semanticValidationRowLimit = $SemanticValidationRowLimit
+        }
+        dashboard_output_path = $ResolvedDashboardPath
+        stdout_path = $StdoutPath
+        stderr_path = $StderrPath
+        elapsed_seconds = [math]::Round($Stopwatch.Elapsed.TotalSeconds, 2)
+        return_code = if ($ChildExited) { $ReturnCode } else { $null }
+        peak_tree_rss_bytes = $PeakRssBytes
+        peak_tree_rss_gb = [math]::Round(($PeakRssBytes / 1GB), 3)
+        peak_tree_rss_at_seconds = $PeakRssAt
+        peak_tree_private_bytes = $PeakPrivateBytes
+        peak_tree_private_gb = [math]::Round(($PeakPrivateBytes / 1GB), 3)
+        peak_tree_private_at_seconds = $PeakPrivateAt
+        sample_count = $Samples.Count
+        dashboard_exists = (Test-Path -LiteralPath $ResolvedDashboardPath -PathType Leaf)
+        dashboard_bytes = if (Test-Path -LiteralPath $ResolvedDashboardPath -PathType Leaf) { (Get-Item -LiteralPath $ResolvedDashboardPath).Length } else { 0 }
+        samples = @($Samples)
+    }
+}
+
+function Write-StressReportFile {
+    [CmdletBinding()]
+    [OutputType([pscustomobject])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$ReportPath,
+
+        [Parameter(Mandatory = $true)]
+        [pscustomobject]$Report
+    )
+
+    $reportDirectory = Split-Path -Path $ReportPath -Parent
+    if (-not [string]::IsNullOrWhiteSpace($reportDirectory) -and -not (Test-Path -LiteralPath $reportDirectory -PathType Container)) {
+        [void](New-Item -Path $reportDirectory -ItemType Directory -Force)
+    }
+
+    $tempReportPath = $ReportPath + '.tmp'
+    $Report | ConvertTo-Json -Depth 6 | Set-Content -LiteralPath $tempReportPath -Encoding utf8
+    Move-Item -LiteralPath $tempReportPath -Destination $ReportPath -Force
+    return $Report
+}
+
 function Write-StressHeartbeat {
     [CmdletBinding()]
     param(
@@ -185,9 +292,14 @@ $reportPath = if ([string]::IsNullOrWhiteSpace($ReportOutputPath)) {
 else {
     [System.IO.Path]::GetFullPath($ReportOutputPath)
 }
+$reportDirectory = Split-Path -Path $reportPath -Parent
 
 if (-not (Test-Path -LiteralPath $resolvedSyntheticPath -PathType Container)) {
     throw "Synthetic dataset path '$resolvedSyntheticPath' was not found."
+}
+
+if (-not [string]::IsNullOrWhiteSpace($reportDirectory) -and -not (Test-Path -LiteralPath $reportDirectory -PathType Container)) {
+    [void](New-Item -Path $reportDirectory -ItemType Directory -Force)
 }
 
 if ($ClearDashboardCache) {
@@ -306,12 +418,14 @@ function Add-MeasurementSample {
 }
 
 Add-MeasurementSample -Samples $samples -Process $process -Stopwatch $stopwatch -PeakRssBytes ([ref]$peakRssBytes) -PeakRssAt ([ref]$peakRssAt) -PeakPrivateBytes ([ref]$peakPrivateBytes) -PeakPrivateAt ([ref]$peakPrivateAt)
+$report = Write-StressReportFile -ReportPath $reportPath -Report (Get-StressReportObject -Name $Name -Command $command -Validate ($Validate -eq $true) -ValidationMode $ValidationMode -AllowLargeSemanticValidation ($AllowLargeSemanticValidation -eq $true) -SemanticValidationRowLimit $SemanticValidationRowLimit -ResolvedDashboardPath $resolvedDashboardPath -StdoutPath $stdoutPath -StderrPath $stderrPath -Stopwatch $stopwatch -PeakRssBytes $peakRssBytes -PeakRssAt $peakRssAt -PeakPrivateBytes $peakPrivateBytes -PeakPrivateAt $peakPrivateAt -Samples $samples -ChildExited $false)
 Write-StressHeartbeat -Name $Name -Stopwatch $stopwatch -Samples $samples -StdoutPath $stdoutPath -DashboardPath $resolvedDashboardPath -PeakRssBytes $peakRssBytes -PeakPrivateBytes $peakPrivateBytes
 
 while (-not $process.HasExited) {
     Start-Sleep -Seconds $PollIntervalSeconds
     $process.Refresh()
     Add-MeasurementSample -Samples $samples -Process $process -Stopwatch $stopwatch -PeakRssBytes ([ref]$peakRssBytes) -PeakRssAt ([ref]$peakRssAt) -PeakPrivateBytes ([ref]$peakPrivateBytes) -PeakPrivateAt ([ref]$peakPrivateAt)
+    $report = Write-StressReportFile -ReportPath $reportPath -Report (Get-StressReportObject -Name $Name -Command $command -Validate ($Validate -eq $true) -ValidationMode $ValidationMode -AllowLargeSemanticValidation ($AllowLargeSemanticValidation -eq $true) -SemanticValidationRowLimit $SemanticValidationRowLimit -ResolvedDashboardPath $resolvedDashboardPath -StdoutPath $stdoutPath -StderrPath $stderrPath -Stopwatch $stopwatch -PeakRssBytes $peakRssBytes -PeakRssAt $peakRssAt -PeakPrivateBytes $peakPrivateBytes -PeakPrivateAt $peakPrivateAt -Samples $samples -ChildExited $false)
     if (-not $process.HasExited) {
         Write-StressHeartbeat -Name $Name -Stopwatch $stopwatch -Samples $samples -StdoutPath $stdoutPath -DashboardPath $resolvedDashboardPath -PeakRssBytes $peakRssBytes -PeakPrivateBytes $peakPrivateBytes
     }
@@ -322,33 +436,7 @@ $process.Refresh()
 Add-MeasurementSample -Samples $samples -Process $process -Stopwatch $stopwatch -PeakRssBytes ([ref]$peakRssBytes) -PeakRssAt ([ref]$peakRssAt) -PeakPrivateBytes ([ref]$peakPrivateBytes) -PeakPrivateAt ([ref]$peakPrivateAt)
 $stopwatch.Stop()
 
-$report = [PSCustomObject]@{
-    name = $Name
-    command = $command
-    validation = [PSCustomObject]@{
-        validate = ($Validate -eq $true)
-        validationMode = if ($Validate) { $ValidationMode } else { 'none' }
-        allowLargeSemanticValidation = ($AllowLargeSemanticValidation -eq $true)
-        semanticValidationRowLimit = $SemanticValidationRowLimit
-    }
-    dashboard_output_path = $resolvedDashboardPath
-    stdout_path = $stdoutPath
-    stderr_path = $stderrPath
-    elapsed_seconds = [math]::Round($stopwatch.Elapsed.TotalSeconds, 2)
-    return_code = $process.ExitCode
-    peak_tree_rss_bytes = $peakRssBytes
-    peak_tree_rss_gb = [math]::Round(($peakRssBytes / 1GB), 3)
-    peak_tree_rss_at_seconds = $peakRssAt
-    peak_tree_private_bytes = $peakPrivateBytes
-    peak_tree_private_gb = [math]::Round(($peakPrivateBytes / 1GB), 3)
-    peak_tree_private_at_seconds = $peakPrivateAt
-    sample_count = $samples.Count
-    dashboard_exists = (Test-Path -LiteralPath $resolvedDashboardPath -PathType Leaf)
-    dashboard_bytes = if (Test-Path -LiteralPath $resolvedDashboardPath -PathType Leaf) { (Get-Item -LiteralPath $resolvedDashboardPath).Length } else { 0 }
-    samples = @($samples)
-}
-
-$report | ConvertTo-Json -Depth 6 | Set-Content -Path $reportPath -Encoding utf8
+$report = Write-StressReportFile -ReportPath $reportPath -Report (Get-StressReportObject -Name $Name -Command $command -Validate ($Validate -eq $true) -ValidationMode $ValidationMode -AllowLargeSemanticValidation ($AllowLargeSemanticValidation -eq $true) -SemanticValidationRowLimit $SemanticValidationRowLimit -ResolvedDashboardPath $resolvedDashboardPath -StdoutPath $stdoutPath -StderrPath $stderrPath -Stopwatch $stopwatch -PeakRssBytes $peakRssBytes -PeakRssAt $peakRssAt -PeakPrivateBytes $peakPrivateBytes -PeakPrivateAt $peakPrivateAt -Samples $samples -ChildExited $true -ReturnCode $process.ExitCode)
 
 Write-Output ("  Elapsed seconds: {0}" -f $report.elapsed_seconds)
 Write-Output ("  Peak RSS GB: {0}" -f $report.peak_tree_rss_gb)

--- a/tests/README.md
+++ b/tests/README.md
@@ -289,6 +289,8 @@ That command:
 - appends each run to `.local\benchmark-history\benchmark-history.jsonl`
 - writes aggregate `series-summary.json` and `series-summary.md` artifacts
 
+`Measure-BranchVsMainBenchmark.ps1` and `Invoke-BenchmarkSeries.ps1` default to Azure-only capture. Add `-IncludeLocalBenchmark` when you also want local timings in the same run, or `-LocalOnly` when you want to skip Azure entirely.
+
 Function App timing semantics:
 - `function_app.elapsed_seconds` now tracks active execution time when the runtime status blob is available
 - `function_app.end_to_end_elapsed_seconds` retains invoke-to-finish timing for queue and cold-start review
@@ -299,6 +301,8 @@ Capture a current-branch-only benchmark baseline with:
 ```powershell
 $stamp = Get-Date -Format 'yyyyMMdd-HHmmss'
 pwsh -NoProfile -File .\tests\Measure-BranchVsMainBenchmark.ps1 -CurrentOnly -CurrentBaselineName 'current-live' -DatasetPath .\exports-synthetic-live -ResultsOutputPath (Join-Path $PWD ('.local\current-baseline-live-' + $stamp + '.json'))
+
+pwsh -NoProfile -File .\tests\Measure-BranchVsMainBenchmark.ps1 -CurrentOnly -IncludeLocalBenchmark -CurrentBaselineName 'current-live-with-local' -DatasetPath .\exports-synthetic-live -ResultsOutputPath (Join-Path $PWD ('.local\current-baseline-live-with-local-' + $stamp + '.json'))
 ```
 
 Append a normalized local history entry after a benchmark completes with:

--- a/tests/Record-BenchmarkHistory.ps1
+++ b/tests/Record-BenchmarkHistory.ps1
@@ -19,6 +19,7 @@ Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
 . (Join-Path $PSScriptRoot 'Import-BenchmarkDatasetCatalog.ps1')
+. (Join-Path $PSScriptRoot 'helpers\BenchmarkSeriesTools.ps1')
 
 function Get-ObjectPropertyValue {
     [CmdletBinding()]
@@ -271,6 +272,7 @@ function Get-BenchmarkHistoryEntry {
         benchmark_generated_utc = Format-DateTimeValue -Value (Get-ObjectPropertyValue -InputObject $Result -Name 'generated_utc')
         benchmark_mode = [string](Get-ObjectPropertyValue -InputObject $Result -Name 'benchmark_mode')
         local_only = [bool](Get-ObjectPropertyValue -InputObject $Result -Name 'local_only')
+        include_local_benchmark = Test-BenchmarkIncludesLocalRun -BenchmarkObject $Result
         persistent_local_workflow = [bool](Get-ObjectPropertyValue -InputObject $Result -Name 'persistent_local_workflow')
         subscription = $subscriptionSummary
         dataset = Get-DatasetSummary -Result $Result
@@ -321,8 +323,9 @@ function Find-PreviousMatchingEntry {
     $candidateEntries = @(
         $Entries | Where-Object {
             ([string]$_.benchmark_result_path -ne [string]$CurrentEntry.benchmark_result_path) -and
-            ([string]$_.benchmark_mode -eq [string]$CurrentEntry.benchmark_mode) -and
+            ((Get-BenchmarkModeScenarioKey -BenchmarkMode ([string]$_.benchmark_mode)) -eq (Get-BenchmarkModeScenarioKey -BenchmarkMode ([string]$CurrentEntry.benchmark_mode))) -and
             ([bool]$_.local_only -eq [bool]$CurrentEntry.local_only) -and
+            ((Test-BenchmarkIncludesLocalRun -BenchmarkObject $_) -eq (Test-BenchmarkIncludesLocalRun -BenchmarkObject $CurrentEntry)) -and
             ([bool]$_.persistent_local_workflow -eq [bool]$CurrentEntry.persistent_local_workflow) -and
             ([string]$_.dataset.identity -eq [string]$CurrentEntry.dataset.identity) -and
             ([string]$_.current.baseline -eq [string]$CurrentEntry.current.baseline) -and
@@ -521,6 +524,8 @@ function Write-BenchmarkHistorySummary {
     $lines = [System.Collections.Generic.List[string]]::new()
     $entryRecordedUtc = Format-DateTimeValue -Value $Entry.recorded_utc
     $previousEntryRecordedUtc = Format-DateTimeValue -Value $(if ($null -ne $PreviousEntry) { $PreviousEntry.recorded_utc } else { $null })
+    $entryIncludesLocalBenchmark = Test-BenchmarkIncludesLocalRun -BenchmarkObject $Entry
+    $previousEntryIncludesLocalBenchmark = if ($null -ne $PreviousEntry) { Test-BenchmarkIncludesLocalRun -BenchmarkObject $PreviousEntry } else { $false }
     $lines.Add('# Benchmark History Summary') | Out-Null
     $lines.Add('') | Out-Null
     $lines.Add('Latest capture') | Out-Null
@@ -535,8 +540,10 @@ function Write-BenchmarkHistorySummary {
     if ($null -ne $Entry.current.repo) {
         $lines.Add(('- Current git: `{0}` @ `{1}` ({2})' -f $Entry.current.repo.branch, $Entry.current.repo.commit_short, $(if ($Entry.current.repo.dirty) { 'dirty' } else { 'clean' }))) | Out-Null
     }
-    $lines.Add(('- Local elapsed: {0}' -f (Format-SecondsValue -Value $Entry.current.local_elapsed_seconds))) | Out-Null
+    if ($entryIncludesLocalBenchmark) {
+        $lines.Add(('- Local elapsed: {0}' -f (Format-SecondsValue -Value $Entry.current.local_elapsed_seconds))) | Out-Null
         $lines.Add(('- Local pre-run environment: {0}' -f (Format-EnvironmentSnapshotValue -Snapshot $Entry.current.local_environment_snapshot))) | Out-Null
+    }
     $lines.Add(('- Runbook elapsed: {0}' -f (Format-SecondsValue -Value $Entry.current.runbook_elapsed_seconds))) | Out-Null
     $lines.Add(('- Function elapsed: {0} ({1})' -f (Format-SecondsValue -Value $Entry.current.function_elapsed_seconds), $(if ([string]::IsNullOrWhiteSpace([string]$Entry.current.function_timing_basis)) { 'legacy' } else { [string]$Entry.current.function_timing_basis }))) | Out-Null
     if ($null -ne $Entry.current.function_end_to_end_elapsed_seconds) {
@@ -569,7 +576,9 @@ function Write-BenchmarkHistorySummary {
         $lines.Add('') | Out-Null
         $lines.Add(('- Recorded: `{0}`' -f $previousEntryRecordedUtc)) | Out-Null
         $lines.Add(('- Result file: `{0}`' -f $PreviousEntry.benchmark_result_path)) | Out-Null
-        $lines.Add(('- Local delta: {0}' -f (Format-DeltaValue -CurrentValue $Entry.current.local_elapsed_seconds -PreviousValue $PreviousEntry.current.local_elapsed_seconds))) | Out-Null
+        if ($entryIncludesLocalBenchmark -and $previousEntryIncludesLocalBenchmark) {
+            $lines.Add(('- Local delta: {0}' -f (Format-DeltaValue -CurrentValue $Entry.current.local_elapsed_seconds -PreviousValue $PreviousEntry.current.local_elapsed_seconds))) | Out-Null
+        }
         $lines.Add(('- Runbook delta: {0}' -f (Format-DeltaValue -CurrentValue $Entry.current.runbook_elapsed_seconds -PreviousValue $PreviousEntry.current.runbook_elapsed_seconds))) | Out-Null
         $lines.Add(('- Function delta: {0}' -f (Format-DeltaValue -CurrentValue $Entry.current.function_elapsed_seconds -PreviousValue $PreviousEntry.current.function_elapsed_seconds))) | Out-Null
         if ($null -ne $Entry.current.function_end_to_end_elapsed_seconds -and $null -ne $PreviousEntry.current.function_end_to_end_elapsed_seconds) {

--- a/tests/Run-SharedHelperRegression.ps1
+++ b/tests/Run-SharedHelperRegression.ps1
@@ -3733,6 +3733,17 @@ function Test-MeasureStressRunWritesProgressAndFinalReport {
 
         $process.WaitForExit()
 
+        if (-not $IsWindows) {
+            $stdoutContent = if (Test-Path -LiteralPath $stdoutPath -PathType Leaf) { Get-Content -LiteralPath $stdoutPath -Raw } else { '' }
+            $stderrContent = if (Test-Path -LiteralPath $stderrPath -PathType Leaf) { Get-Content -LiteralPath $stderrPath -Raw } else { '' }
+            $processOutput = @($stdoutContent, $stderrContent) -join [Environment]::NewLine
+
+            Assert-True ($process.ExitCode -ne 0) 'Expected Measure-StressRun regression fixture to fail fast on non-Windows platforms.'
+            Assert-True (-not (Test-Path -LiteralPath $reportPath -PathType Leaf)) 'Expected non-Windows Measure-StressRun execution to avoid writing a stress report.'
+            Assert-True ($processOutput.Contains('currently supports Windows only')) 'Expected non-Windows Measure-StressRun execution to explain the Windows-only platform guard.'
+            return
+        }
+
         $report = Get-Content -LiteralPath $reportPath -Raw | ConvertFrom-Json -Depth 20
 
         Assert-True $reportSeenWhileRunning 'Expected Measure-StressRun to persist a progress report before the wrapper process exits.'

--- a/tests/Run-SharedHelperRegression.ps1
+++ b/tests/Run-SharedHelperRegression.ps1
@@ -4333,6 +4333,8 @@ function Test-DashboardValidateOnlyFailsWhenHostedPayloadMissing {
     $outputPath = Join-Path $tempRoot 'dashboard.html'
     $auditPath = Join-Path $tempRoot 'audit.json'
     $assetsPath = Join-Path $tempRoot 'dashboard.assets'
+    $validateStdoutPath = Join-Path $tempRoot 'validate-only.stdout.log'
+    $validateStderrPath = Join-Path $tempRoot 'validate-only.stderr.log'
 
     try {
         Copy-Item -Path (Join-Path $fixturePath '*') -Destination $tempRoot -Recurse -Force
@@ -4344,8 +4346,20 @@ function Test-DashboardValidateOnlyFailsWhenHostedPayloadMissing {
         Assert-True ((Test-Path -LiteralPath $payloadAssetPath -PathType Leaf)) 'Expected split-assets generation to write a hosted payload before the negative validation step.'
         Remove-Item -LiteralPath $payloadAssetPath -Force
 
-        & pwsh -NoProfile -File $dashboardScriptPath -DirectoryPath $tempRoot -OutputPath $outputPath -ValidateOnly -ValidationOutputPath $auditPath | Out-Null
-        $validationExitCode = $LASTEXITCODE
+        $pwshCommand = Get-Command -Name 'pwsh' -ErrorAction Stop
+        $validationProcess = Start-Process -FilePath $pwshCommand.Source -ArgumentList @(
+            '-NoProfile'
+            '-File'
+            $dashboardScriptPath
+            '-DirectoryPath'
+            $tempRoot
+            '-OutputPath'
+            $outputPath
+            '-ValidateOnly'
+            '-ValidationOutputPath'
+            $auditPath
+        ) -WorkingDirectory (Split-Path -Path $dashboardScriptPath -Parent) -RedirectStandardOutput $validateStdoutPath -RedirectStandardError $validateStderrPath -PassThru -Wait
+        $validationExitCode = $validationProcess.ExitCode
 
         Assert-True ($validationExitCode -ne 0) 'Expected ValidateOnly to fail when a hosted dashboard payload asset is missing.'
         Assert-True (-not (Test-Path -LiteralPath $auditPath -PathType Leaf)) 'Expected missing hosted payload validation to avoid writing a passing audit artifact.'
@@ -4370,6 +4384,8 @@ function Test-PackageOnlyRejectsMismatchedNormalizedPayloadManifest {
     $normalizedManifestPath = Join-Path $tempRoot '.local\payload\dashboard-payload.json'
     $tamperedPayloadPath = Join-Path $tempRoot '.local\payload\dashboard-payload-tampered.json.gz'
     $outputPath = Join-Path $tempRoot 'dashboard.html'
+    $packageStdoutPath = Join-Path $tempRoot 'package-only.stdout.log'
+    $packageStderrPath = Join-Path $tempRoot 'package-only.stderr.log'
 
     try {
         Copy-Item -Path (Join-Path $fixturePath '*') -Destination $tempRoot -Recurse -Force
@@ -4381,8 +4397,23 @@ function Test-PackageOnlyRejectsMismatchedNormalizedPayloadManifest {
 
         Write-GzipTextFile -Path $tamperedPayloadPath -Content '{"lookups":{"devices":[],"cves":[]},"vulnsFormat":"rows-v1","vulns":[]}'
 
-        & pwsh -NoProfile -File $dashboardScriptPath -DirectoryPath $tempRoot -OutputPath $outputPath -ExportMachineData:$false -PackageOnly -NormalizedPayloadInputPath $tamperedPayloadPath -NormalizedPayloadManifestInputPath $normalizedManifestPath | Out-Null
-        $packageExitCode = $LASTEXITCODE
+        $pwshCommand = Get-Command -Name 'pwsh' -ErrorAction Stop
+        $packageProcess = Start-Process -FilePath $pwshCommand.Source -ArgumentList @(
+            '-NoProfile'
+            '-File'
+            $dashboardScriptPath
+            '-DirectoryPath'
+            $tempRoot
+            '-OutputPath'
+            $outputPath
+            '-ExportMachineData:$false'
+            '-PackageOnly'
+            '-NormalizedPayloadInputPath'
+            $tamperedPayloadPath
+            '-NormalizedPayloadManifestInputPath'
+            $normalizedManifestPath
+        ) -WorkingDirectory (Split-Path -Path $dashboardScriptPath -Parent) -RedirectStandardOutput $packageStdoutPath -RedirectStandardError $packageStderrPath -PassThru -Wait
+        $packageExitCode = $packageProcess.ExitCode
 
         Assert-True ($packageExitCode -ne 0) 'Expected package-only generation to reject a payload whose bytes do not match the provided manifest.'
         Assert-True (-not (Test-Path -LiteralPath $outputPath -PathType Leaf)) 'Expected package-only manifest mismatch to avoid writing a dashboard.'

--- a/tests/Run-SharedHelperRegression.ps1
+++ b/tests/Run-SharedHelperRegression.ps1
@@ -7,6 +7,7 @@ Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
 . (Join-Path (Split-Path -Path $PSScriptRoot -Parent) 'build\Import-SharedHelpers.ps1')
+. (Join-Path $PSScriptRoot 'helpers\BenchmarkSeriesTools.ps1')
 
 function Assert-True {
     [CmdletBinding()]
@@ -1811,6 +1812,8 @@ function Test-ConvertToNormalizedDataReportsContentStoreNormalizationPhase {
         Assert-True ('LoadContentStoreDeviceProfiles' -in $phaseNames) 'Expected content-store normalization to report device-profile loading through the normalization callback.'
         Assert-True ('LoadContentStoreTemplates' -in $phaseNames) 'Expected content-store normalization to report template loading through the normalization callback.'
         Assert-True ('StreamContentStoreRefs' -in $phaseNames) 'Expected content-store normalization to report ref streaming through the normalization callback.'
+        Assert-True ('StreamContentStoreCurrentRefs' -in $phaseNames) 'Expected content-store normalization to split current ref streaming into its own normalization phase.'
+        Assert-True ('StreamContentStoreHistoryRefs' -in $phaseNames) 'Expected content-store normalization to split history ref streaming into its own normalization phase.'
     }
     finally {
         if (Test-Path -LiteralPath $tempRoot) {
@@ -2390,8 +2393,23 @@ function Test-InvokeContentStoreNormalizationReleasesTransientContextBeforePaylo
     [void](New-Item -Path $tempRoot -ItemType Directory -Force)
     $outputPath = Join-Path $tempRoot 'normalized-vulns.json'
     $payloadPath = Join-Path $tempRoot 'payload.json.gz'
+    $originalWriteMemoryUsage = if (Test-Path -LiteralPath Function:\Write-MemoryUsage) {
+        Get-Item -LiteralPath Function:\Write-MemoryUsage
+    }
+    else {
+        $null
+    }
 
     try {
+        Set-Item -LiteralPath Function:\Write-MemoryUsage -Value {
+            param(
+                [Parameter(Mandatory = $false)]
+                [string]$Label = ''
+            )
+
+            Write-Output ("mock memory usage: {0}" -f $Label)
+        }
+
         $currentRow = Get-TestVulnRow -Id 'content-store-context-release-001' -CveId 'CVE-2026-0154' -SnapshotDate '2026-03-20' -Version '2.0.0'
         $currentRow.DeviceId = 'device-context-release-001'
         $currentRow.DeviceName = 'device-context-release-001.contoso.com'
@@ -2453,7 +2471,7 @@ function Test-InvokeContentStoreNormalizationReleasesTransientContextBeforePaylo
             }
         }
 
-        $result = Invoke-ContentStoreNormalization `
+        $result = @(Invoke-ContentStoreNormalization `
             -DataPath $tempRoot `
             -VulnOutputPath $outputPath `
             -Context $context `
@@ -2463,18 +2481,28 @@ function Test-InvokeContentStoreNormalizationReleasesTransientContextBeforePaylo
             -AdvancedHuntingInventoryData $advancedHuntingInventoryData `
             -NvdCveData $nvdCveData `
             -PayloadOutputPath $payloadPath `
-            -ConsumeLookupsOnPayloadClose
+            -ConsumeLookupsOnPayloadClose)
 
-        Assert-True ($result.ProcessedCount -eq 1) 'Expected content-store context-release regression fixture to normalize one row.'
-        Assert-True ([string]$result.PayloadPath -eq $payloadPath) 'Expected content-store context-release regression fixture to write the direct payload output.'
-        Assert-True ((Get-CompressedPayloadVulnCount -Path $payloadPath) -eq $result.ProcessedCount) 'Expected content-store context-release regression payload row count to match the processed count.'
+        Assert-True ($result.Count -eq 1) 'Expected content-store normalization to suppress hosted memory diagnostics from the return pipeline.'
+
+        $normalizationResult = $result[0]
+        Assert-True ($normalizationResult.ProcessedCount -eq 1) 'Expected content-store context-release regression fixture to normalize one row.'
+        Assert-True ([string]$normalizationResult.PayloadPath -eq $payloadPath) 'Expected content-store context-release regression fixture to write the direct payload output.'
+        Assert-True ((Get-CompressedPayloadVulnCount -Path $payloadPath) -eq $normalizationResult.ProcessedCount) 'Expected content-store context-release regression payload row count to match the processed count.'
         Assert-True ($context.Machines.Count -eq 0) 'Expected content-store normalization to release machine lookups before payload close.'
         Assert-True ($context.AdvancedHuntingData.Count -eq 0) 'Expected content-store normalization to release Advanced Hunting CVE data before payload close.'
         Assert-True ($context.AdvancedHuntingDeviceUsers.Count -eq 0) 'Expected content-store normalization to release Advanced Hunting device-user data before payload close.'
         Assert-True ($context.NvdCveData.Count -eq 0) 'Expected content-store normalization to release NVD CVE data before payload close.'
-        Assert-True ($context.AdvancedHuntingInventoryData.Count -eq 1) 'Expected content-store normalization to preserve inventory enrichment needed during ref streaming.'
+        Assert-True ($context.AdvancedHuntingInventoryData.Count -eq 0) 'Expected content-store normalization to release inventory enrichment before payload close once ref streaming completes.'
     }
     finally {
+        if ($null -ne $originalWriteMemoryUsage) {
+            Set-Item -LiteralPath Function:\Write-MemoryUsage -Value $originalWriteMemoryUsage.ScriptBlock
+        }
+        elseif (Test-Path -LiteralPath Function:\Write-MemoryUsage) {
+            Remove-Item -LiteralPath Function:\Write-MemoryUsage -Force -ErrorAction SilentlyContinue
+        }
+
         if (Test-Path -LiteralPath $tempRoot) {
             Remove-Item -LiteralPath $tempRoot -Recurse -Force -ErrorAction SilentlyContinue
         }
@@ -3205,6 +3233,137 @@ function Test-WriteBase64FileContentMatchesReferenceOutput {
     }
 }
 
+function Test-BenchmarkSeriesSummaryHandlesAzureOnlyRunMode {
+    [CmdletBinding()]
+    param()
+
+    $azureOnlyRun = [PSCustomObject]@{
+        include_local_benchmark = $false
+        local_only = $false
+        current = [PSCustomObject]@{
+            local = $null
+            runbook = [PSCustomObject]@{
+                elapsed_seconds = 575.25
+            }
+            function_app = [PSCustomObject]@{
+                active_elapsed_seconds = 530.51
+                end_to_end_elapsed_seconds = 532.12
+                pickup_delay_seconds = 1.61
+            }
+        }
+    }
+
+    $summary = Get-BenchmarkSeriesMetricSummary -RunResults @($azureOnlyRun) -LocalOnly:$false -IncludeLocalBenchmark:$false -IncludePersistentLocalWorkflow:$false
+
+    Assert-True (-not (Test-BenchmarkIncludesLocalRun -BenchmarkObject $azureOnlyRun)) 'Expected Azure-only benchmark runs to report that no local benchmark was included.'
+    Assert-True ($null -eq $summary.local_elapsed_seconds) 'Expected Azure-only benchmark summaries to omit local elapsed metrics.'
+    Assert-True ($null -ne $summary.runbook_elapsed_seconds) 'Expected Azure-only benchmark summaries to retain runbook elapsed metrics.'
+    Assert-True ($null -ne $summary.function_active_elapsed_seconds) 'Expected Azure-only benchmark summaries to retain Function App elapsed metrics.'
+}
+
+function Test-BenchmarkSeriesSummaryHandlesCombinedRunMode {
+    [CmdletBinding()]
+    param()
+
+    $combinedRun = [PSCustomObject]@{
+        include_local_benchmark = $true
+        local_only = $false
+        current = [PSCustomObject]@{
+            local = [PSCustomObject]@{
+                elapsed_seconds = 120.5
+            }
+            runbook = [PSCustomObject]@{
+                elapsed_seconds = 575.25
+            }
+            function_app = [PSCustomObject]@{
+                active_elapsed_seconds = 530.51
+                end_to_end_elapsed_seconds = 532.12
+                pickup_delay_seconds = 1.61
+            }
+        }
+    }
+
+    $summary = Get-BenchmarkSeriesMetricSummary -RunResults @($combinedRun) -LocalOnly:$false -IncludeLocalBenchmark:$true -IncludePersistentLocalWorkflow:$false
+
+    Assert-True (Test-BenchmarkIncludesLocalRun -BenchmarkObject $combinedRun) 'Expected combined Azure plus local benchmark runs to report that a local benchmark was included.'
+    Assert-True ($null -ne $summary.local_elapsed_seconds) 'Expected combined benchmark summaries to retain local elapsed metrics.'
+}
+
+function Test-BenchmarkSeriesSummaryHandlesLocalOnlyRunMode {
+    [CmdletBinding()]
+    param()
+
+    $localOnlyRun = [PSCustomObject]@{
+        local_only = $true
+        current = [PSCustomObject]@{
+            local = [PSCustomObject]@{
+                elapsed_seconds = 98.75
+            }
+            runbook = $null
+            function_app = $null
+        }
+    }
+
+    $summary = Get-BenchmarkSeriesMetricSummary -RunResults @($localOnlyRun) -LocalOnly:$true -IncludeLocalBenchmark:$false -IncludePersistentLocalWorkflow:$false
+
+    Assert-True (Test-BenchmarkIncludesLocalRun -BenchmarkObject $localOnlyRun) 'Expected local-only benchmark runs to report that a local benchmark was included even when the explicit include_local_benchmark flag is absent.'
+    Assert-True ($null -ne $summary.local_elapsed_seconds) 'Expected local-only benchmark summaries to retain local elapsed metrics.'
+    Assert-True ($null -eq $summary.runbook_elapsed_seconds) 'Expected local-only benchmark summaries to omit runbook elapsed metrics.'
+    Assert-True ($null -eq $summary.function_active_elapsed_seconds) 'Expected local-only benchmark summaries to omit Function App elapsed metrics.'
+}
+
+function Test-BenchmarkIncludesLocalRunHandlesLegacyInferenceShape {
+    [CmdletBinding()]
+    param()
+
+    $legacyRun = [PSCustomObject]@{
+        local_only = $false
+        persistent_local_workflow = $true
+        current = [PSCustomObject]@{
+            local = [PSCustomObject]@{
+                elapsed_seconds = 142.25
+            }
+            runbook = [PSCustomObject]@{
+                elapsed_seconds = 575.25
+            }
+            function_app = [PSCustomObject]@{
+                active_elapsed_seconds = 530.51
+                end_to_end_elapsed_seconds = 532.12
+                pickup_delay_seconds = 1.61
+            }
+        }
+    }
+
+    Assert-True (Test-BenchmarkIncludesLocalRun -BenchmarkObject $legacyRun) 'Expected benchmark history helpers to infer local benchmark capture from legacy result shapes that include a local result but omit include_local_benchmark.'
+}
+
+function Test-BenchmarkModeScenarioKeyHandlesLegacyModeMapping {
+    [CmdletBinding()]
+    param()
+
+    Assert-True ((Get-BenchmarkModeScenarioKey -BenchmarkMode 'current-only') -eq 'current-only') 'Expected the legacy current-only benchmark mode to normalize to the current-only scenario.'
+    Assert-True ((Get-BenchmarkModeScenarioKey -BenchmarkMode 'azure-current-only') -eq 'current-only') 'Expected azure-current-only benchmark mode to normalize to the current-only scenario.'
+    Assert-True ((Get-BenchmarkModeScenarioKey -BenchmarkMode 'azure-plus-local-current-only') -eq 'current-only') 'Expected azure-plus-local-current-only benchmark mode to normalize to the current-only scenario.'
+    Assert-True ((Get-BenchmarkModeScenarioKey -BenchmarkMode 'branch-vs-main') -eq 'branch-vs-main') 'Expected the legacy branch-vs-main benchmark mode to normalize to the branch-vs-main scenario.'
+    Assert-True ((Get-BenchmarkModeScenarioKey -BenchmarkMode 'azure-branch-vs-main') -eq 'branch-vs-main') 'Expected azure-branch-vs-main benchmark mode to normalize to the branch-vs-main scenario.'
+    Assert-True ((Get-BenchmarkModeScenarioKey -BenchmarkMode 'azure-plus-local-branch-vs-main') -eq 'branch-vs-main') 'Expected azure-plus-local-branch-vs-main benchmark mode to normalize to the branch-vs-main scenario.'
+}
+
+function Test-WriteProgressMarkerIncludesEtaWhenTotalCountKnown {
+    [CmdletBinding()]
+    param()
+
+    $progressState = New-ProgressMarkerState -ActivityName 'ETA regression' -ProgressInterval 10 -HeartbeatIntervalSeconds 60 -CheckInterval 1 -TotalCount 100
+    $outputRecords = @(& {
+            Write-ProgressMarker -State $progressState -Count 10 -UnitLabel 'row(s)'
+        } 6>&1)
+    $outputText = (@($outputRecords | ForEach-Object { Get-OutputRecordText -Record $_ }) -join [Environment]::NewLine)
+
+    Assert-True (-not [string]::IsNullOrWhiteSpace($outputText)) 'Expected Write-ProgressMarker to emit a progress message when the interval is reached.'
+    Assert-True ($outputText.Contains('ETA ')) 'Expected Write-ProgressMarker to include ETA text when the total row count is known.'
+    Assert-True ($outputText.Contains('10.0% complete')) 'Expected Write-ProgressMarker ETA output to preserve the percent complete marker.'
+}
+
 function Test-ValidationHelperPayloadCanonicalization {
     [CmdletBinding()]
     param()
@@ -3246,6 +3405,347 @@ function Test-ValidationHelperPayloadCanonicalization {
         Assert-True (@(Compare-Object -ReferenceObject $rowFormatSignatures -DifferenceObject $columnFormatSignatures).Count -eq 0) 'Expected validation helper canonicalization to treat rows-v1 and columns-v1 payloads as semantically equivalent.'
     }
     finally {
+        if (Test-Path -LiteralPath $tempRoot) {
+            Remove-Item -LiteralPath $tempRoot -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+}
+
+function Test-ValidationHelperSourceCanonicalization {
+    [CmdletBinding()]
+    param()
+
+    $tempRoot = Join-Path ([System.IO.Path]::GetTempPath()) ('validation-helper-source-canonicalization-' + [guid]::NewGuid().ToString('N'))
+    [void](New-Item -Path $tempRoot -ItemType Directory -Force)
+    $repoRoot = Split-Path -Path $PSScriptRoot -Parent
+
+    try {
+        . (Join-Path $repoRoot 'build\Import-ValidationHelpers.ps1')
+
+        $row = Get-TestVulnRow -Id 'validation-source-001' -CveId 'CVE-2026-0313' -SnapshotDate '2026-03-20' -Version '3.2.0'
+        $row.CvssScore = 8.15
+        $row.VulnerabilitySeverityLevel = 'High'
+        $row.ExploitabilityLevel = 'ExploitIsPublic'
+        $row.FirstSeenTimestamp = '2026-03-21T00:00:00Z'
+        $row.LastSeenTimestamp = '2026-03-18T00:00:00Z'
+        $row.DiskPaths = @('C:\z-agent.dll', 'C:\a-agent.dll')
+        $row.RegistryPaths = @('HKLM\Software\Contoso\ZAgent', 'HKLM\Software\Contoso\AAgent')
+        Write-NdjsonRecordsFile -Path (Get-VulnCurrentPath -BasePath $tempRoot) -Records @($row)
+
+        $machines = @{
+            'device-001' = [PSCustomObject]@{
+                id = 'device-001'
+                computerDnsName = 'device01.contoso.com'
+                rbacGroupName = 'Servers'
+                osPlatform = 'Windows 11'
+                osVersion = '10.0.22631'
+                machineTags = @('Prod', 'Ring0')
+                lastIpAddress = '10.0.0.21'
+                lastExternalIpAddress = '52.0.0.21'
+                healthStatus = 'Active'
+                riskScore = 'Medium'
+                exposureLevel = 'Low'
+                deviceValue = 'Normal'
+                managedBy = 'Intune'
+                isAadJoined = $true
+                lastSeen = '2026-03-22T00:00:00Z'
+                firstSeen = '2026-02-15T00:00:00Z'
+            }
+        }
+        $advancedHunting = @{
+            'CVE-2026-0313' = [PSCustomObject]@{
+                PublishedDate = '2026-03-05T10:11:12Z'
+                VulnerabilityDescription = "  Source`n canonical   description  "
+                EpssScore = 0.8123
+                AffectedSoftware = @('contoso:legacy agent', 'fabrikam:other')
+                IsExploitAvailable = $true
+            }
+        }
+        $nvdCveData = @{
+            'CVE-2026-0313' = [PSCustomObject]@{
+                PublishedDate = '2026-03-04T00:00:00Z'
+                VulnerabilityDescription = 'NVD fallback description'
+                LastModifiedDate = '2026-03-17T01:02:03Z'
+                BaseScore = 8.0
+                BaseSeverity = 'HIGH'
+                Vector = 'AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H'
+                CisaExploitAdd = '2026-03-18T00:00:00Z'
+                CisaActionDue = '2026-04-01T00:00:00Z'
+                CisaRequiredAction = " Patch`r`n immediately "
+                Weaknesses = @('CWE-79', 'CWE-20')
+            }
+        }
+        $inventoryKey = Get-AdvancedHuntingInventoryMatchKey -DeviceId $row.DeviceId -SoftwareVendor $row.SoftwareVendor -SoftwareName $row.SoftwareName -SoftwareVersion $row.SoftwareVersion
+        $advancedHuntingInventory = @{
+            $inventoryKey = [PSCustomObject]@{
+                ProductCodeCpe = 'cpe:/a:contoso:legacy_agent'
+                EndOfSupportStatus = 'supported'
+                EndOfSupportDate = '2028-01-01T00:00:00Z'
+            }
+        }
+        $vendorSet = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+        [void]$vendorSet.Add((Get-VendorMatchKey -Vendor $row.SoftwareVendor))
+
+        $firstLastSwappedCount = 0
+        $missingMachineCount = 0
+        $signatures = @(Read-SourceCanonicalSignatureStream -ExportsPath $tempRoot -Machines $machines -AdvancedHunting $advancedHunting -AdvancedHuntingInventory $advancedHuntingInventory -NvdCveData $nvdCveData -VendorSet $vendorSet -FirstLastSwappedCount ([ref]$firstLastSwappedCount) -MissingMachineCount ([ref]$missingMachineCount))
+
+        $expectedRow = [PSCustomObject]@{
+            DeviceId = 'device-001'
+            DeviceName = 'device01.contoso.com'
+            RbacGroupName = 'Servers'
+            OSPlatform = 'Windows 11'
+            OSVersion = '10.0.22631'
+            MachineTags = @('Prod', 'Ring0')
+            MachineInfo = [PSCustomObject]@{
+                ip = '10.0.0.21'
+                eip = '52.0.0.21'
+                hs = 'Active'
+                rs = 'Medium'
+                el = 'Low'
+                dv = 'Normal'
+                mb = 'Intune'
+                aad = $true
+                ls = '2026-03-22'
+                fs = '2026-02-15'
+            }
+            CveId = 'CVE-2026-0313'
+            CvssScore = 8.15
+            VulnerabilitySeverityLevel = 'High'
+            ExploitabilityLevel = 'ExploitIsPublic'
+            CveBatchUrl = $row.CveBatchUrl
+            CveBatchTitle = $row.CveBatchTitle
+            PublishedDate = '2026-03-05'
+            VulnerabilityDescription = 'Source canonical description'
+            EpssScore = 0.8123
+            AffectedSoftware = @('contoso:legacy agent')
+            IsExploitAvailable = $true
+            NvdLastModifiedDate = '2026-03-17'
+            NvdBaseScore = 8.0
+            NvdBaseSeverity = 'HIGH'
+            NvdVector = 'AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H'
+            NvdKevDate = '2026-03-18'
+            NvdActionDue = '2026-04-01'
+            NvdRequiredAction = 'Patch immediately'
+            NvdWeaknesses = @('CWE-79', 'CWE-20')
+            SoftwareVendor = 'Contoso'
+            SoftwareName = 'Legacy Agent'
+            SoftwareVersion = '3.2.0'
+            RecommendationReference = 'KB000001'
+            ProductCodeCpe = 'cpe:/a:contoso:legacy_agent'
+            EndOfSupportStatus = 'supported'
+            EndOfSupportDate = '2028-01-01'
+            FirstSeenTimestamp = '2026-03-18'
+            LastSeenTimestamp = '2026-03-21'
+            SecurityUpdateAvailable = $true
+            RecommendedSecurityUpdate = 'KB000001'
+            RecommendedSecurityUpdateId = 'KB000001'
+            RecommendedSecurityUpdateUrl = 'https://example.invalid/kb000001'
+            DiskPaths = @('C:\z-agent.dll', 'C:\a-agent.dll')
+            RegistryPaths = @('HKLM\Software\Contoso\ZAgent', 'HKLM\Software\Contoso\AAgent')
+        }
+        $expectedSignature = Get-CanonicalValidationRowSignature -Row $expectedRow
+
+        Assert-True ($signatures.Count -eq 1) 'Expected source canonicalization fixture to emit one signature.'
+        Assert-True ($signatures[0] -eq $expectedSignature) 'Expected source canonicalization to preserve the canonical row signature for enriched source records.'
+        Assert-True ($firstLastSwappedCount -eq 1) 'Expected source canonicalization to continue tracking reordered first/last seen timestamps.'
+        Assert-True ($missingMachineCount -eq 0) 'Expected source canonicalization fixture to resolve machine metadata without fallback misses.'
+    }
+    finally {
+        if (Test-Path -LiteralPath $tempRoot) {
+            Remove-Item -LiteralPath $tempRoot -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+}
+
+function Test-WriteCombinedPayloadGzipCanConsumeColumnLookupData {
+    [CmdletBinding()]
+    param()
+
+    $tempRoot = Join-Path ([System.IO.Path]::GetTempPath()) ('payload-consume-lookups-' + [guid]::NewGuid().ToString('N'))
+    [void](New-Item -Path $tempRoot -ItemType Directory -Force)
+    $repoRoot = Split-Path -Path $PSScriptRoot -Parent
+    $columnsOutputPath = Join-Path $tempRoot 'columns-normalized.json'
+    $columnPath = Join-Path $tempRoot 'columns'
+    $payloadPath = Join-Path $tempRoot 'columns-payload.json.gz'
+
+    try {
+        . (Join-Path $repoRoot 'build\Import-ValidationHelpers.ps1')
+
+        $currentRow = Get-TestVulnRow -Id 'payload-consume-001' -CveId 'CVE-2026-0411' -SnapshotDate '2026-03-20' -Version '4.0.0'
+        $historyRow = Get-TestVulnRow -Id 'payload-consume-002' -CveId 'CVE-2026-0412' -SnapshotDate '2026-03-18' -Version '4.1.0'
+        $historyRow.DeviceId = 'device-002'
+        $historyRow.DeviceName = 'device02.contoso.com'
+
+        Write-NdjsonRecordsFile -Path (Get-VulnCurrentPath -BasePath $tempRoot) -Records @($currentRow)
+        [void](New-Item -Path (Get-VulnHistoryPath -BasePath $tempRoot -PeriodKey '2026Q1') -ItemType File -Force)
+        Write-NdjsonRecordsFile -Path (Get-VulnHistoryRowsPath -BasePath $tempRoot -PeriodKey '2026Q1') -Records @($historyRow)
+
+        $columnsResult = ConvertTo-NormalizedData -DataPath $tempRoot -VulnOutputPath $columnsOutputPath -VulnColumnDirectoryPath $columnPath -Machines @{} -AdvancedHuntingData @{}
+        $deviceCountBeforeConsume = @($columnsResult.Lookups.devices).Count
+        $cveCountBeforeConsume = @($columnsResult.Lookups.cves).Count
+
+        Write-CombinedPayloadGzip -Lookups $columnsResult.Lookups -VulnColumnPaths $columnsResult.VulnColumnPaths -OutputPath $payloadPath -ConsumeLookups
+
+        $payloadSignatures = @(Read-PayloadCanonicalSignatureStream -PayloadPath $payloadPath | Sort-Object)
+
+        Assert-True ($deviceCountBeforeConsume -gt 0) 'Expected the payload fixture to start with populated device lookups before consuming them.'
+        Assert-True ($cveCountBeforeConsume -gt 0) 'Expected the payload fixture to start with populated CVE lookups before consuming them.'
+        Assert-True ($payloadSignatures.Count -eq 2) 'Expected the consumed-lookups payload fixture to preserve both vulnerability rows.'
+        Assert-True ($null -eq $columnsResult.Lookups.devices) 'Expected payload gzip with -ConsumeLookups to release device lookups after serialization.'
+        Assert-True ($null -eq $columnsResult.Lookups.software) 'Expected payload gzip with -ConsumeLookups to release software lookups after serialization.'
+        Assert-True ($null -eq $columnsResult.Lookups.cves) 'Expected payload gzip with -ConsumeLookups to release CVE lookups after serialization.'
+    }
+    finally {
+        if (Test-Path -LiteralPath $tempRoot) {
+            Remove-Item -LiteralPath $tempRoot -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+}
+
+function Test-GetDashboardEmbeddedPayloadInspectionStreamsSelfContainedPayload {
+    [CmdletBinding()]
+    param()
+
+    $tempRoot = Join-Path ([System.IO.Path]::GetTempPath()) ('dashboard-embedded-payload-inspection-' + [guid]::NewGuid().ToString('N'))
+    [void](New-Item -Path $tempRoot -ItemType Directory -Force)
+    $payloadPath = Join-Path $tempRoot 'payload.json.gz'
+    $htmlPath = Join-Path $tempRoot 'dashboard.html'
+
+    try {
+        Write-GzipTextFile -Path $payloadPath -Content '{"vulnsFormat":"rows-v1","vulns":[[0,0,0,0,"2026-03-20","2026-03-21",null,null,null,null,null],[1,1,1,1,"2026-03-18","2026-03-19",null,null,null,null,null]],"lookups":{"devices":[{"id":"device-001"},{"id":"device-002"}],"cves":[{"id":"CVE-2026-1001"},{"id":"CVE-2026-1002"}]}}'
+        $payloadSha256 = Get-FileSha256Hex -Path $payloadPath
+
+        $template = @"
+<html>
+<head><script id="dataFormat" type="application/json">compressed</script></head>
+<body>
+<script id="vulnsData" type="application/json">__PAYLOAD__</script>
+</body>
+</html>
+"@
+        Write-TemplatedHtml -Template $template -Segments @(@{ Placeholder = '__PAYLOAD__'; Base64FilePath = $payloadPath }) -OutputPath $htmlPath -InsertBase64LineBreaks
+
+        $inspection = Get-DashboardEmbeddedPayloadInspection -Path $htmlPath
+
+        Assert-True ($inspection.DataFormat -eq 'compressed') 'Expected self-contained dashboard inspection to report compressed data format.'
+        Assert-True ($inspection.PayloadRowCount -eq 2) 'Expected self-contained dashboard inspection to preserve the embedded payload row count.'
+        Assert-True ($inspection.PayloadSha256 -eq $payloadSha256) 'Expected self-contained dashboard inspection to preserve the embedded payload SHA256.'
+    }
+    finally {
+        if (Test-Path -LiteralPath $tempRoot) {
+            Remove-Item -LiteralPath $tempRoot -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+}
+
+function Test-MeasureStressRunWritesProgressAndFinalReport {
+    [CmdletBinding()]
+    param()
+
+    $tempRoot = Join-Path ([System.IO.Path]::GetTempPath()) ('measure-stress-run-report-' + [guid]::NewGuid().ToString('N'))
+    $datasetRoot = Join-Path $tempRoot 'dataset'
+    $outputRoot = Join-Path $tempRoot 'output'
+    [void](New-Item -Path $datasetRoot -ItemType Directory -Force)
+    [void](New-Item -Path $outputRoot -ItemType Directory -Force)
+    $repoRoot = Split-Path -Path $PSScriptRoot -Parent
+    $measureScriptPath = Join-Path $repoRoot 'tests\Measure-StressRun.ps1'
+    $dashboardPath = Join-Path $outputRoot 'dashboard.html'
+    $reportPath = Join-Path $outputRoot 'stress-report.json'
+    $stdoutPath = Join-Path $outputRoot 'measure.stdout.log'
+    $stderrPath = Join-Path $outputRoot 'measure.stderr.log'
+    $process = $null
+
+    try {
+        . (Join-Path $repoRoot 'build\Import-ValidationHelpers.ps1')
+
+        $row = Get-TestVulnRow -Id 'stress-report-001' -CveId 'CVE-2026-0701' -SnapshotDate '2026-03-20' -Version '7.0.0'
+        Write-NdjsonRecordsFile -Path (Get-VulnCurrentPath -BasePath $datasetRoot) -Records @($row)
+
+        $machines = @(
+            [PSCustomObject]@{
+                id = 'device-001'
+                computerDnsName = 'device01.contoso.com'
+                rbacGroupName = 'Servers'
+                osPlatform = 'Windows 11'
+                osVersion = '10.0.22631'
+                machineTags = @('Prod')
+                lastIpAddress = '10.0.0.21'
+                lastExternalIpAddress = ''
+                healthStatus = 'Active'
+                riskScore = 'Medium'
+                exposureLevel = 'Medium'
+                deviceValue = 'Normal'
+                managedBy = 'Intune'
+                isAadJoined = $true
+                lastSeen = '2026-03-20'
+                firstSeen = '2026-02-01'
+            }
+        )
+
+        [System.IO.File]::WriteAllText((Join-Path $datasetRoot 'Machines_Current.json'), ($machines | ConvertTo-Json -Compress -Depth 20), [System.Text.UTF8Encoding]::new($false))
+        [System.IO.File]::WriteAllText((Join-Path $datasetRoot 'AdvancedHunting_Current.json'), '[]', [System.Text.UTF8Encoding]::new($false))
+        [System.IO.File]::WriteAllText((Join-Path $datasetRoot 'synthetic-manifest.json'), (([ordered]@{
+            actualDeviceCount = 1
+            actualCurrentRows = 1
+            actualHistoryRows = 0
+        }) | ConvertTo-Json -Compress), [System.Text.UTF8Encoding]::new($false))
+
+        $pwshCommand = Get-Command -Name 'pwsh' -ErrorAction Stop
+        $argumentList = @(
+            '-NoProfile'
+            '-File'
+            $measureScriptPath
+            '-Name'
+            'stress-report-regression'
+            '-SyntheticOutputPath'
+            $datasetRoot
+            '-DashboardOutputPath'
+            $dashboardPath
+            '-ReportOutputPath'
+            $reportPath
+            '-Validate'
+            '-ValidationMode'
+            'artifacts'
+            '-PollIntervalSeconds'
+            '1'
+        )
+
+        $process = Start-Process -FilePath $pwshCommand.Source -ArgumentList $argumentList -WorkingDirectory $repoRoot -RedirectStandardOutput $stdoutPath -RedirectStandardError $stderrPath -PassThru
+
+        $reportSeenWhileRunning = $false
+        $deadline = [datetime]::UtcNow.AddSeconds(30)
+        while ([datetime]::UtcNow -lt $deadline) {
+            $process.Refresh()
+            if (Test-Path -LiteralPath $reportPath -PathType Leaf) {
+                if (-not $process.HasExited) {
+                    $reportSeenWhileRunning = $true
+                }
+                break
+            }
+
+            if ($process.HasExited) {
+                break
+            }
+
+            Start-Sleep -Milliseconds 200
+        }
+
+        $process.WaitForExit()
+
+        $report = Get-Content -LiteralPath $reportPath -Raw | ConvertFrom-Json -Depth 20
+
+        Assert-True $reportSeenWhileRunning 'Expected Measure-StressRun to persist a progress report before the wrapper process exits.'
+        Assert-True ($report.report_state -eq 'completed') 'Expected Measure-StressRun to finalize the persisted report after the child process exits.'
+        Assert-True ($report.return_code -eq 0) 'Expected Measure-StressRun regression fixture to complete successfully.'
+        Assert-True ($report.sample_count -gt 0) 'Expected Measure-StressRun regression fixture to record at least one process-tree sample.'
+        Assert-True ($report.dashboard_exists -eq $true) 'Expected Measure-StressRun regression fixture to generate the dashboard output.'
+    }
+    finally {
+        if ($null -ne $process -and -not $process.HasExited) {
+            Stop-Process -Id $process.Id -Force -ErrorAction SilentlyContinue
+        }
+
         if (Test-Path -LiteralPath $tempRoot) {
             Remove-Item -LiteralPath $tempRoot -Recurse -Force -ErrorAction SilentlyContinue
         }
@@ -3436,12 +3936,14 @@ function Test-StreamingDashboardAuditDetectsSourceMismatchDespitePayloadParity {
 
         Assert-True ($primeAudit.RowComparison.Match -eq $true) 'Expected the priming forced streaming audit to succeed before the source exports diverge.'
         Assert-True ($primeAudit.SemanticParity.SourceSignatureCacheUsed -eq $false) 'Expected the priming forced streaming audit to build the source signature cache.'
+        Assert-True ((Test-Path -LiteralPath $payloadPath -PathType Leaf)) 'Expected the streaming audit to preserve externally referenced payload files after the priming pass.'
         Assert-True ($audit.PayloadParity.Match -eq $true) 'Expected dashboard payload bytes to remain equal to the cached normalized payload.'
         Assert-True ($audit.SemanticParity.PayloadByteParityMatch -eq $true) 'Expected streaming audit diagnostics to record dashboard payload byte parity.'
         Assert-True ($audit.RowComparison.Match -eq $false) 'Expected streaming semantic parity to fail when the source exports diverge from the dashboard payload.'
         Assert-True ($audit.RowComparison.MissingCount -eq 1) 'Expected the extra source row to be reported as missing from the dashboard payload.'
         Assert-True ([string]$audit.SemanticParity.ComparisonPayloadSource -eq 'cached-payload') 'Expected source streaming audit to reuse the cached payload when byte parity proves dashboard equivalence.'
         Assert-True ($audit.SemanticParity.SourceSignatureCacheUsed -eq $false) 'Expected the streaming audit to bypass the cached source signature set after the source exports fingerprint changes.'
+        Assert-True ((Test-Path -LiteralPath $payloadPath -PathType Leaf)) 'Expected the streaming audit to preserve externally referenced payload files after full comparison completes.'
     }
     finally {
         if (Test-Path -LiteralPath $tempRoot) {
@@ -4296,6 +4798,8 @@ Test-ConvertToNormalizedDataCanConsumeLookupsOnPayloadClose
 Write-Output '  Consuming payload-close lookup checks passed.'
 Test-ConvertToNormalizedDataContentStorePathDoesNotUseLegacyDictionaryReader
 Write-Output '  Content-store streaming normalization checks passed.'
+Test-InvokeContentStoreNormalizationReleasesTransientContextBeforePayloadClose
+Write-Output '  Content-store transient context-release and hosted-memory diagnostics checks passed.'
 Test-ConvertToNormalizedDataDeduplicatesRepeatedCveLookup
 Write-Output '  Repeated CVE lookup deduplication checks passed.'
 Test-ConvertToNormalizedDataReportsZeroOnboardedContentStoreDiagnostic
@@ -4310,8 +4814,24 @@ Test-NormalizedVulnColumnCacheRefreshesInventoryColumn
 Write-Output '  Inventory-backed normalized vuln column cache reuse checks passed.'
 Test-WriteBase64FileContentMatchesReferenceOutput
 Write-Output '  Streamed base64 writer checks passed.'
+Test-BenchmarkSeriesSummaryHandlesAzureOnlyRunMode
+Test-BenchmarkSeriesSummaryHandlesCombinedRunMode
+Test-BenchmarkSeriesSummaryHandlesLocalOnlyRunMode
+Test-BenchmarkIncludesLocalRunHandlesLegacyInferenceShape
+Test-BenchmarkModeScenarioKeyHandlesLegacyModeMapping
+Write-Output '  Benchmark series mode checks passed.'
+Test-WriteProgressMarkerIncludesEtaWhenTotalCountKnown
+Write-Output '  Progress marker ETA checks passed.'
+Test-WriteCombinedPayloadGzipCanConsumeColumnLookupData
+Write-Output '  Payload lookup consumption checks passed.'
+Test-GetDashboardEmbeddedPayloadInspectionStreamsSelfContainedPayload
+Write-Output '  Embedded payload inspection checks passed.'
+Test-MeasureStressRunWritesProgressAndFinalReport
+Write-Output '  Measure-StressRun report persistence checks passed.'
 Test-ValidationHelperPayloadCanonicalization
 Write-Output '  Validation helper payload-format checks passed.'
+Test-ValidationHelperSourceCanonicalization
+Write-Output '  Validation helper source canonicalization checks passed.'
 Test-ValidationHelperStandaloneImport
 Write-Output '  Validation helper standalone import checks passed.'
 Test-DashboardValidationFailureExtendedEnrichmentGate

--- a/tests/helpers/BenchmarkSeriesTools.ps1
+++ b/tests/helpers/BenchmarkSeriesTools.ps1
@@ -78,6 +78,74 @@ function Get-NumericSeriesSummary {
     }
 }
 
+function Get-BenchmarkModeScenarioKey {
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory = $false)]
+        [AllowNull()]
+        [string]$BenchmarkMode
+    )
+
+    if ([string]::IsNullOrWhiteSpace($BenchmarkMode)) {
+        return ''
+    }
+
+    if ($BenchmarkMode -match 'current-only$') {
+        return 'current-only'
+    }
+
+    if ($BenchmarkMode -match 'branch-vs-main$') {
+        return 'branch-vs-main'
+    }
+
+    return [string]$BenchmarkMode
+}
+
+function Test-BenchmarkIncludesLocalRun {
+    [CmdletBinding()]
+    [OutputType([bool])]
+    param(
+        [Parameter(Mandatory = $false)]
+        [AllowNull()]
+        $BenchmarkObject
+    )
+
+    if ($null -eq $BenchmarkObject) {
+        return $false
+    }
+
+    $includeLocalProperty = $BenchmarkObject.PSObject.Properties['include_local_benchmark']
+    if ($null -ne $includeLocalProperty -and $null -ne $includeLocalProperty.Value) {
+        return [bool]$includeLocalProperty.Value
+    }
+
+    $localOnlyProperty = $BenchmarkObject.PSObject.Properties['local_only']
+    if ($null -ne $localOnlyProperty -and [bool]$localOnlyProperty.Value) {
+        return $true
+    }
+
+    $currentProperty = $BenchmarkObject.PSObject.Properties['current']
+    if ($null -ne $currentProperty -and $null -ne $currentProperty.Value) {
+        $localProperty = $currentProperty.Value.PSObject.Properties['local']
+        if ($null -ne $localProperty) {
+            return ($null -ne $localProperty.Value)
+        }
+
+        $localElapsedProperty = $currentProperty.Value.PSObject.Properties['local_elapsed_seconds']
+        if ($null -ne $localElapsedProperty) {
+            return ($null -ne $localElapsedProperty.Value)
+        }
+    }
+
+    $localElapsedProperty = $BenchmarkObject.PSObject.Properties['local_elapsed_seconds']
+    if ($null -ne $localElapsedProperty) {
+        return ($null -ne $localElapsedProperty.Value)
+    }
+
+    return $false
+}
+
 function Get-MarkdownStatisticLine {
     [CmdletBinding()]
     [OutputType([string])]
@@ -137,14 +205,21 @@ function Get-BenchmarkSeriesMetricSummary {
         [bool]$LocalOnly,
 
         [Parameter(Mandatory = $true)]
+        [bool]$IncludeLocalBenchmark,
+
+        [Parameter(Mandatory = $true)]
         [bool]$IncludePersistentLocalWorkflow
     )
 
+    $capturesLocalMetrics = ($LocalOnly -or $IncludeLocalBenchmark)
+
     return [PSCustomObject]@{
-        local_elapsed_seconds = Get-NumericSeriesSummary -Values (Get-BenchmarkMetricSeriesValueList -RunResults $RunResults -Selector {
+        local_elapsed_seconds = if ($capturesLocalMetrics) { Get-NumericSeriesSummary -Values (Get-BenchmarkMetricSeriesValueList -RunResults $RunResults -Selector {
             param($result)
-            [double]$result.current.local.elapsed_seconds
-        })
+            if ($null -ne $result.current -and $null -ne $result.current.local) {
+                [double]$result.current.local.elapsed_seconds
+            }
+        }) } else { $null }
         runbook_elapsed_seconds = if ($LocalOnly) { $null } else { Get-NumericSeriesSummary -Values (Get-BenchmarkMetricSeriesValueList -RunResults $RunResults -Selector {
             param($result)
             if ($null -ne $result.current.runbook) {
@@ -220,9 +295,13 @@ function Write-BenchmarkSeriesSummaryOutput {
     $summaryLines.Add(('- Iterations: `{0}`' -f [int]$Summary.iteration_count)) | Out-Null
     $summaryLines.Add(('- Results root: `{0}`' -f $resolvedResultsRoot)) | Out-Null
     $summaryLines.Add('') | Out-Null
-    $summaryLines.Add((Get-MarkdownStatisticLine -Label 'Local elapsed' -Summary $Summary.local_elapsed_seconds)) | Out-Null
 
     $localOnly = [bool]$Summary.local_only
+    $includeLocalBenchmark = Test-BenchmarkIncludesLocalRun -BenchmarkObject $Summary
+    if ($includeLocalBenchmark) {
+        $summaryLines.Add((Get-MarkdownStatisticLine -Label 'Local elapsed' -Summary $Summary.local_elapsed_seconds)) | Out-Null
+    }
+
     if (-not $localOnly) {
         $summaryLines.Add((Get-MarkdownStatisticLine -Label 'Runbook elapsed' -Summary $Summary.runbook_elapsed_seconds)) | Out-Null
         $summaryLines.Add((Get-MarkdownStatisticLine -Label 'Function active elapsed' -Summary $Summary.function_active_elapsed_seconds)) | Out-Null


### PR DESCRIPTION
## Summary
- improve normalization and payload handling for large datasets, including content-store streaming and payload cache integration
- strengthen validation and benchmark compatibility coverage, including shared-helper regressions and legacy benchmark-mode history matching
- fix hosted Automation and Function App normalization so Azure-only memory diagnostics do not pollute helper return values

## Validation
- `pwsh -NoProfile -File .\tests\Run-SharedHelperRegression.ps1`
- `pwsh -NoProfile -File .\build\Invoke-RegressionValidation.ps1`
- `pwsh -NoProfile -File .\build\Invoke-LiveDashboardDryRun.ps1 -UseExistingAzContext`
- `pwsh -NoProfile -File .\build\Invoke-AzureDeploymentValidation.ps1 -AutomationAccountName aa-defender-reporting -FunctionAppName func-defender-reporting -ResourceGroupName rg-defender-reporting -SkipMdePermissions -DashboardDeliveryMode Dual -FunctionExecutionDatasetPath .\.local\large-datasets\synthetic-50k-1_5m -ValidationTimeoutSeconds 7200 -FunctionExecutionTimeoutMinutes 45`
- large semantic audit previously revalidated green against `.\.local\large-datasets\synthetic-50k-1_5m`
- Edge browser inspection completed earlier in the branch for both self-contained and hosted outputs