### PR TITLE
Add repo health guardrails and validation observability

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,14 @@ For local testing of the split-assets build, use a local HTTP server instead of 
 | `Setup-AzureResources.ps1` | Provisions Azure compute (Automation Account or Function App), storage, scheduling, and optional Container App hosting |
 | `Setup-GitHubActionServicePrincipal.ps1` | Creates the Entra app and federated credential for GitHub Actions OIDC |
 
+## Maintainer entry points
+
+The root scripts above are the primary user-facing entrypoints. Maintainer and agent workflows should use the repo-owned guides for the rest of the control plane:
+
+- [`build/README.md`](build/README.md) for build, generated-artifact, and validation entrypoints
+- [`tests/README.md`](tests/README.md) for regression, semantic-review, benchmark, and hosted-smoke lanes
+- [`docs/workflows.md`](docs/workflows.md) for GitHub Actions workflow behavior and when each workflow is expected to run
+
 ## Canonical data files
 
 | File | Purpose |

--- a/build/Build-SharedHelpers.ps1
+++ b/build/Build-SharedHelpers.ps1
@@ -18,4 +18,13 @@ if (-not (Test-Path -LiteralPath $manifestToolsPath -PathType Leaf)) {
 . $manifestToolsPath
 
 $artifactManifest = Build-PowerShellArtifactFromManifest -ManifestPath $manifestPath -RepoRoot $repoRoot
+if (-not (Test-Path -LiteralPath $artifactManifest.OutputPath -PathType Leaf)) {
+    throw "Expected generated shared helpers at '$($artifactManifest.OutputPath)'."
+}
+
+$generatedArtifact = Get-Item -LiteralPath $artifactManifest.OutputPath
+if ($generatedArtifact.Length -le 0) {
+    throw "Generated shared helpers artifact is empty: '$($artifactManifest.OutputPath)'."
+}
+
 Write-Host "Generated shared helpers: $($artifactManifest.OutputPath)" -ForegroundColor Green

--- a/build/Build-ValidationHelpers.ps1
+++ b/build/Build-ValidationHelpers.ps1
@@ -18,4 +18,13 @@ if (-not (Test-Path -LiteralPath $manifestToolsPath -PathType Leaf)) {
 . $manifestToolsPath
 
 $artifactManifest = Build-PowerShellArtifactFromManifest -ManifestPath $manifestPath -RepoRoot $repoRoot
+if (-not (Test-Path -LiteralPath $artifactManifest.OutputPath -PathType Leaf)) {
+    throw "Expected generated validation helpers at '$($artifactManifest.OutputPath)'."
+}
+
+$generatedArtifact = Get-Item -LiteralPath $artifactManifest.OutputPath
+if ($generatedArtifact.Length -le 0) {
+    throw "Generated validation helpers artifact is empty: '$($artifactManifest.OutputPath)'."
+}
+
 Write-Host "Generated validation helpers: $($artifactManifest.OutputPath)" -ForegroundColor Green

--- a/build/Invoke-RegressionValidation.ps1
+++ b/build/Invoke-RegressionValidation.ps1
@@ -140,6 +140,8 @@ function Invoke-ArtifactManifestValidation {
         [string[]]$ManifestPaths
     )
 
+    [void](Test-PowerShellArtifactManifestConflict -ManifestPaths $ManifestPaths -RepoRoot $repoRoot)
+
     foreach ($manifestPath in $ManifestPaths) {
         [void](Test-PowerShellArtifactManifestCoverage -ManifestPath $manifestPath -RepoRoot $repoRoot)
     }

--- a/build/README.md
+++ b/build/README.md
@@ -42,6 +42,18 @@ When `-SkipMdePermissions` is paired with Function App execution validation, pas
 
 During seeded Function App validation, the script now writes a short-lived control blob at `dashboards/_diagnostics/ExportAndGenerate.control.json` and polls the runtime status blob at `dashboards/_diagnostics/ExportAndGenerate.status.json`. This makes Flex Consumption execution diagnosable even when admin VFS access and built-in log streaming are unavailable.
 
+## Validation hierarchy
+
+Use the validation entrypoints as a layered stack instead of interchangeable scripts:
+
+| Level | When to use it | Entrypoint | Purpose |
+| --- | --- | --- | --- |
+| 1. Deterministic preflight | Before every PR and before any heavier validation | `.\build\Invoke-RegressionValidation.ps1` | Rebuild generated artifacts, validate manifests, parse scripts, run ScriptAnalyzer, execute shared-helper regressions, run dashboard JS assertions, and smoke-test the committed fixture |
+| 2. Live export integration | When export logic, shipped dashboard behavior, or scheduled-update flow changes | `.\build\Invoke-LiveDashboardDryRun.ps1 -UseExistingAzContext` | Exercise the real export and dashboard-generation path locally with live auth and emit the audit/manifests used by the update workflow |
+| 3. Azure acceptance | Before merging Azure packaging/runtime changes and before release-sensitive perf changes | `.\build\Invoke-AzureDeploymentValidation.ps1 -AutomationAccountName <name> -FunctionAppName <name>` | Rebuild locally, redeploy Azure Automation and Function App, and run seeded live validation in the hosted environment |
+
+Prefer the lightest level that covers the change you made, then escalate only when the changed surface requires it.
+
 ## Fast maintenance loops
 
 When you change `templates/dashboard.js`, run the focused dashboard assertions before the heavier preflight path:
@@ -83,6 +95,23 @@ The generated helper bundles are no longer assembled by scanning a flat source f
 - the output path for the generated artifact
 
 This makes dependency order explicit, lets the regression preflight catch orphaned source files, and makes the source tree easier for agents to navigate by domain instead of by numeric filename prefixes.
+
+### Manifest guardrails
+
+- `sourceRoots` define the only tracked source directories an artifact is allowed to claim.
+- Every `sourceFiles` entry must live under one of that manifest's `sourceRoots`.
+- Generated `outputPath` values must stay outside tracked source roots.
+- A tracked source file should be owned by one artifact manifest only.
+- When you change a manifest or a file under one of its source roots, rebuild the generated artifact before opening a PR.
+
+These checks now fail fast in the build helpers and in the deterministic preflight so manifest drift is easier to catch before CI.
+
+## Agent-safe maintenance patterns
+
+- Treat files under `src/powershell/`, `build/private/`, `build/manifests/`, and `build/azure/` as the source of truth.
+- Do not hand-edit `build/generated/*.ps1`, `azure/Invoke-DashboardPipeline.ps1`, or `azure/function-app/ExportAndGenerate/run.ps1`; regenerate them from the tracked sources instead.
+- When you add a new maintainer entrypoint or review lane, update the corresponding maintainer docs in `build/README.md`, `tests/README.md`, or `docs/workflows.md` in the same change.
+- Prefer shared helpers under `build/private/` and `tests/helpers/` over copying utility functions into new scripts.
 
 ## Staged dashboard workflow
 

--- a/build/private/ArtifactManifestTools.ps1
+++ b/build/private/ArtifactManifestTools.ps1
@@ -15,6 +15,29 @@ function Resolve-RepoRelativePath {
     return [System.IO.Path]::GetFullPath((Join-Path -Path $RepoRoot -ChildPath $RelativePath))
 }
 
+function Test-ArtifactPathWithinRoot {
+    [CmdletBinding()]
+    [OutputType([bool])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Path,
+
+        [Parameter(Mandatory = $true)]
+        [string]$Root
+    )
+
+    $resolvedPath = [System.IO.Path]::GetFullPath($Path)
+    $resolvedRoot = [System.IO.Path]::GetFullPath($Root)
+    $comparison = [System.StringComparison]::OrdinalIgnoreCase
+
+    if ($resolvedPath.Equals($resolvedRoot, $comparison)) {
+        return $true
+    }
+
+    $rootWithSeparator = $resolvedRoot.TrimEnd('\', '/') + [System.IO.Path]::DirectorySeparatorChar
+    return $resolvedPath.StartsWith($rootWithSeparator, $comparison)
+}
+
 function Read-PowerShellArtifactManifest {
     [CmdletBinding()]
     [OutputType([pscustomobject])]
@@ -73,11 +96,59 @@ function Read-PowerShellArtifactManifest {
         }
     )
 
+    $relativeSourceRootCounts = @{}
+    foreach ($relativePath in @($sourceRoots | ForEach-Object { [string]$_ })) {
+        if ($relativeSourceRootCounts.ContainsKey($relativePath)) {
+            $relativeSourceRootCounts[$relativePath]++
+        }
+        else {
+            $relativeSourceRootCounts[$relativePath] = 1
+        }
+    }
+
+    $duplicateSourceRoots = @($relativeSourceRootCounts.GetEnumerator() | Where-Object { $_.Value -gt 1 } | Sort-Object Name)
+    if ($duplicateSourceRoots.Count -gt 0) {
+        $duplicateList = @($duplicateSourceRoots | ForEach-Object { $_.Name }) -join ', '
+        throw "Artifact manifest '$ManifestPath' contains duplicate sourceRoots: $duplicateList"
+    }
+
+    for ($leftIndex = 0; $leftIndex -lt $resolvedSourceRoots.Count; $leftIndex++) {
+        for ($rightIndex = $leftIndex + 1; $rightIndex -lt $resolvedSourceRoots.Count; $rightIndex++) {
+            $leftRoot = $resolvedSourceRoots[$leftIndex]
+            $rightRoot = $resolvedSourceRoots[$rightIndex]
+            if ((Test-ArtifactPathWithinRoot -Path $leftRoot -Root $rightRoot) -or (Test-ArtifactPathWithinRoot -Path $rightRoot -Root $leftRoot)) {
+                $leftRelativeRoot = [string]$sourceRoots[$leftIndex]
+                $rightRelativeRoot = [string]$sourceRoots[$rightIndex]
+                throw "Artifact manifest '$ManifestPath' contains overlapping sourceRoots '$leftRelativeRoot' and '$rightRelativeRoot'."
+            }
+        }
+    }
+
+    foreach ($sourceFile in $resolvedSourceFiles) {
+        $matchingRoots = @($resolvedSourceRoots | Where-Object { Test-ArtifactPathWithinRoot -Path $sourceFile -Root $_ })
+        if ($matchingRoots.Count -eq 0) {
+            $relativeFilePath = $sourceFile.Substring([System.IO.Path]::GetFullPath($RepoRoot).Length + 1).Replace('\', '/')
+            throw "Artifact manifest '$ManifestPath' references source file '$relativeFilePath' outside the declared sourceRoots."
+        }
+    }
+
+    $resolvedOutputPath = Resolve-RepoRelativePath -RepoRoot $RepoRoot -RelativePath ([string]$manifest.outputPath)
+    foreach ($sourceRootPath in $resolvedSourceRoots) {
+        if (Test-ArtifactPathWithinRoot -Path $resolvedOutputPath -Root $sourceRootPath) {
+            $relativeRootPath = $sourceRoots[[array]::IndexOf($resolvedSourceRoots, $sourceRootPath)]
+            throw "Artifact manifest '$ManifestPath' writes output '$($manifest.outputPath)' inside sourceRoot '$relativeRootPath'. Generated outputs must stay outside tracked source roots."
+        }
+    }
+
+    if ($resolvedSourceFiles -contains $resolvedOutputPath) {
+        throw "Artifact manifest '$ManifestPath' outputPath '$($manifest.outputPath)' conflicts with a source file entry."
+    }
+
     return [PSCustomObject]@{
         ManifestPath = [System.IO.Path]::GetFullPath($ManifestPath)
         ArtifactName = [string]$manifest.artifactName
         Description = [string]$manifest.description
-        OutputPath = Resolve-RepoRelativePath -RepoRoot $RepoRoot -RelativePath ([string]$manifest.outputPath)
+        OutputPath = $resolvedOutputPath
         OutputRelativePath = [string]$manifest.outputPath
         SourceFiles = @($resolvedSourceFiles)
         SourceRelativePaths = @($sourceFileEntries | ForEach-Object { [string]$_ })
@@ -241,6 +312,44 @@ function Test-PowerShellArtifactManifestCoverage {
     if ($orphanedFiles.Count -gt 0) {
         $orphanedList = @($orphanedFiles | ForEach-Object { $_.Substring($RepoRoot.Length + 1).Replace('\\', '/') }) -join ', '
         throw "Artifact manifest '$ManifestPath' does not include all source files under its sourceRoots. Missing entries: $orphanedList"
+    }
+
+    return $true
+}
+
+function Test-PowerShellArtifactManifestConflict {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string[]]$ManifestPaths,
+
+        [Parameter(Mandatory = $true)]
+        [string]$RepoRoot
+    )
+
+    $sourceFileOwners = @{}
+    $outputPathOwners = @{}
+
+    foreach ($manifestPath in $ManifestPaths) {
+        $manifest = Read-PowerShellArtifactManifest -ManifestPath $manifestPath -RepoRoot $RepoRoot
+
+        foreach ($sourceFile in $manifest.SourceFiles) {
+            if ($sourceFileOwners.ContainsKey($sourceFile)) {
+                $existingOwner = [string]$sourceFileOwners[$sourceFile]
+                $relativeSourceFile = $sourceFile.Substring([System.IO.Path]::GetFullPath($RepoRoot).Length + 1).Replace('\', '/')
+                throw "Artifact manifest '$manifestPath' reuses source file '$relativeSourceFile' already claimed by '$existingOwner'."
+            }
+
+            $sourceFileOwners[$sourceFile] = [System.IO.Path]::GetFullPath($manifestPath)
+        }
+
+        if ($outputPathOwners.ContainsKey($manifest.OutputPath)) {
+            $existingOwner = [string]$outputPathOwners[$manifest.OutputPath]
+            $relativeOutputPath = $manifest.OutputPath.Substring([System.IO.Path]::GetFullPath($RepoRoot).Length + 1).Replace('\', '/')
+            throw "Artifact manifest '$manifestPath' reuses outputPath '$relativeOutputPath' already claimed by '$existingOwner'."
+        }
+
+        $outputPathOwners[$manifest.OutputPath] = [System.IO.Path]::GetFullPath($manifestPath)
     }
 
     return $true

--- a/docs/performance-gate-playbook.md
+++ b/docs/performance-gate-playbook.md
@@ -52,6 +52,12 @@ Guardrails:
 - `tests/Invoke-HotPhaseReview.ps1` now defaults to artifact parity review instead of semantic replay.
 - Use `-ValidationMode semantic` only when you are intentionally investigating semantic audit cost or validating semantic changes.
 - Large local semantic runs above the configured row limit require `-AllowLargeSemanticValidation` so they are not started accidentally.
+- `tests/Invoke-HotPhaseReview.ps1`, `tests/Invoke-ValidationModeComparison.ps1`, `tests/Measure-BranchVsMainBenchmark.ps1`, `tests/Measure-StressRun.ps1`, and `tests/Invoke-WithPwshMemoryGuard.ps1` rely on Windows memory-sampling primitives.
+
+Semantic validation guardrails:
+- The default local semantic row limit is `1,000,000` rows; the routine medium dataset stays under that limit, while the standard `synthetic-50k-1_5m` sign-off lane does not.
+- Use `tests/Invoke-RoutineSemanticReview.ps1` for repeatable branch iteration and reserve `-AllowLargeSemanticValidation` for intentional final-signoff or high-risk investigations.
+- If you need browser-level hosted coverage, pair the deterministic preflight with `tests/Invoke-HostedDashboardRuntimeSmoke.ps1` on Windows instead of escalating directly to the large semantic lane.
 
 Timing interpretation:
 - Azure Automation already tracks active execution time from job start to job end.

--- a/docs/source-layout.md
+++ b/docs/source-layout.md
@@ -34,6 +34,14 @@ This repository now treats generated helper bundles as build artifacts, not as t
 3. Rebuild with `./build/Build-SharedHelpers.ps1` or `./build/Build-ValidationHelpers.ps1` as needed.
 4. Run `./build/Invoke-RegressionValidation.ps1` before merge.
 
+## Agent-safe change guardrails
+
+- Treat `src/powershell/**`, `build/private/**`, `build/manifests/**`, and `build/azure/**` as the authoritative sources.
+- Treat `build/generated/*.ps1`, `azure/Invoke-DashboardPipeline.ps1`, and `azure/function-app/ExportAndGenerate/run.ps1` as derived outputs.
+- Keep each tracked source file owned by one manifest and keep generated outputs outside tracked source roots.
+- If you add a new maintainer workflow or validation lane, update the matching maintainer docs (`build/README.md`, `tests/README.md`, and `docs/workflows.md`) in the same PR.
+- Reuse helpers from `tests/helpers/` or `build/private/` before introducing duplicate utility functions in new scripts.
+
 ## Remaining decomposition watchlist
 
 The current overhaul has moved helper ownership out of the large top-level entry scripts and into explicit source-first domains. The remaining follow-up work is narrower and currently centered on:

--- a/tests/README.md
+++ b/tests/README.md
@@ -8,6 +8,21 @@ This folder contains lightweight PowerShell regression coverage for the Defender
 - `tests/manual/` contains ad hoc troubleshooting harnesses that are useful during development but are not part of `build/Invoke-RegressionValidation.ps1`.
 - The top-level scripts in `tests/` are the supported automation entrypoints for regression validation, stress generation, benchmarking, and synthetic live-export creation.
 
+## Platform support
+
+Some entrypoints are cross-platform and some depend on Windows memory-sampling primitives or Microsoft Edge.
+
+| Entrypoint | Windows | macOS | Linux | Notes |
+| --- | --- | --- | --- | --- |
+| `build/Invoke-RegressionValidation.ps1` | Yes | Yes | Yes | Primary deterministic preflight |
+| `build/Invoke-LiveDashboardDryRun.ps1` | Yes | Yes | Yes | Requires the right Az/auth context |
+| `tests/Invoke-HotPhaseReview.ps1` | Yes | No | No | Uses Windows memory/process sampling |
+| `tests/Invoke-ValidationModeComparison.ps1` | Yes | No | No | Uses Windows memory/process sampling |
+| `tests/Measure-BranchVsMainBenchmark.ps1` | Yes | No | No | Uses Windows memory/process sampling |
+| `tests/Measure-StressRun.ps1` | Yes | No | No | Uses Windows memory/process sampling |
+| `tests/Invoke-WithPwshMemoryGuard.ps1` | Yes | No | No | Uses Windows memory/process sampling |
+| `tests/Invoke-HostedDashboardRuntimeSmoke.ps1` | Yes | No | No | Requires Microsoft Edge; use `-AllowSkip` when optional |
+
 ## Deterministic preflight entrypoint
 
 Run the full local regression bundle with:
@@ -17,6 +32,22 @@ pwsh -NoProfile -File .\build\Invoke-RegressionValidation.ps1
 ```
 
 That script is the authoritative deterministic preflight used for local work and PR validation. It rebuilds the generated deployment artifacts, runs parser and PSScriptAnalyzer checks across source scripts, executes focused shared-helper regression tests, and performs a small dashboard fixture smoke generation.
+
+The shared-helper regression lane now logs `START <Test-Name>` and a per-test elapsed time. If the preflight looks slow, use that output to identify the active or expensive test before assuming the suite is hung.
+
+## Test lanes at a glance
+
+| Lane | Primary entrypoint | Use it for |
+| --- | --- | --- |
+| Deterministic regression gate | `build/Invoke-RegressionValidation.ps1` | Every PR and before heavier validation |
+| Live export integration | `build/Invoke-LiveDashboardDryRun.ps1 -UseExistingAzContext` | Export/authentication/shipped-dashboard changes |
+| Hosted browser/runtime smoke | `tests/Invoke-HostedDashboardRuntimeSmoke.ps1` | Split-assets delivery or hosted runtime changes |
+| Local perf phase review | `tests/Invoke-HotPhaseReview.ps1` | Normalization, payload, validation, or packaging perf work |
+| Routine semantic review | `tests/Invoke-RoutineSemanticReview.ps1` | Repeatable medium-dataset semantic review during iteration |
+| Benchmarking and stress tools | `tests/Invoke-BenchmarkSeries.ps1`, `tests/Measure-BranchVsMainBenchmark.ps1`, `tests/Measure-StressRun.ps1` | Comparative or historical performance work |
+| Manual diagnostics | `tests/manual/` | Ad hoc troubleshooting only |
+
+Helper rule: if a new test or benchmark script needs shared utilities, put them in `tests/helpers/` instead of copying helper functions into multiple entrypoints.
 
 ## CI-aligned live dry run
 
@@ -218,6 +249,19 @@ That command:
 
 Use this workflow for routine semantic or validation review during iteration, then keep the full `synthetic-50k-1_5m` semantic gate for release sign-off and high-risk normalization changes.
 
+## Hosted dashboard runtime smoke
+
+Run the hosted dashboard through a non-visual Edge smoke when split-assets delivery changes or when you want an explicit browser-runtime check:
+
+```powershell
+pwsh -NoProfile -File .\tests\Invoke-HostedDashboardRuntimeSmoke.ps1 -DashboardPath <hosted-html-path>
+```
+
+Notes:
+- this lane requires Windows and Microsoft Edge
+- use `-AllowSkip` when you want optional local coverage on machines without Edge
+- pair it with `build/Invoke-RegressionValidation.ps1`; it supplements the deterministic gate instead of replacing it
+
 ## Validation mode comparison
 
 Split packaging, full validation, and attested validation into separate measured runs with:
@@ -234,6 +278,17 @@ That command:
 - writes `validation-mode-comparison.json` under `.local/validation-mode-comparison/<timestamp>/`
 
 Use this workflow when validation is the dominant hot phase and you need to distinguish package cost from semantic replay cost.
+
+## Benchmark and stress tool selection
+
+| Goal | Preferred entrypoint | Notes |
+| --- | --- | --- |
+| One-command repeated local benchmark on the durable dataset | `tests/Invoke-BenchmarkSeries.ps1` | Use when refreshing or comparing repeatable local baselines |
+| Current branch vs. main or a one-off branch capture | `tests/Measure-BranchVsMainBenchmark.ps1` | Best for side-by-side local comparison |
+| Phase-by-phase local review | `tests/Invoke-HotPhaseReview.ps1` | Start here before heavier benchmark or Azure work |
+| Medium-dataset semantic validation during iteration | `tests/Invoke-RoutineSemanticReview.ps1` | Preferred semantic lane for routine branch work |
+| Validation cost split between packaging and semantic replay | `tests/Invoke-ValidationModeComparison.ps1` | Use when validation time dominates |
+| Custom stress capture | `tests/Measure-StressRun.ps1` | Reserve for targeted stress investigation, not routine branch validation |
 
 ## Benchmarking
 

--- a/tests/Run-SharedHelperRegression.ps1
+++ b/tests/Run-SharedHelperRegression.ps1
@@ -44,6 +44,184 @@ function Get-OutputRecordText {
     return ($Record | Out-String).Trim()
 }
 
+function Test-ArtifactManifestRejectsOutputInsideSourceRoot {
+    [CmdletBinding()]
+    param()
+
+    $repoRoot = Split-Path -Path $PSScriptRoot -Parent
+    $artifactManifestToolsPath = Join-Path $repoRoot 'build\private\ArtifactManifestTools.ps1'
+    Assert-True ((Test-Path -LiteralPath $artifactManifestToolsPath -PathType Leaf)) "Expected artifact manifest helper script at '$artifactManifestToolsPath'."
+
+    $tempRoot = Join-Path ([System.IO.Path]::GetTempPath()) ('artifact-manifest-output-root-' + [guid]::NewGuid().ToString('N'))
+    try {
+        [void](New-Item -Path (Join-Path $tempRoot 'src\powershell\Shared') -ItemType Directory -Force)
+        [void](New-Item -Path (Join-Path $tempRoot 'build\manifests') -ItemType Directory -Force)
+        Set-Content -LiteralPath (Join-Path $tempRoot 'src\powershell\Shared\Core.ps1') -Value 'function Invoke-TestManifestHelper { }' -Encoding utf8
+
+        $manifestPath = Join-Path $tempRoot 'build\manifests\artifact-test.json'
+        $manifest = [ordered]@{
+            artifactName = 'artifact-test'
+            outputPath = 'src/powershell/Shared/generated-helper.ps1'
+            sourceRoots = @('src/powershell/Shared')
+            sourceFiles = @('src/powershell/Shared/Core.ps1')
+        }
+        $manifest | ConvertTo-Json -Depth 10 | Set-Content -LiteralPath $manifestPath -Encoding utf8
+
+        $failure = $null
+        try {
+            . $artifactManifestToolsPath
+            $null = Read-PowerShellArtifactManifest -ManifestPath $manifestPath -RepoRoot $tempRoot
+        }
+        catch {
+            $failure = $_
+        }
+
+        Assert-True ($null -ne $failure) 'Expected manifest validation to reject generated outputs under a tracked sourceRoot.'
+        Assert-True (($failure.Exception.Message -like '*inside sourceRoot*') -or ($failure.Exception.Message -like '*Generated outputs must stay outside tracked source roots*')) 'Expected manifest validation failure to explain that generated outputs must stay outside sourceRoots.'
+    }
+    finally {
+        if (Test-Path -LiteralPath $tempRoot) {
+            Remove-Item -LiteralPath $tempRoot -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+}
+
+function Test-ArtifactManifestRejectsSourceRootOverlap {
+    [CmdletBinding()]
+    param()
+
+    $repoRoot = Split-Path -Path $PSScriptRoot -Parent
+    $artifactManifestToolsPath = Join-Path $repoRoot 'build\private\ArtifactManifestTools.ps1'
+    Assert-True ((Test-Path -LiteralPath $artifactManifestToolsPath -PathType Leaf)) "Expected artifact manifest helper script at '$artifactManifestToolsPath'."
+
+    $tempRoot = Join-Path ([System.IO.Path]::GetTempPath()) ('artifact-manifest-overlap-' + [guid]::NewGuid().ToString('N'))
+    try {
+        [void](New-Item -Path (Join-Path $tempRoot 'src\powershell\Shared\Nested') -ItemType Directory -Force)
+        [void](New-Item -Path (Join-Path $tempRoot 'build\manifests') -ItemType Directory -Force)
+        Set-Content -LiteralPath (Join-Path $tempRoot 'src\powershell\Shared\Nested\Helper.ps1') -Value 'function Invoke-TestNestedManifestHelper { }' -Encoding utf8
+
+        $manifestPath = Join-Path $tempRoot 'build\manifests\artifact-test.json'
+        $manifest = [ordered]@{
+            artifactName = 'artifact-test'
+            outputPath = 'build/generated/shared-helper.ps1'
+            sourceRoots = @(
+                'src/powershell/Shared'
+                'src/powershell/Shared/Nested'
+            )
+            sourceFiles = @('src/powershell/Shared/Nested/Helper.ps1')
+        }
+        $manifest | ConvertTo-Json -Depth 10 | Set-Content -LiteralPath $manifestPath -Encoding utf8
+
+        $failure = $null
+        try {
+            . $artifactManifestToolsPath
+            $null = Read-PowerShellArtifactManifest -ManifestPath $manifestPath -RepoRoot $tempRoot
+        }
+        catch {
+            $failure = $_
+        }
+
+        Assert-True ($null -ne $failure) 'Expected manifest validation to reject overlapping sourceRoots.'
+        Assert-True ($failure.Exception.Message -like '*overlapping sourceRoots*') 'Expected manifest validation failure to call out overlapping sourceRoots.'
+    }
+    finally {
+        if (Test-Path -LiteralPath $tempRoot) {
+            Remove-Item -LiteralPath $tempRoot -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+}
+
+function Test-ArtifactManifestRejectsSourceFileOutsideSourceRoot {
+    [CmdletBinding()]
+    param()
+
+    $repoRoot = Split-Path -Path $PSScriptRoot -Parent
+    $artifactManifestToolsPath = Join-Path $repoRoot 'build\private\ArtifactManifestTools.ps1'
+    Assert-True ((Test-Path -LiteralPath $artifactManifestToolsPath -PathType Leaf)) "Expected artifact manifest helper script at '$artifactManifestToolsPath'."
+
+    $tempRoot = Join-Path ([System.IO.Path]::GetTempPath()) ('artifact-manifest-outside-root-' + [guid]::NewGuid().ToString('N'))
+    try {
+        [void](New-Item -Path (Join-Path $tempRoot 'src\powershell\Shared') -ItemType Directory -Force)
+        [void](New-Item -Path (Join-Path $tempRoot 'src\powershell\Validation') -ItemType Directory -Force)
+        [void](New-Item -Path (Join-Path $tempRoot 'build\manifests') -ItemType Directory -Force)
+        Set-Content -LiteralPath (Join-Path $tempRoot 'src\powershell\Validation\ValidationHelper.ps1') -Value 'function Invoke-TestValidationHelper { }' -Encoding utf8
+
+        $manifestPath = Join-Path $tempRoot 'build\manifests\artifact-test.json'
+        $manifest = [ordered]@{
+            artifactName = 'artifact-test'
+            outputPath = 'build/generated/shared-helper.ps1'
+            sourceRoots = @('src/powershell/Shared')
+            sourceFiles = @('src/powershell/Validation/ValidationHelper.ps1')
+        }
+        $manifest | ConvertTo-Json -Depth 10 | Set-Content -LiteralPath $manifestPath -Encoding utf8
+
+        $failure = $null
+        try {
+            . $artifactManifestToolsPath
+            $null = Read-PowerShellArtifactManifest -ManifestPath $manifestPath -RepoRoot $tempRoot
+        }
+        catch {
+            $failure = $_
+        }
+
+        Assert-True ($null -ne $failure) 'Expected manifest validation to reject source files outside the declared sourceRoots.'
+        Assert-True ($failure.Exception.Message -like '*outside the declared sourceRoots*') 'Expected manifest validation failure to explain the source-file boundary violation.'
+    }
+    finally {
+        if (Test-Path -LiteralPath $tempRoot) {
+            Remove-Item -LiteralPath $tempRoot -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+}
+
+function Test-ArtifactManifestRejectsCrossArtifactSourceConflict {
+    [CmdletBinding()]
+    param()
+
+    $repoRoot = Split-Path -Path $PSScriptRoot -Parent
+    $artifactManifestToolsPath = Join-Path $repoRoot 'build\private\ArtifactManifestTools.ps1'
+    Assert-True ((Test-Path -LiteralPath $artifactManifestToolsPath -PathType Leaf)) "Expected artifact manifest helper script at '$artifactManifestToolsPath'."
+
+    $tempRoot = Join-Path ([System.IO.Path]::GetTempPath()) ('artifact-manifest-conflict-' + [guid]::NewGuid().ToString('N'))
+    try {
+        [void](New-Item -Path (Join-Path $tempRoot 'src\powershell\Shared') -ItemType Directory -Force)
+        [void](New-Item -Path (Join-Path $tempRoot 'build\manifests') -ItemType Directory -Force)
+        Set-Content -LiteralPath (Join-Path $tempRoot 'src\powershell\Shared\SharedHelper.ps1') -Value 'function Invoke-TestConflictHelper { }' -Encoding utf8
+
+        $sharedManifestPath = Join-Path $tempRoot 'build\manifests\shared.json'
+        $validationManifestPath = Join-Path $tempRoot 'build\manifests\validation.json'
+        [ordered]@{
+            artifactName = 'shared-helpers'
+            outputPath = 'build/generated/shared-helper.ps1'
+            sourceRoots = @('src/powershell/Shared')
+            sourceFiles = @('src/powershell/Shared/SharedHelper.ps1')
+        } | ConvertTo-Json -Depth 10 | Set-Content -LiteralPath $sharedManifestPath -Encoding utf8
+        [ordered]@{
+            artifactName = 'validation-helpers'
+            outputPath = 'build/generated/validation-helper.ps1'
+            sourceRoots = @('src/powershell/Shared')
+            sourceFiles = @('src/powershell/Shared/SharedHelper.ps1')
+        } | ConvertTo-Json -Depth 10 | Set-Content -LiteralPath $validationManifestPath -Encoding utf8
+
+        $failure = $null
+        try {
+            . $artifactManifestToolsPath
+            $null = Test-PowerShellArtifactManifestConflict -ManifestPaths @($sharedManifestPath, $validationManifestPath) -RepoRoot $tempRoot
+        }
+        catch {
+            $failure = $_
+        }
+
+        Assert-True ($null -ne $failure) 'Expected manifest conflict validation to reject shared source file ownership across artifacts.'
+        Assert-True (-not [string]::IsNullOrWhiteSpace([string]$failure.Exception.Message)) 'Expected manifest conflict validation failure to produce a useful error message.'
+    }
+    finally {
+        if (Test-Path -LiteralPath $tempRoot) {
+            Remove-Item -LiteralPath $tempRoot -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+}
+
 function Get-TestVulnRow {
     [CmdletBinding()]
     param(
@@ -4755,169 +4933,120 @@ function Test-FunctionExecutionStatusSummaryIncludesNormalizationProgressInfo {
     Assert-True ($summary -notlike '*rows=125.000*') 'Expected validation status summary text to avoid host-culture row count formatting.'
 }
 
+function Invoke-SharedHelperRegressionTest {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Name,
+
+        [Parameter(Mandatory = $true)]
+        [string]$SuccessMessage
+    )
+
+    $testCommand = Get-Command -Name $Name -CommandType Function -ErrorAction Stop
+    $stopwatch = [System.Diagnostics.Stopwatch]::StartNew()
+
+    Write-Output ("START {0}" -f $Name)
+    & $testCommand
+    $stopwatch.Stop()
+
+    Write-Output ("  {0} ({1} ms)" -f $SuccessMessage, $stopwatch.ElapsedMilliseconds)
+}
+
 Write-Output 'Running shared-helper regression checks...'
-Test-CanonicalLayoutHelper
-Write-Output '  Canonical layout helper checks passed.'
-Test-FileSetFingerprintIgnoresTimestampChange
-Write-Output '  File-set fingerprint stability checks passed.'
-Test-NormalizedPayloadCacheRejectsManifestHashMismatch
-Write-Output '  Normalized payload cache integrity checks passed.'
-Test-NormalizedPayloadManifestSourceSummary
-Write-Output '  Normalized payload source metadata checks passed.'
-Test-SaveJSLibraryFileRefreshesEmptyCache
-Write-Output '  JavaScript library cache refresh checks passed.'
-Test-VulnContentStoreExistenceNeedsRef
-Write-Output '  Content-store existence checks passed.'
-Test-LocalExportArtifactCleanup
-Write-Output '  Local export artifact cleanup checks passed.'
-Test-InitializeMachineHistoryStoreBackfillsCurrentRecordMetadata
-Write-Output '  Machine store initialization checks passed.'
-Test-MachineHistoryRemovePathsAllowsEmptyPublishedHistorySet
-Write-Output '  Machine history cleanup empty-set checks passed.'
-Test-BulkSnapshotImportSmoke
-Write-Output '  Bulk snapshot import smoke checks passed.'
-Test-BulkSnapshotImportSingleSnapshot
-Write-Output '  Single-snapshot vulnerability import checks passed.'
-Test-BulkSnapshotImportMultipartSnapshot
-Write-Output '  Multipart vulnerability import checks passed.'
-Test-BulkSnapshotImportMergesIntoExistingCanonicalStore
-Write-Output '  Existing-store vulnerability merge checks passed.'
-Test-HttpRetryDelayHelperBehavior
-Write-Output '  Retry delay helper checks passed.'
-Test-WebRequestWithRetryTransientTransportBehavior
-Write-Output '  Web request transient transport retry checks passed.'
-Test-BulkVulnerabilitySnapshotDownloadMultipartNameUniqueness
-Write-Output '  Multipart vulnerability download naming checks passed.'
-Test-BulkVulnerabilitySnapshotDownloadStagingBehavior
-Write-Output '  Multipart vulnerability download staging checks passed.'
-Test-BulkVulnerabilitySnapshotDownloadRetriesEmptyBlob
-Write-Output '  Multipart vulnerability empty-blob retry checks passed.'
-Test-BulkVulnerabilitySnapshotDownloadEmptyBlobExhaustionBehavior
-Write-Output '  Multipart vulnerability empty-blob retry exhaustion checks passed.'
-Test-BulkVulnerabilitySnapshotDownloadMoveFailureCleanupBehavior
-Write-Output '  Multipart vulnerability move-failure cleanup checks passed.'
-Test-BulkVulnerabilitySnapshotDownloadCleanupBehavior
-Write-Output '  Multipart vulnerability failed-download cleanup checks passed.'
-Test-VulnCurrentFileRejectsDuplicateId
-Write-Output '  Current-file duplicate Id checks passed.'
-Test-RepairVulnHistoryLayoutSkipsCanonicalQuarterlyStore
-Write-Output '  Canonical quarterly history repair skip checks passed.'
-Test-VulnStoreRequiresCanonicalRepairDetectsMalformedQuarterlyHistory
-Write-Output '  Canonical quarterly history gate checks passed.'
-Test-RepairVulnHistoryLayoutRebuildsCanonicalQuarterlyRowSidecar
-Write-Output '  Canonical quarterly rows-sidecar repair checks passed.'
-Test-RepairVulnHistoryLayoutRepairsLegacyYearlyStore
-Write-Output '  Legacy yearly history repair checks passed.'
-Test-VulnHistoryFileValidatesQuarterlyHistoryDocument
-Write-Output '  Quarterly history validation checks passed.'
-Test-VulnCanonicalSignatureStability
-Write-Output '  Canonical vulnerability signature checks passed.'
-Test-MergeVulnObservedWindowRows
-Write-Output '  Vulnerability observation merge checks passed.'
-Test-ReadNormalizedVulnStoreRow
-Write-Output '  Normalized vulnerability store reader checks passed.'
-Test-ResolveNormalizedLookupIndexListHandlesScalarAndCollectionValues
-Write-Output '  Lookup index list normalization checks passed.'
-Test-ResolveNormalizedInventoryLookupSkipsEmptyInventoryData
-Write-Output '  Inventory lookup normalization checks passed.'
-Test-AddNormalizedCveUsesStableSeverityIndexLookup
-Write-Output '  CVE severity lookup checks passed.'
-Test-GetNormalizedRecordLookupHandlesScalarPathInputs
-Write-Output '  Scalar path lookup checks passed.'
-Test-InvokeNormalizationProgressCallbackUsesCountAndHeartbeat
-Write-Output '  Normalization progress callback cadence checks passed.'
-Test-ConvertToNormalizedDataReportsContentStoreNormalizationPhase
-Write-Output '  Content-store normalization phase callback checks passed.'
-Test-ConvertToNormalizedDataUsesStableDeviceIdFallback
-Write-Output '  Stable device fallback identity checks passed.'
-Test-ConvertToNormalizedDataWritesExpectedRowCount
-Write-Output '  Normalized vuln row-count checks passed.'
-Test-ConvertToNormalizedDataWritesDirectPayload
-Write-Output '  Direct payload normalization checks passed.'
-Test-ConvertToNormalizedDataPreservesOptionalNvdFallback
-Write-Output '  Optional NVD fallback normalization checks passed.'
-Test-ConvertToNormalizedDataCanConsumeLookupsOnPayloadClose
-Write-Output '  Consuming payload-close lookup checks passed.'
-Test-ConvertToNormalizedDataContentStorePathDoesNotUseLegacyDictionaryReader
-Write-Output '  Content-store streaming normalization checks passed.'
-Test-InvokeContentStoreNormalizationReleasesTransientContextBeforePayloadClose
-Write-Output '  Content-store transient context-release and hosted-memory diagnostics checks passed.'
-Test-ConvertToNormalizedDataDeduplicatesRepeatedCveLookup
-Write-Output '  Repeated CVE lookup deduplication checks passed.'
-Test-ConvertToNormalizedDataReportsZeroOnboardedContentStoreDiagnostic
-Write-Output '  Zero-onboarded content-store diagnostics checks passed.'
-Test-ConvertToNormalizedDataIncludesAdvancedHuntingDeviceUserMap
-Write-Output '  Advanced Hunting device-user normalization checks passed.'
-Test-WriteCombinedPayloadGzipPreservesColumnPayload
-Write-Output '  Combined payload writer column-path checks passed.'
-Test-NormalizedVulnColumnCacheRebuildsPayloadWithFreshLookups
-Write-Output '  Normalized vuln column cache reuse checks passed.'
-Test-NormalizedVulnColumnCacheRefreshesInventoryColumn
-Write-Output '  Inventory-backed normalized vuln column cache reuse checks passed.'
-Test-WriteBase64FileContentMatchesReferenceOutput
-Write-Output '  Streamed base64 writer checks passed.'
-Test-BenchmarkSeriesSummaryHandlesAzureOnlyRunMode
-Test-BenchmarkSeriesSummaryHandlesCombinedRunMode
-Test-BenchmarkSeriesSummaryHandlesLocalOnlyRunMode
-Test-BenchmarkIncludesLocalRunHandlesLegacyInferenceShape
-Test-BenchmarkModeScenarioKeyHandlesLegacyModeMapping
-Write-Output '  Benchmark series mode checks passed.'
-Test-WriteProgressMarkerIncludesEtaWhenTotalCountKnown
-Write-Output '  Progress marker ETA checks passed.'
-Test-WriteCombinedPayloadGzipCanConsumeColumnLookupData
-Write-Output '  Payload lookup consumption checks passed.'
-Test-GetDashboardEmbeddedPayloadInspectionStreamsSelfContainedPayload
-Write-Output '  Embedded payload inspection checks passed.'
-Test-MeasureStressRunWritesProgressAndFinalReport
-Write-Output '  Measure-StressRun report persistence checks passed.'
-Test-ValidationHelperPayloadCanonicalization
-Write-Output '  Validation helper payload-format checks passed.'
-Test-ValidationHelperSourceCanonicalization
-Write-Output '  Validation helper source canonicalization checks passed.'
-Test-ValidationHelperStandaloneImport
-Write-Output '  Validation helper standalone import checks passed.'
-Test-DashboardValidationFailureExtendedEnrichmentGate
-Write-Output '  Validation helper failure-gate checks passed.'
-Test-StreamingDashboardAuditDetectsSourceMismatchDespitePayloadParity
-Write-Output '  Streaming dashboard source-parity checks passed.'
-Test-StreamingDashboardAuditReusesCachedPayloadSignatureSet
-Write-Output '  Streaming dashboard payload-signature reuse checks passed.'
-Test-DashboardAuditBootstrapsSyntheticLargePayloadCacheWithNormalizationLookup
-Write-Output '  Dashboard synthetic large-dataset bootstrap checks passed.'
-Test-DashboardValidationUsesStableFallbackDeviceProfile
-Write-Output '  Dashboard validation fallback device profile checks passed.'
-Test-DashboardOpenStateAuditUsesPatchEvidenceAndInactivityCutoff
-Write-Output '  Dashboard open-state audit checks passed.'
-Test-DashboardValidationPreservesNoneSeverityData
-Write-Output '  Dashboard none-severity validation checks passed.'
-Test-DashboardSplitAssetsGenerationAndValidation
-Write-Output '  Dashboard split-assets generation and validation checks passed.'
-Test-DashboardValidateOnlyFailsWhenHostedPayloadMissing
-Write-Output '  Hosted dashboard missing-payload negative checks passed.'
-Test-PackageOnlyRejectsMismatchedNormalizedPayloadManifest
-Write-Output '  Package-only manifest mismatch negative checks passed.'
-Test-DashboardDualPackagingGenerationAndValidation
-Write-Output '  Dashboard dual packaging generation and validation checks passed.'
-Test-AdvancedHuntingBundleMatchesDedicatedReaderData
-Write-Output '  Advanced Hunting bundle reader checks passed.'
-Test-AdvancedHuntingBundleStringArrayFiltersSparseInputs
-Write-Output '  Advanced Hunting bundle sparse string-array checks passed.'
-Test-ReadNormalizationMachineLookupMatchesCompressedMachineLookup
-Write-Output '  Machine tuple reader checks passed.'
-Test-NormalizationMachineTupleExtendsLegacyTuple
-Write-Output '  Machine tuple extension checks passed.'
-Test-LegacyMachineTupleFallbackPreservesProjectedRowMetadata
-Write-Output '  Legacy tuple fallback checks passed.'
-Test-SourceCveEnrichmentReadsExploitAvailabilityFromObjectRecord
-Write-Output '  Source enrichment exploit-availability checks passed.'
-Test-VulnPropertyHelpersSupportSupportedRowShapes
-Write-Output '  Vulnerability property helper shape checks passed.'
-Test-VulnContentStoreRoundTrip
-Write-Output '  Vulnerability content store round-trip checks passed.'
-Test-VulnObservedWindowCacheRoundTrip
-Write-Output '  Observed-window cache round-trip checks passed.'
-Test-FunctionAppWriteOutputNoEnumeratePreservesJObject
-Write-Output '  Function App Write-Output -NoEnumerate checks passed.'
-Test-FunctionExecutionStatusSummaryIncludesNormalizationProgressInfo
-Write-Output '  Function execution status summary metadata checks passed.'
+$sharedHelperRegressionTests = @(
+    @{ Name = 'Test-ArtifactManifestRejectsOutputInsideSourceRoot'; SuccessMessage = 'Artifact manifest output-root guard checks passed.' }
+    @{ Name = 'Test-ArtifactManifestRejectsSourceRootOverlap'; SuccessMessage = 'Artifact manifest overlap guard checks passed.' }
+    @{ Name = 'Test-ArtifactManifestRejectsSourceFileOutsideSourceRoot'; SuccessMessage = 'Artifact manifest source-root boundary checks passed.' }
+    @{ Name = 'Test-ArtifactManifestRejectsCrossArtifactSourceConflict'; SuccessMessage = 'Artifact manifest cross-artifact conflict checks passed.' }
+    @{ Name = 'Test-CanonicalLayoutHelper'; SuccessMessage = 'Canonical layout helper checks passed.' }
+    @{ Name = 'Test-FileSetFingerprintIgnoresTimestampChange'; SuccessMessage = 'File-set fingerprint stability checks passed.' }
+    @{ Name = 'Test-NormalizedPayloadCacheRejectsManifestHashMismatch'; SuccessMessage = 'Normalized payload cache integrity checks passed.' }
+    @{ Name = 'Test-NormalizedPayloadManifestSourceSummary'; SuccessMessage = 'Normalized payload source metadata checks passed.' }
+    @{ Name = 'Test-SaveJSLibraryFileRefreshesEmptyCache'; SuccessMessage = 'JavaScript library cache refresh checks passed.' }
+    @{ Name = 'Test-VulnContentStoreExistenceNeedsRef'; SuccessMessage = 'Content-store existence checks passed.' }
+    @{ Name = 'Test-LocalExportArtifactCleanup'; SuccessMessage = 'Local export artifact cleanup checks passed.' }
+    @{ Name = 'Test-InitializeMachineHistoryStoreBackfillsCurrentRecordMetadata'; SuccessMessage = 'Machine store initialization checks passed.' }
+    @{ Name = 'Test-MachineHistoryRemovePathsAllowsEmptyPublishedHistorySet'; SuccessMessage = 'Machine history cleanup empty-set checks passed.' }
+    @{ Name = 'Test-BulkSnapshotImportSmoke'; SuccessMessage = 'Bulk snapshot import smoke checks passed.' }
+    @{ Name = 'Test-BulkSnapshotImportSingleSnapshot'; SuccessMessage = 'Single-snapshot vulnerability import checks passed.' }
+    @{ Name = 'Test-BulkSnapshotImportMultipartSnapshot'; SuccessMessage = 'Multipart vulnerability import checks passed.' }
+    @{ Name = 'Test-BulkSnapshotImportMergesIntoExistingCanonicalStore'; SuccessMessage = 'Existing-store vulnerability merge checks passed.' }
+    @{ Name = 'Test-HttpRetryDelayHelperBehavior'; SuccessMessage = 'Retry delay helper checks passed.' }
+    @{ Name = 'Test-WebRequestWithRetryTransientTransportBehavior'; SuccessMessage = 'Web request transient transport retry checks passed.' }
+    @{ Name = 'Test-BulkVulnerabilitySnapshotDownloadMultipartNameUniqueness'; SuccessMessage = 'Multipart vulnerability download naming checks passed.' }
+    @{ Name = 'Test-BulkVulnerabilitySnapshotDownloadStagingBehavior'; SuccessMessage = 'Multipart vulnerability download staging checks passed.' }
+    @{ Name = 'Test-BulkVulnerabilitySnapshotDownloadRetriesEmptyBlob'; SuccessMessage = 'Multipart vulnerability empty-blob retry checks passed.' }
+    @{ Name = 'Test-BulkVulnerabilitySnapshotDownloadEmptyBlobExhaustionBehavior'; SuccessMessage = 'Multipart vulnerability empty-blob retry exhaustion checks passed.' }
+    @{ Name = 'Test-BulkVulnerabilitySnapshotDownloadMoveFailureCleanupBehavior'; SuccessMessage = 'Multipart vulnerability move-failure cleanup checks passed.' }
+    @{ Name = 'Test-BulkVulnerabilitySnapshotDownloadCleanupBehavior'; SuccessMessage = 'Multipart vulnerability failed-download cleanup checks passed.' }
+    @{ Name = 'Test-VulnCurrentFileRejectsDuplicateId'; SuccessMessage = 'Current-file duplicate Id checks passed.' }
+    @{ Name = 'Test-RepairVulnHistoryLayoutSkipsCanonicalQuarterlyStore'; SuccessMessage = 'Canonical quarterly history repair skip checks passed.' }
+    @{ Name = 'Test-VulnStoreRequiresCanonicalRepairDetectsMalformedQuarterlyHistory'; SuccessMessage = 'Canonical quarterly history gate checks passed.' }
+    @{ Name = 'Test-RepairVulnHistoryLayoutRebuildsCanonicalQuarterlyRowSidecar'; SuccessMessage = 'Canonical quarterly rows-sidecar repair checks passed.' }
+    @{ Name = 'Test-RepairVulnHistoryLayoutRepairsLegacyYearlyStore'; SuccessMessage = 'Legacy yearly history repair checks passed.' }
+    @{ Name = 'Test-VulnHistoryFileValidatesQuarterlyHistoryDocument'; SuccessMessage = 'Quarterly history validation checks passed.' }
+    @{ Name = 'Test-VulnCanonicalSignatureStability'; SuccessMessage = 'Canonical vulnerability signature checks passed.' }
+    @{ Name = 'Test-MergeVulnObservedWindowRows'; SuccessMessage = 'Vulnerability observation merge checks passed.' }
+    @{ Name = 'Test-ReadNormalizedVulnStoreRow'; SuccessMessage = 'Normalized vulnerability store reader checks passed.' }
+    @{ Name = 'Test-ResolveNormalizedLookupIndexListHandlesScalarAndCollectionValues'; SuccessMessage = 'Lookup index list normalization checks passed.' }
+    @{ Name = 'Test-ResolveNormalizedInventoryLookupSkipsEmptyInventoryData'; SuccessMessage = 'Inventory lookup normalization checks passed.' }
+    @{ Name = 'Test-AddNormalizedCveUsesStableSeverityIndexLookup'; SuccessMessage = 'CVE severity lookup checks passed.' }
+    @{ Name = 'Test-GetNormalizedRecordLookupHandlesScalarPathInputs'; SuccessMessage = 'Scalar path lookup checks passed.' }
+    @{ Name = 'Test-InvokeNormalizationProgressCallbackUsesCountAndHeartbeat'; SuccessMessage = 'Normalization progress callback cadence checks passed.' }
+    @{ Name = 'Test-ConvertToNormalizedDataReportsContentStoreNormalizationPhase'; SuccessMessage = 'Content-store normalization phase callback checks passed.' }
+    @{ Name = 'Test-ConvertToNormalizedDataUsesStableDeviceIdFallback'; SuccessMessage = 'Stable device fallback identity checks passed.' }
+    @{ Name = 'Test-ConvertToNormalizedDataWritesExpectedRowCount'; SuccessMessage = 'Normalized vuln row-count checks passed.' }
+    @{ Name = 'Test-ConvertToNormalizedDataWritesDirectPayload'; SuccessMessage = 'Direct payload normalization checks passed.' }
+    @{ Name = 'Test-ConvertToNormalizedDataPreservesOptionalNvdFallback'; SuccessMessage = 'Optional NVD fallback normalization checks passed.' }
+    @{ Name = 'Test-ConvertToNormalizedDataCanConsumeLookupsOnPayloadClose'; SuccessMessage = 'Consuming payload-close lookup checks passed.' }
+    @{ Name = 'Test-ConvertToNormalizedDataContentStorePathDoesNotUseLegacyDictionaryReader'; SuccessMessage = 'Content-store streaming normalization checks passed.' }
+    @{ Name = 'Test-InvokeContentStoreNormalizationReleasesTransientContextBeforePayloadClose'; SuccessMessage = 'Content-store transient context-release and hosted-memory diagnostics checks passed.' }
+    @{ Name = 'Test-ConvertToNormalizedDataDeduplicatesRepeatedCveLookup'; SuccessMessage = 'Repeated CVE lookup deduplication checks passed.' }
+    @{ Name = 'Test-ConvertToNormalizedDataReportsZeroOnboardedContentStoreDiagnostic'; SuccessMessage = 'Zero-onboarded content-store diagnostics checks passed.' }
+    @{ Name = 'Test-ConvertToNormalizedDataIncludesAdvancedHuntingDeviceUserMap'; SuccessMessage = 'Advanced Hunting device-user normalization checks passed.' }
+    @{ Name = 'Test-WriteCombinedPayloadGzipPreservesColumnPayload'; SuccessMessage = 'Combined payload writer column-path checks passed.' }
+    @{ Name = 'Test-NormalizedVulnColumnCacheRebuildsPayloadWithFreshLookups'; SuccessMessage = 'Normalized vuln column cache reuse checks passed.' }
+    @{ Name = 'Test-NormalizedVulnColumnCacheRefreshesInventoryColumn'; SuccessMessage = 'Inventory-backed normalized vuln column cache reuse checks passed.' }
+    @{ Name = 'Test-WriteBase64FileContentMatchesReferenceOutput'; SuccessMessage = 'Streamed base64 writer checks passed.' }
+    @{ Name = 'Test-BenchmarkSeriesSummaryHandlesAzureOnlyRunMode'; SuccessMessage = 'Benchmark series mode checks passed.' }
+    @{ Name = 'Test-BenchmarkSeriesSummaryHandlesCombinedRunMode'; SuccessMessage = 'Benchmark series mode checks passed.' }
+    @{ Name = 'Test-BenchmarkSeriesSummaryHandlesLocalOnlyRunMode'; SuccessMessage = 'Benchmark series mode checks passed.' }
+    @{ Name = 'Test-BenchmarkIncludesLocalRunHandlesLegacyInferenceShape'; SuccessMessage = 'Benchmark series mode checks passed.' }
+    @{ Name = 'Test-BenchmarkModeScenarioKeyHandlesLegacyModeMapping'; SuccessMessage = 'Benchmark series mode checks passed.' }
+    @{ Name = 'Test-WriteProgressMarkerIncludesEtaWhenTotalCountKnown'; SuccessMessage = 'Progress marker ETA checks passed.' }
+    @{ Name = 'Test-WriteCombinedPayloadGzipCanConsumeColumnLookupData'; SuccessMessage = 'Payload lookup consumption checks passed.' }
+    @{ Name = 'Test-GetDashboardEmbeddedPayloadInspectionStreamsSelfContainedPayload'; SuccessMessage = 'Embedded payload inspection checks passed.' }
+    @{ Name = 'Test-MeasureStressRunWritesProgressAndFinalReport'; SuccessMessage = 'Measure-StressRun report persistence checks passed.' }
+    @{ Name = 'Test-ValidationHelperPayloadCanonicalization'; SuccessMessage = 'Validation helper payload-format checks passed.' }
+    @{ Name = 'Test-ValidationHelperSourceCanonicalization'; SuccessMessage = 'Validation helper source canonicalization checks passed.' }
+    @{ Name = 'Test-ValidationHelperStandaloneImport'; SuccessMessage = 'Validation helper standalone import checks passed.' }
+    @{ Name = 'Test-DashboardValidationFailureExtendedEnrichmentGate'; SuccessMessage = 'Validation helper failure-gate checks passed.' }
+    @{ Name = 'Test-StreamingDashboardAuditDetectsSourceMismatchDespitePayloadParity'; SuccessMessage = 'Streaming dashboard source-parity checks passed.' }
+    @{ Name = 'Test-StreamingDashboardAuditReusesCachedPayloadSignatureSet'; SuccessMessage = 'Streaming dashboard payload-signature reuse checks passed.' }
+    @{ Name = 'Test-DashboardAuditBootstrapsSyntheticLargePayloadCacheWithNormalizationLookup'; SuccessMessage = 'Dashboard synthetic large-dataset bootstrap checks passed.' }
+    @{ Name = 'Test-DashboardValidationUsesStableFallbackDeviceProfile'; SuccessMessage = 'Dashboard validation fallback device profile checks passed.' }
+    @{ Name = 'Test-DashboardOpenStateAuditUsesPatchEvidenceAndInactivityCutoff'; SuccessMessage = 'Dashboard open-state audit checks passed.' }
+    @{ Name = 'Test-DashboardValidationPreservesNoneSeverityData'; SuccessMessage = 'Dashboard none-severity validation checks passed.' }
+    @{ Name = 'Test-DashboardSplitAssetsGenerationAndValidation'; SuccessMessage = 'Dashboard split-assets generation and validation checks passed.' }
+    @{ Name = 'Test-DashboardValidateOnlyFailsWhenHostedPayloadMissing'; SuccessMessage = 'Hosted dashboard missing-payload negative checks passed.' }
+    @{ Name = 'Test-PackageOnlyRejectsMismatchedNormalizedPayloadManifest'; SuccessMessage = 'Package-only manifest mismatch negative checks passed.' }
+    @{ Name = 'Test-DashboardDualPackagingGenerationAndValidation'; SuccessMessage = 'Dashboard dual packaging generation and validation checks passed.' }
+    @{ Name = 'Test-AdvancedHuntingBundleMatchesDedicatedReaderData'; SuccessMessage = 'Advanced Hunting bundle reader checks passed.' }
+    @{ Name = 'Test-AdvancedHuntingBundleStringArrayFiltersSparseInputs'; SuccessMessage = 'Advanced Hunting bundle sparse string-array checks passed.' }
+    @{ Name = 'Test-ReadNormalizationMachineLookupMatchesCompressedMachineLookup'; SuccessMessage = 'Machine tuple reader checks passed.' }
+    @{ Name = 'Test-NormalizationMachineTupleExtendsLegacyTuple'; SuccessMessage = 'Machine tuple extension checks passed.' }
+    @{ Name = 'Test-LegacyMachineTupleFallbackPreservesProjectedRowMetadata'; SuccessMessage = 'Legacy tuple fallback checks passed.' }
+    @{ Name = 'Test-SourceCveEnrichmentReadsExploitAvailabilityFromObjectRecord'; SuccessMessage = 'Source enrichment exploit-availability checks passed.' }
+    @{ Name = 'Test-VulnPropertyHelpersSupportSupportedRowShapes'; SuccessMessage = 'Vulnerability property helper shape checks passed.' }
+    @{ Name = 'Test-VulnContentStoreRoundTrip'; SuccessMessage = 'Vulnerability content store round-trip checks passed.' }
+    @{ Name = 'Test-VulnObservedWindowCacheRoundTrip'; SuccessMessage = 'Observed-window cache round-trip checks passed.' }
+    @{ Name = 'Test-FunctionAppWriteOutputNoEnumeratePreservesJObject'; SuccessMessage = 'Function App Write-Output -NoEnumerate checks passed.' }
+    @{ Name = 'Test-FunctionExecutionStatusSummaryIncludesNormalizationProgressInfo'; SuccessMessage = 'Function execution status summary metadata checks passed.' }
+)
+
+foreach ($sharedHelperRegressionTest in $sharedHelperRegressionTests) {
+    Invoke-SharedHelperRegressionTest -Name $sharedHelperRegressionTest.Name -SuccessMessage $sharedHelperRegressionTest.SuccessMessage
+}
+
 Write-Output 'Shared-helper regression checks passed.'


### PR DESCRIPTION
## Summary
- strengthen PowerShell artifact manifest validation and cross-manifest conflict checks
- fail fast when generated helper outputs are missing or empty
- add per-test timing output to the shared-helper regression runner and document the repo-health validation workflow

## Validation
- `pwsh -NoProfile -File .\tests\Run-SharedHelperRegression.ps1`
- `pwsh -NoProfile -File .\build\Invoke-RegressionValidation.ps1`