### PR TITLE
Improve repo-health benchmark tooling

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,26 @@
+# Default review owner for this repository.
+* @NathanMcNulty
+
+# Canonical source-of-truth files.
+/src/powershell/ @NathanMcNulty
+/build/private/ @NathanMcNulty
+/build/manifests/ @NathanMcNulty
+/build/azure/runbook-source.ps1 @NathanMcNulty
+/Generate-VulnerabilityDashboard.ps1 @NathanMcNulty
+/Invoke-VulnerabilityExport.ps1 @NathanMcNulty
+/Invoke-NvdCveExport.ps1 @NathanMcNulty
+/Setup-AzureResources.ps1 @NathanMcNulty
+/Setup-GitHubActionServicePrincipal.ps1 @NathanMcNulty
+/templates/ @NathanMcNulty
+/tests/ @NathanMcNulty
+/docs/ @NathanMcNulty
+/build/README.md @NathanMcNulty
+/README.md @NathanMcNulty
+
+# Tracked derived artifacts should be reviewed alongside their source inputs.
+/azure/Invoke-DashboardPipeline.ps1 @NathanMcNulty
+/VulnerabilityDashboard.html @NathanMcNulty
+
+# Repository automation and review policy.
+/.github/workflows/ @NathanMcNulty
+/.github/PULL_REQUEST_TEMPLATE.md @NathanMcNulty

--- a/Generate-VulnerabilityDashboard.ps1
+++ b/Generate-VulnerabilityDashboard.ps1
@@ -541,6 +541,110 @@ function Get-DashboardPackagingPlan {
     )
 }
 
+function Assert-DashboardRuntimeContract {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [bool]$Validate,
+
+        [Parameter(Mandatory = $true)]
+        [bool]$ValidateOnly,
+
+        [Parameter(Mandatory = $true)]
+        [bool]$SplitAssets,
+
+        [Parameter(Mandatory = $true)]
+        [bool]$DualPackage,
+
+        [Parameter(Mandatory = $true)]
+        [bool]$NormalizeOnly,
+
+        [Parameter(Mandatory = $true)]
+        [bool]$PackageOnly,
+
+        [Parameter(Mandatory = $false)]
+        [AllowEmptyString()]
+        [string]$HostedOutputPath
+    )
+
+    $conflicts = @(
+        @{
+            Condition = ($Validate -and $ValidateOnly)
+            Message = 'Specify either -Validate or -ValidateOnly, not both.'
+        }
+        @{
+            Condition = ($SplitAssets -and $DualPackage)
+            Message = 'Specify either -SplitAssets or -DualPackage, not both.'
+        }
+        @{
+            Condition = ($NormalizeOnly -and $PackageOnly)
+            Message = 'Specify either -NormalizeOnly or -PackageOnly, not both.'
+        }
+        @{
+            Condition = ($NormalizeOnly -and $DualPackage)
+            Message = 'Specify either -NormalizeOnly or -DualPackage, not both.'
+        }
+        @{
+            Condition = ($NormalizeOnly -and $ValidateOnly)
+            Message = 'Specify either -NormalizeOnly or -ValidateOnly, not both.'
+        }
+        @{
+            Condition = ($NormalizeOnly -and $Validate)
+            Message = 'Specify either -NormalizeOnly or -Validate, not both.'
+        }
+        @{
+            Condition = ($PackageOnly -and $ValidateOnly)
+            Message = 'Specify either -PackageOnly or -ValidateOnly, not both.'
+        }
+        @{
+            Condition = ($DualPackage -and $ValidateOnly)
+            Message = 'Specify either -DualPackage or -ValidateOnly, not both.'
+        }
+        @{
+            Condition = ((-not $DualPackage) -and (-not [string]::IsNullOrWhiteSpace($HostedOutputPath)))
+            Message = '-HostedOutputPath is only supported with -DualPackage.'
+        }
+    )
+
+    foreach ($conflict in $conflicts) {
+        if ($conflict.Condition) {
+            throw $conflict.Message
+        }
+    }
+}
+
+function Resolve-DashboardValidationPlan {
+    [CmdletBinding()]
+    [OutputType([object[]])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [bool]$ValidateOnly,
+
+        [Parameter(Mandatory = $true)]
+        [string]$OutputPath,
+
+        [Parameter(Mandatory = $false)]
+        [AllowEmptyString()]
+        [string]$ValidationOutputPath,
+
+        [Parameter(Mandatory = $false)]
+        [AllowEmptyCollection()]
+        [object[]]$GeneratedTargets = @()
+    )
+
+    if ($ValidateOnly) {
+        return @(
+            [PSCustomObject]@{
+                Label = 'dashboard'
+                OutputPath = [System.IO.Path]::GetFullPath($OutputPath)
+                ValidationOutputPath = if (-not [string]::IsNullOrWhiteSpace($ValidationOutputPath)) { [System.IO.Path]::GetFullPath($ValidationOutputPath) } else { $null }
+            }
+        )
+    }
+
+    return @($GeneratedTargets)
+}
+
 # =============================================================================
 # MAIN SCRIPT
 # =============================================================================
@@ -549,46 +653,20 @@ $tempRoot = $null
 $localPhaseTimings = [System.Collections.Generic.List[object]]::new()
 $script:LocalDiagnosticPhaseLogPath = $null
 $localDiagnosticPipelineStatus = 'completed'
+$dashboardValidationTargets = @()
 
 try {
     Initialize-LocalDiagnosticPhaseLog -Path $DiagnosticPhaseLogPath
     Write-LocalDiagnosticPhaseLogEvent -EventType 'pipeline-start' -Name 'dashboard-generation'
 
-    if ($Validate -and $ValidateOnly) {
-        throw 'Specify either -Validate or -ValidateOnly, not both.'
-    }
-
-    if ($SplitAssets -and $DualPackage) {
-        throw 'Specify either -SplitAssets or -DualPackage, not both.'
-    }
-
-    if ($NormalizeOnly -and $PackageOnly) {
-        throw 'Specify either -NormalizeOnly or -PackageOnly, not both.'
-    }
-
-    if ($NormalizeOnly -and $DualPackage) {
-        throw 'Specify either -NormalizeOnly or -DualPackage, not both.'
-    }
-
-    if ($NormalizeOnly -and $ValidateOnly) {
-        throw 'Specify either -NormalizeOnly or -ValidateOnly, not both.'
-    }
-
-    if ($NormalizeOnly -and $Validate) {
-        throw 'Specify either -NormalizeOnly or -Validate, not both.'
-    }
-
-    if ($PackageOnly -and $ValidateOnly) {
-        throw 'Specify either -PackageOnly or -ValidateOnly, not both.'
-    }
-
-    if ($DualPackage -and $ValidateOnly) {
-        throw 'Specify either -DualPackage or -ValidateOnly, not both.'
-    }
-
-    if ((-not $DualPackage) -and (-not [string]::IsNullOrWhiteSpace($HostedOutputPath))) {
-        throw '-HostedOutputPath is only supported with -DualPackage.'
-    }
+    Assert-DashboardRuntimeContract `
+        -Validate ([bool]$Validate) `
+        -ValidateOnly ([bool]$ValidateOnly) `
+        -SplitAssets ([bool]$SplitAssets) `
+        -DualPackage ([bool]$DualPackage) `
+        -NormalizeOnly ([bool]$NormalizeOnly) `
+        -PackageOnly ([bool]$PackageOnly) `
+        -HostedOutputPath $HostedOutputPath
 
     Write-Host "`n========================================" -ForegroundColor Cyan
     Write-Host "  Vulnerability Dashboard Generator" -ForegroundColor Cyan
@@ -1145,18 +1223,7 @@ try {
     if ($Validate -or $ValidateOnly) {
         $phaseContext = Get-LocalDiagnosticPhaseContext -Name 'Validate dashboard'
         . (Join-Path $PSScriptRoot 'build\Import-ValidationHelpers.ps1')
-        $validationTargets = if ($ValidateOnly) {
-            @(
-                [PSCustomObject]@{
-                    Label = 'dashboard'
-                    OutputPath = [System.IO.Path]::GetFullPath($OutputPath)
-                    ValidationOutputPath = if (-not [string]::IsNullOrWhiteSpace($ValidationOutputPath)) { [System.IO.Path]::GetFullPath($ValidationOutputPath) } else { $null }
-                }
-            )
-        }
-        else {
-            @($dashboardValidationTargets)
-        }
+        $validationTargets = @(Resolve-DashboardValidationPlan -ValidateOnly:([bool]$ValidateOnly) -OutputPath $OutputPath -ValidationOutputPath $ValidationOutputPath -GeneratedTargets @($dashboardValidationTargets))
 
         foreach ($validationTarget in $validationTargets) {
             if ($validationTargets.Count -gt 1) {

--- a/build/README.md
+++ b/build/README.md
@@ -113,6 +113,14 @@ These checks now fail fast in the build helpers and in the deterministic preflig
 - When you add a new maintainer entrypoint or review lane, update the corresponding maintainer docs in `build/README.md`, `tests/README.md`, or `docs/workflows.md` in the same change.
 - Prefer shared helpers under `build/private/` and `tests/helpers/` over copying utility functions into new scripts.
 
+## CODEOWNERS and review ownership
+
+The repository now keeps review ownership in `.github/CODEOWNERS`.
+
+- Canonical source files stay owned at the source-of-truth layer (`src/powershell/`, `build/private/`, `build/manifests/`, `build/azure/runbook-source.ps1`, root maintainer entrypoints, and docs/tests).
+- Tracked derived artifacts such as `azure/Invoke-DashboardPipeline.ps1` and `VulnerabilityDashboard.html` are still code-owned so PRs that touch them get review coverage, but they should be regenerated from their owning sources instead of edited directly.
+- Ignored generated artifacts such as `build/generated/*.ps1` and `azure/function-app/ExportAndGenerate/run.ps1` are not tracked by git, so CODEOWNERS cannot match them directly; review the source files that generate them.
+
 ## Staged dashboard workflow
 
 `Generate-VulnerabilityDashboard.ps1` now supports splitting the expensive normalization step from later packaging and validation work:

--- a/docs/performance-baselines.md
+++ b/docs/performance-baselines.md
@@ -44,7 +44,7 @@ The raw result JSON files from the April 5, 2026 capture remain local-only under
 
 | Dataset | Shape | Architecture | Azure path | Acceptance markers | Review notes |
 | --- | --- | --- | --- | --- | --- |
-| `synthetic-50k-1_5m` | `50,000` devices, `1,500,000` rows, `3,097` CVEs | `monolithic-v1` | Azure Automation plus hosted Function App (`Dual`) | Function App execution accepted `2026-05-06T06:26:05Z`; dashboard blob written `2026-05-06T06:33:39Z`; blob-write interval `454s` | Treat this as the accepted Stage 1 large Azure envelope anchor until a newer accepted run replaces it. Compare future standard-dataset Azure runs against this record plus the review thresholds in `docs/performance-gate-playbook.md`, and keep the raw Azure validation artifacts local under `.local/`. |
+| `synthetic-50k-1_5m` | `50,000` devices, `1,500,000` rows, `3,097` normalized CVE lookup entries | `monolithic-v1` | Azure Automation plus hosted Function App (`Dual`) | Function App execution accepted `2026-05-06T06:26:05Z`; dashboard blob written `2026-05-06T06:33:39Z`; blob-write interval `454s` | Treat this as the accepted Stage 1 large Azure envelope anchor until a newer accepted run replaces it. Compare future standard-dataset Azure runs against this record plus the review thresholds in `docs/performance-gate-playbook.md`, and keep the raw Azure validation artifacts local under `.local/`. |
 
 ## Capture notes
 
@@ -64,6 +64,8 @@ The raw result JSON files from the April 5, 2026 capture remain local-only under
 - The durable `benchmark-medium-v1` persistent local cache reuse pass was effectively stable across reruns (`45.44s` to `45.49s`) and is the preferred baseline for normalized-column cache reuse.
 - The hosted review baseline was captured twice on the same dataset and command path. This document records ranges because the cold local normalization pass moved more than the hosted paths across reruns.
 - The local benchmark harness stages a private dataset copy before validation so raw datasets do not get mutated by sidecar regeneration during baseline capture.
+- Synthetic benchmark artifacts now publish `uniqueCveIdCount`, `normalizedCveLookupCount`, and `contentTemplateCount` in both `synthetic-manifest.json` and `benchmark-dataset.json`. `normalizedCveLookupCount` is the same breadth surfaced as `CVEs` in the Azure acceptance summaries above.
+- `benchmark-large-50k-v1` regenerates from the mutable `exports` source path, so its breadth counters can drift even when the dataset id, seed, device target, and row target stay fixed. Use the manifest breadth counters rather than assuming the accepted May 6 anchor's normalized CVE count will remain constant across later refreshes.
 - The standard large Azure entry intentionally records the accepted invocation and blob-write markers that are already tracked in-repo. Preserve the raw Azure validation artifacts under `.local/` when refreshing this section so future updates can add comparable working-set or execution-unit detail without reconstructing the run later.
 
 ## Regenerating the baseline

--- a/docs/source-layout.md
+++ b/docs/source-layout.md
@@ -42,6 +42,12 @@ This repository now treats generated helper bundles as build artifacts, not as t
 - If you add a new maintainer workflow or validation lane, update the matching maintainer docs (`build/README.md`, `tests/README.md`, and `docs/workflows.md`) in the same PR.
 - Reuse helpers from `tests/helpers/` or `build/private/` before introducing duplicate utility functions in new scripts.
 
+## Review ownership
+
+- `.github/CODEOWNERS` mirrors the source-of-truth layout so review requests land on the canonical files first.
+- Tracked derived artifacts can still have ownership entries for review visibility, but they should move in lockstep with the source files that generate them.
+- Ignored generated files are outside git and therefore outside CODEOWNERS scope; use the owning source directories and manifests as the review boundary for those outputs.
+
 ## Remaining decomposition watchlist
 
 The current overhaul has moved helper ownership out of the large top-level entry scripts and into explicit source-first domains. The remaining follow-up work is narrower and currently centered on:

--- a/tests/Generate-SyntheticLargeExports.ps1
+++ b/tests/Generate-SyntheticLargeExports.ps1
@@ -61,6 +61,7 @@ Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
 . (Join-Path (Split-Path -Path $PSScriptRoot -Parent) 'build\Import-SharedHelpers.ps1')
+. (Join-Path $PSScriptRoot 'helpers\TestScriptSupport.ps1')
 
 function Get-PresetSetting {
     [CmdletBinding()]
@@ -92,19 +93,6 @@ function Get-PresetSetting {
             throw "Unsupported preset '$Name'."
         }
     }
-}
-
-function Get-AvailableMemoryGB {
-    [CmdletBinding()]
-    [OutputType([double])]
-    param()
-
-    if (-not $IsWindows) {
-        return [double]::NaN
-    }
-
-    $os = Get-CimInstance Win32_OperatingSystem -ErrorAction Stop
-    return [math]::Round(($os.FreePhysicalMemory / 1MB), 2)
 }
 
 function Get-FreeDiskSpaceGB {
@@ -798,6 +786,49 @@ function Add-SourceRowContentTemplateIndex {
     return $contentIndexValue
 }
 
+function Get-ContentTemplateBreadthSummary {
+    [CmdletBinding()]
+    [OutputType([pscustomobject])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [AllowEmptyCollection()]
+        [System.Collections.IEnumerable]$ContentTemplates
+    )
+
+    $templateCount = 0
+    $uniqueCveIds = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+    $normalizedCveLookups = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+
+    foreach ($template in @($ContentTemplates)) {
+        if ($null -eq $template) {
+            continue
+        }
+
+        $templateCount++
+        $cveId = [string]$template.PSObject.Properties['c']?.Value
+        if ([string]::IsNullOrWhiteSpace($cveId)) {
+            continue
+        }
+
+        [void]$uniqueCveIds.Add($cveId)
+        $lookupKey = @(
+            $cveId
+            [string]$template.PSObject.Properties['sc']?.Value
+            [string]$template.PSObject.Properties['sev']?.Value
+            [string]$template.PSObject.Properties['ex']?.Value
+            [string]$template.PSObject.Properties['bu']?.Value
+            [string]$template.PSObject.Properties['bt']?.Value
+        ) -join '|'
+        [void]$normalizedCveLookups.Add($lookupKey)
+    }
+
+    return [PSCustomObject]@{
+        contentTemplateCount = $templateCount
+        uniqueCveIdCount = $uniqueCveIds.Count
+        normalizedCveLookupCount = $normalizedCveLookups.Count
+    }
+}
+
 $presetSettings = Get-PresetSetting -Name $Preset
 if ($TargetDeviceCount -le 0) {
     $TargetDeviceCount = [int]$presetSettings.TargetDeviceCount
@@ -1344,6 +1375,8 @@ $contentDictionary = [PSCustomObject]@{
 Write-GenerationCheckpoint -OutputPath $OutputPath -Stage 'writing-content-dictionary' -CompletedDevices $TargetDeviceCount -TotalDevices $TargetDeviceCount -WrittenCurrentRows $writtenCurrentRows -WrittenHistoryRows $writtenHistoryRows -Stopwatch $generationStopwatch
 Write-GzipTextFile -Path (Get-VulnContentDictionaryPath -BasePath $OutputPath) -Content $contentDictionary
 
+$contentTemplateBreadth = Get-ContentTemplateBreadthSummary -ContentTemplates $contentTemplates
+
 $manifest = [PSCustomObject]@{
     preset = $Preset
     seed = $Seed
@@ -1365,12 +1398,18 @@ $manifest = [PSCustomObject]@{
     sourceRowProfiles = $rowProfiles.Count
     historyPeriods = @($historyRefsWriters.Keys | Sort-Object)
     advancedHuntingRows = $filteredAdvancedHunting.Count
+    contentTemplateCount = $contentTemplateBreadth.contentTemplateCount
+    uniqueCveIdCount = $contentTemplateBreadth.uniqueCveIdCount
+    normalizedCveLookupCount = $contentTemplateBreadth.normalizedCveLookupCount
 }
 $manifest | ConvertTo-Json -Depth 10 | Set-Content -Path (Join-Path $OutputPath 'synthetic-manifest.json') -Encoding utf8
 $generationStopwatch.Stop()
 Write-GenerationCheckpoint -OutputPath $OutputPath -Stage 'completed' -CompletedDevices $TargetDeviceCount -TotalDevices $TargetDeviceCount -WrittenCurrentRows $writtenCurrentRows -WrittenHistoryRows $writtenHistoryRows -Stopwatch $generationStopwatch -Extra @{
     advancedHuntingRows = $filteredAdvancedHunting.Count
     historyPeriods = @($historyRefsWriters.Keys | Sort-Object)
+    contentTemplateCount = $contentTemplateBreadth.contentTemplateCount
+    uniqueCveIdCount = $contentTemplateBreadth.uniqueCveIdCount
+    normalizedCveLookupCount = $contentTemplateBreadth.normalizedCveLookupCount
 }
 
 Write-Output ''
@@ -1379,4 +1418,6 @@ Write-Output ("  Output path: {0}" -f ([System.IO.Path]::GetFullPath($OutputPath
 Write-Output ("  Devices: {0}" -f $plans.Count)
 Write-Output ("  Vulnerability rows: {0} current + {1} history = {2} total" -f $writtenCurrentRows, $writtenHistoryRows, ($writtenCurrentRows + $writtenHistoryRows))
 Write-Output ("  Advanced Hunting rows: {0}" -f $filteredAdvancedHunting.Count)
+Write-Output ("  CVE breadth: {0} unique CVE IDs, {1} normalized CVE lookups" -f $contentTemplateBreadth.uniqueCveIdCount, $contentTemplateBreadth.normalizedCveLookupCount)
+Write-Output ("  Content templates: {0}" -f $contentTemplateBreadth.contentTemplateCount)
 Write-Output ("  History periods: {0}" -f ((@($historyRefsWriters.Keys | Sort-Object) -join ', ')))

--- a/tests/Invoke-HotPhaseReview.ps1
+++ b/tests/Invoke-HotPhaseReview.ps1
@@ -40,57 +40,10 @@ param(
 
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
+. (Join-Path $PSScriptRoot 'helpers\TestScriptSupport.ps1')
 
 if (-not $IsWindows) {
     throw 'tests/Invoke-HotPhaseReview.ps1 currently supports Windows only because it relies on Win32 CIM classes for process and memory sampling.'
-}
-
-function Get-TextWithoutAnsiEscape {
-    [CmdletBinding()]
-    [OutputType([string])]
-    param(
-        [Parameter(Mandatory = $true)]
-        [AllowEmptyString()]
-        [string]$Text
-    )
-
-    return ([regex]::Replace($Text, "`e\[[0-9;]*m", ''))
-}
-
-function Get-AvailableMemoryGB {
-    [CmdletBinding()]
-    [OutputType([double])]
-    param()
-
-    $os = Get-CimInstance Win32_OperatingSystem
-    return [math]::Round(($os.FreePhysicalMemory / 1MB), 2)
-}
-
-function Get-HeartbeatTimestampText {
-    [CmdletBinding()]
-    [OutputType([string])]
-    param()
-
-    return (Get-Date).ToString('yyyy-MM-dd HH:mm:ss')
-}
-
-function Add-PathSuffixBeforeExtensionLocal {
-    [CmdletBinding()]
-    [OutputType([string])]
-    param(
-        [Parameter(Mandatory = $true)]
-        [string]$Path,
-
-        [Parameter(Mandatory = $true)]
-        [string]$Suffix
-    )
-
-    $extension = [System.IO.Path]::GetExtension($Path)
-    if ([string]::IsNullOrEmpty($extension)) {
-        return ($Path + $Suffix)
-    }
-
-    return ($Path.Substring(0, $Path.Length - $extension.Length) + $Suffix + $extension)
 }
 
 function Get-DatasetRowCountForReview {
@@ -149,28 +102,6 @@ function Invoke-GeneratedArtifactValidation {
         hostedPath = [System.IO.Path]::GetFullPath($HostedPath)
         hostedAssetsPath = Join-Path (Split-Path -Path (Resolve-Path -LiteralPath $HostedPath).Path -Parent) (([System.IO.Path]::GetFileNameWithoutExtension($HostedPath)) + '.assets')
         passed = $true
-    }
-}
-
-function Get-HeartbeatFileStatus {
-    [CmdletBinding()]
-    [OutputType([pscustomobject])]
-    param(
-        [Parameter(Mandatory = $true)]
-        [string]$Path
-    )
-
-    if (-not (Test-Path -LiteralPath $Path -PathType Leaf)) {
-        return [PSCustomObject]@{
-            bytes = 0L
-            ageSeconds = $null
-        }
-    }
-
-    $item = Get-Item -LiteralPath $Path
-    return [PSCustomObject]@{
-        bytes = [int64]$item.Length
-        ageSeconds = [math]::Round(((Get-Date).ToUniversalTime() - $item.LastWriteTimeUtc).TotalSeconds, 1)
     }
 }
 

--- a/tests/Invoke-ValidationModeComparison.ps1
+++ b/tests/Invoke-ValidationModeComparison.ps1
@@ -23,60 +23,10 @@ param(
 
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
+. (Join-Path $PSScriptRoot 'helpers\TestScriptSupport.ps1')
 
 if (-not $IsWindows) {
     throw 'tests/Invoke-ValidationModeComparison.ps1 currently supports Windows only because it relies on Win32 CIM classes for process and memory sampling.'
-}
-
-function Get-TextWithoutAnsiEscape {
-    [CmdletBinding()]
-    [OutputType([string])]
-    param(
-        [Parameter(Mandatory = $true)]
-        [AllowEmptyString()]
-        [string]$Text
-    )
-
-    return ([regex]::Replace($Text, "`e\[[0-9;]*m", ''))
-}
-
-function Get-AvailableMemoryGB {
-    [CmdletBinding()]
-    [OutputType([double])]
-    param()
-
-    $os = Get-CimInstance Win32_OperatingSystem
-    return [math]::Round(($os.FreePhysicalMemory / 1MB), 2)
-}
-
-function Get-HeartbeatTimestampText {
-    [CmdletBinding()]
-    [OutputType([string])]
-    param()
-
-    return (Get-Date).ToString('yyyy-MM-dd HH:mm:ss')
-}
-
-function Get-HeartbeatFileStatus {
-    [CmdletBinding()]
-    [OutputType([pscustomobject])]
-    param(
-        [Parameter(Mandatory = $true)]
-        [string]$Path
-    )
-
-    if (-not (Test-Path -LiteralPath $Path -PathType Leaf)) {
-        return [PSCustomObject]@{
-            bytes = 0L
-            ageSeconds = $null
-        }
-    }
-
-    $item = Get-Item -LiteralPath $Path
-    return [PSCustomObject]@{
-        bytes = [int64]$item.Length
-        ageSeconds = [math]::Round(((Get-Date).ToUniversalTime() - $item.LastWriteTimeUtc).TotalSeconds, 1)
-    }
 }
 
 function Write-ModeComparisonHeartbeat {

--- a/tests/Invoke-WithPwshMemoryGuard.ps1
+++ b/tests/Invoke-WithPwshMemoryGuard.ps1
@@ -22,18 +22,10 @@ param(
 
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
+. (Join-Path $PSScriptRoot 'helpers\TestScriptSupport.ps1')
 
 if (-not $IsWindows) {
     throw 'tests/Invoke-WithPwshMemoryGuard.ps1 currently supports Windows only because it relies on Win32 CIM classes for process and memory sampling.'
-}
-
-function Get-AvailableMemoryGB {
-    [CmdletBinding()]
-    [OutputType([double])]
-    param()
-
-    $os = Get-CimInstance Win32_OperatingSystem
-    return [math]::Round(($os.FreePhysicalMemory / 1MB), 2)
 }
 
 function Get-ProcessTree {

--- a/tests/Measure-BranchVsMainBenchmark.ps1
+++ b/tests/Measure-BranchVsMainBenchmark.ps1
@@ -94,108 +94,7 @@ $script:PollIntervalSeconds = $PollIntervalSeconds
 
 . (Join-Path $PSScriptRoot 'Import-BenchmarkDatasetCatalog.ps1')
 . (Join-Path $PSScriptRoot 'helpers\BenchmarkSeriesTools.ps1')
-
-function Get-HeartbeatTimestampText {
-    [CmdletBinding()]
-    [OutputType([string])]
-    param()
-
-    return (Get-Date).ToString('yyyy-MM-dd HH:mm:ss')
-}
-
-function ConvertTo-UtcDateTime {
-    [CmdletBinding()]
-    [OutputType([datetime])]
-    param(
-        [Parameter(Mandatory = $false)]
-        [AllowNull()]
-        $Value
-    )
-
-    if ($null -eq $Value) {
-        return $null
-    }
-
-    if ($Value -is [datetime]) {
-        return ([datetime]$Value).ToUniversalTime()
-    }
-
-    if ($Value -is [datetimeoffset]) {
-        return ([datetimeoffset]$Value).UtcDateTime
-    }
-
-    $text = [string]$Value
-    if ([string]::IsNullOrWhiteSpace($text)) {
-        return $null
-    }
-
-    $parsed = [datetimeoffset]::MinValue
-    if ([datetimeoffset]::TryParse($text, [ref]$parsed)) {
-        return $parsed.UtcDateTime
-    }
-
-    return $null
-}
-
-function Get-ObjectPropertyValue {
-    [CmdletBinding()]
-    param(
-        [Parameter(Mandatory = $false)]
-        [AllowNull()]
-        $InputObject,
-
-        [Parameter(Mandatory = $true)]
-        [string]$Name
-    )
-
-    if ($null -eq $InputObject) {
-        return $null
-    }
-
-    $property = $InputObject.PSObject.Properties[$Name]
-    if ($null -eq $property) {
-        return $null
-    }
-
-    return $property.Value
-}
-
-function Get-TextWithoutAnsiEscape {
-    [CmdletBinding()]
-    [OutputType([string])]
-    param(
-        [Parameter(Mandatory = $true)]
-        [AllowEmptyString()]
-        [string]$Text
-    )
-
-    return ([regex]::Replace($Text, "`e\[[0-9;]*m", ''))
-}
-
-function Test-ScriptParameterSupport {
-    [CmdletBinding()]
-    [OutputType([bool])]
-    param(
-        [Parameter(Mandatory = $true)]
-        [string]$ScriptPath,
-
-        [Parameter(Mandatory = $true)]
-        [string]$ParameterName
-    )
-
-    if (-not (Test-Path -LiteralPath $ScriptPath -PathType Leaf)) {
-        return $false
-    }
-
-    try {
-        $command = Get-Command -Name $ScriptPath -ErrorAction Stop
-        return $command.Parameters.ContainsKey($ParameterName)
-    }
-    catch {
-        Write-Verbose ("Unable to inspect parameters for {0}: {1}" -f $ScriptPath, $_.Exception.Message)
-        return $false
-    }
-}
+. (Join-Path $PSScriptRoot 'helpers\TestScriptSupport.ps1')
 
 function Write-AdHocBenchmarkSeriesSummary {
     [CmdletBinding()]
@@ -250,109 +149,6 @@ function Write-AdHocBenchmarkSeriesSummary {
 
     $summary = [PSCustomObject]$summaryProperties
     [void](Write-BenchmarkSeriesSummaryOutput -ResultsRoot $resultsDirectory -Summary $summary)
-}
-
-function Get-LocalDiagnosticTimingSummary {
-    [CmdletBinding()]
-    [OutputType([pscustomobject])]
-    param(
-        [Parameter(Mandatory = $true)]
-        [string]$Path
-    )
-
-    if (-not (Test-Path -LiteralPath $Path -PathType Leaf)) {
-        return $null
-    }
-
-    $phaseByName = [ordered]@{}
-    $pipelineStartUtc = $null
-    $pipelineEndUtc = $null
-
-    foreach ($line in Get-Content -LiteralPath $Path) {
-        if ([string]::IsNullOrWhiteSpace($line)) {
-            continue
-        }
-
-        $parts = @([string]$line -split "`t")
-        if ($parts.Count -lt 3) {
-            continue
-        }
-
-        $timestampUtc = ConvertTo-UtcDateTime -Value $parts[0]
-        if ($null -eq $timestampUtc) {
-            continue
-        }
-
-        $eventType = [string]$parts[1]
-        $name = [string]$parts[2]
-        $status = if ($parts.Count -ge 4) { [string]$parts[3] } else { $null }
-
-        switch ($eventType) {
-            'pipeline-start' {
-                if ($null -eq $pipelineStartUtc) {
-                    $pipelineStartUtc = $timestampUtc
-                }
-            }
-            'pipeline-end' {
-                $pipelineEndUtc = $timestampUtc
-            }
-            'phase-start' {
-                if (-not $phaseByName.Contains($name)) {
-                    $phaseByName[$name] = [ordered]@{
-                        name = $name
-                        start_utc = $null
-                        end_utc = $null
-                        status = $null
-                    }
-                }
-
-                if ($null -eq $phaseByName[$name].start_utc) {
-                    $phaseByName[$name].start_utc = $timestampUtc
-                }
-            }
-            'phase-end' {
-                if (-not $phaseByName.Contains($name)) {
-                    $phaseByName[$name] = [ordered]@{
-                        name = $name
-                        start_utc = $null
-                        end_utc = $null
-                        status = $null
-                    }
-                }
-
-                $phaseByName[$name].end_utc = $timestampUtc
-                $phaseByName[$name].status = $status
-            }
-        }
-    }
-
-    $phaseSummaries = @(
-        foreach ($phaseEntry in $phaseByName.Values) {
-            $elapsedSeconds = if ($null -ne $phaseEntry.start_utc -and $null -ne $phaseEntry.end_utc) {
-                [math]::Round((New-TimeSpan -Start $phaseEntry.start_utc -End $phaseEntry.end_utc).TotalSeconds, 2)
-            }
-            else {
-                $null
-            }
-
-            [PSCustomObject]@{
-                name = [string]$phaseEntry.name
-                status = if ([string]::IsNullOrWhiteSpace([string]$phaseEntry.status)) { 'unknown' } else { [string]$phaseEntry.status }
-                elapsedSeconds = $elapsedSeconds
-            }
-        }
-    )
-
-    return [PSCustomObject]@{
-        path = $Path
-        phase_summaries = $phaseSummaries
-        pipeline_elapsed_seconds = if ($null -ne $pipelineStartUtc -and $null -ne $pipelineEndUtc) {
-            [math]::Round((New-TimeSpan -Start $pipelineStartUtc -End $pipelineEndUtc).TotalSeconds, 2)
-        }
-        else {
-            $null
-        }
-    }
 }
 
 function Get-LocalPhaseSummaryFromLog {
@@ -423,7 +219,7 @@ function Get-LocalBenchmarkLogSummary {
         $null
     }
     else {
-        Get-LocalDiagnosticTimingSummary -Path $DiagnosticLogPath
+        Get-DiagnosticPhaseTimingSummary -Path $DiagnosticLogPath
     }
 
     $phaseEntries = if ($null -ne $diagnosticTimingSummary -and @($diagnosticTimingSummary.phase_summaries).Count -gt 0) {
@@ -1659,15 +1455,6 @@ function Get-RunbookEvents {
     }
 
     return @($events | Sort-Object -Property timestamp_utc, message -Unique)
-}
-
-function Get-AvailableMemoryGB {
-    [CmdletBinding()]
-    [OutputType([double])]
-    param()
-
-    $os = Get-CimInstance Win32_OperatingSystem
-    return [math]::Round(($os.FreePhysicalMemory / 1MB), 2)
 }
 
 function Get-PreBenchmarkEnvironmentSnapshot {

--- a/tests/Measure-RunbookOnlyAzureBenchmark.ps1
+++ b/tests/Measure-RunbookOnlyAzureBenchmark.ps1
@@ -53,68 +53,7 @@ $script:DashboardDeliveryMode = $DashboardDeliveryMode
 $script:UseExistingExportsOnly = if ($PSBoundParameters.ContainsKey('UseExistingExportsOnly')) { [bool]$UseExistingExportsOnly } else { $true }
 $script:ExpectedTotalRows = $ExpectedTotalRows
 $script:PollIntervalSeconds = $PollIntervalSeconds
-
-function ConvertTo-UtcDateTime {
-    [CmdletBinding()]
-    [OutputType([datetime])]
-    param(
-        [Parameter(Mandatory = $false)]
-        [AllowNull()]
-        $Value
-    )
-
-    if ($null -eq $Value) {
-        return $null
-    }
-
-    if ($Value -is [datetime]) {
-        return ([datetime]$Value).ToUniversalTime()
-    }
-
-    if ($Value -is [datetimeoffset]) {
-        return ([datetimeoffset]$Value).UtcDateTime
-    }
-
-    $text = [string]$Value
-    if ([string]::IsNullOrWhiteSpace($text)) {
-        return $null
-    }
-
-    $parsed = [datetimeoffset]::MinValue
-    if ([datetimeoffset]::TryParse($text, [ref]$parsed)) {
-        return $parsed.UtcDateTime
-    }
-
-    return $null
-}
-
-function Invoke-GitText {
-    [CmdletBinding()]
-    [OutputType([string])]
-    param(
-        [Parameter(Mandatory = $true)]
-        [string]$RepoPath,
-
-        [Parameter(Mandatory = $true)]
-        [string[]]$Arguments
-    )
-
-    if (-not (Test-Path -LiteralPath $RepoPath -PathType Container)) {
-        return $null
-    }
-
-    $output = (& git -C $RepoPath @Arguments 2>$null | Out-String)
-    if ($LASTEXITCODE -ne 0) {
-        return $null
-    }
-
-    $trimmed = $output.Trim()
-    if ([string]::IsNullOrWhiteSpace($trimmed)) {
-        return $null
-    }
-
-    return $trimmed
-}
+. (Join-Path $PSScriptRoot 'helpers\TestScriptSupport.ps1')
 
 function Invoke-AzCli {
     [CmdletBinding()]

--- a/tests/Measure-StressRun.ps1
+++ b/tests/Measure-StressRun.ps1
@@ -38,48 +38,10 @@ param(
 
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
+. (Join-Path $PSScriptRoot 'helpers\TestScriptSupport.ps1')
 
 if (-not $IsWindows) {
     throw 'tests/Measure-StressRun.ps1 currently supports Windows only because it relies on Win32 CIM classes for process and memory sampling.'
-}
-
-function Get-AvailableMemoryGB {
-    [CmdletBinding()]
-    [OutputType([double])]
-    param()
-
-    $os = Get-CimInstance Win32_OperatingSystem
-    return [math]::Round(($os.FreePhysicalMemory / 1MB), 2)
-}
-
-function Get-HeartbeatTimestampText {
-    [CmdletBinding()]
-    [OutputType([string])]
-    param()
-
-    return (Get-Date).ToString('yyyy-MM-dd HH:mm:ss')
-}
-
-function Get-HeartbeatFileStatus {
-    [CmdletBinding()]
-    [OutputType([pscustomobject])]
-    param(
-        [Parameter(Mandatory = $true)]
-        [string]$Path
-    )
-
-    if (-not (Test-Path -LiteralPath $Path -PathType Leaf)) {
-        return [PSCustomObject]@{
-            bytes = 0L
-            ageSeconds = $null
-        }
-    }
-
-    $item = Get-Item -LiteralPath $Path
-    return [PSCustomObject]@{
-        bytes = [int64]$item.Length
-        ageSeconds = [math]::Round(((Get-Date).ToUniversalTime() - $item.LastWriteTimeUtc).TotalSeconds, 1)
-    }
 }
 
 function Get-StressReportObject {

--- a/tests/New-BenchmarkDataset.ps1
+++ b/tests/New-BenchmarkDataset.ps1
@@ -85,11 +85,19 @@ function Test-BenchmarkDatasetMetadataBreadthSupport {
     param(
         [Parameter(Mandatory = $false)]
         [AllowNull()]
-        $Metadata
+        $Metadata,
+
+        [Parameter(Mandatory = $false)]
+        [AllowNull()]
+        $Manifest
     )
 
     if ($null -eq $Metadata) {
         return $false
+    }
+
+    if (-not (Test-BenchmarkDatasetManifestBreadthSupport -Manifest $Manifest)) {
+        return $true
     }
 
     foreach ($propertyName in @('contentTemplateCount', 'uniqueCveIdCount', 'normalizedCveLookupCount')) {
@@ -99,6 +107,28 @@ function Test-BenchmarkDatasetMetadataBreadthSupport {
     }
 
     return $true
+}
+
+function Test-BenchmarkDatasetManifestBreadthSupport {
+    [CmdletBinding()]
+    [OutputType([bool])]
+    param(
+        [Parameter(Mandatory = $false)]
+        [AllowNull()]
+        $Manifest
+    )
+
+    if ($null -eq $Manifest) {
+        return $false
+    }
+
+    foreach ($propertyName in @('contentTemplateCount', 'uniqueCveIdCount', 'normalizedCveLookupCount')) {
+        if ($null -ne $Manifest.PSObject.Properties[$propertyName]) {
+            return $true
+        }
+    }
+
+    return $false
 }
 
 $repoRoot = Split-Path -Path $PSScriptRoot -Parent
@@ -127,7 +157,7 @@ if ((-not $Force) -and (Test-Path -LiteralPath $manifestPath -PathType Leaf)) {
             $null
         }
 
-        if (-not (Test-BenchmarkDatasetMetadataBreadthSupport -Metadata $existingMetadata)) {
+        if (-not (Test-BenchmarkDatasetMetadataBreadthSupport -Metadata $existingMetadata -Manifest $existingManifest)) {
             $metadata = Get-BenchmarkDatasetMetadataRecord -Definition $definition -DatasetPath $resolvedOutputPath -SourcePath (Resolve-BenchmarkDatasetSourcePath -Definition $definition -RepoRoot $repoRoot) -Manifest $existingManifest
             $metadata | ConvertTo-Json -Depth 20 | Set-Content -LiteralPath $metadataPath -Encoding utf8
         }

--- a/tests/New-BenchmarkDataset.ps1
+++ b/tests/New-BenchmarkDataset.ps1
@@ -17,6 +17,9 @@ param(
     [int]$MinimumFreeDiskGB = 10,
 
     [Parameter(Mandatory = $false)]
+    [switch]$AllowLargeDataset,
+
+    [Parameter(Mandatory = $false)]
     [switch]$Force
 )
 
@@ -24,6 +27,79 @@ Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
 . (Join-Path $PSScriptRoot 'Import-BenchmarkDatasetCatalog.ps1')
+
+function Get-BenchmarkDatasetMetadataRecord {
+    [CmdletBinding()]
+    [OutputType([ordered])]
+    param(
+        [Parameter(Mandatory = $true)]
+        $Definition,
+
+        [Parameter(Mandatory = $true)]
+        [string]$DatasetPath,
+
+        [Parameter(Mandatory = $true)]
+        [string]$SourcePath,
+
+        [Parameter(Mandatory = $false)]
+        [AllowNull()]
+        $Manifest
+    )
+
+    $generatedOnUtc = if ($null -ne $Manifest -and $Manifest.PSObject.Properties['generatedOnUtc']) {
+        $Manifest.generatedOnUtc
+    }
+    else {
+        [datetime]::UtcNow.ToString('o')
+    }
+
+    $metadata = [ordered]@{
+        id = [string]$Definition.id
+        description = [string]$Definition.description
+        preset = [string]$Definition.preset
+        seed = [int]$Definition.seed
+        targetDeviceCount = [int]$Definition.targetDeviceCount
+        targetTotalVulnRows = [int]$Definition.targetTotalVulnRows
+        sourcePath = $SourcePath
+        datasetPath = $DatasetPath
+        generatedBy = 'New-BenchmarkDataset.ps1'
+        generatedOnUtc = $generatedOnUtc
+        historyTags = @($Definition.historyTags)
+    }
+
+    if ($null -ne $Manifest) {
+        foreach ($propertyName in @('contentTemplateCount', 'uniqueCveIdCount', 'normalizedCveLookupCount')) {
+            $property = $Manifest.PSObject.Properties[$propertyName]
+            if ($null -ne $property) {
+                $metadata[$propertyName] = $property.Value
+            }
+        }
+    }
+
+    return $metadata
+}
+
+function Test-BenchmarkDatasetMetadataBreadthSupport {
+    [CmdletBinding()]
+    [OutputType([bool])]
+    param(
+        [Parameter(Mandatory = $false)]
+        [AllowNull()]
+        $Metadata
+    )
+
+    if ($null -eq $Metadata) {
+        return $false
+    }
+
+    foreach ($propertyName in @('contentTemplateCount', 'uniqueCveIdCount', 'normalizedCveLookupCount')) {
+        if ($null -eq $Metadata.PSObject.Properties[$propertyName]) {
+            return $false
+        }
+    }
+
+    return $true
+}
 
 $repoRoot = Split-Path -Path $PSScriptRoot -Parent
 $definition = Get-BenchmarkDatasetDefinition -DatasetId $DatasetId -RepoRoot $repoRoot
@@ -44,20 +120,15 @@ $metadataPath = Get-BenchmarkDatasetMetadataPath -DatasetPath $resolvedOutputPat
 if ((-not $Force) -and (Test-Path -LiteralPath $manifestPath -PathType Leaf)) {
     $existingManifest = Get-Content -LiteralPath $manifestPath -Raw | ConvertFrom-Json -Depth 20
     if (Test-BenchmarkDatasetDefinitionMatch -Definition $definition -Manifest $existingManifest) {
-        if (-not (Test-Path -LiteralPath $metadataPath -PathType Leaf)) {
-            $metadata = [ordered]@{
-                id = [string]$definition.id
-                description = [string]$definition.description
-                preset = [string]$definition.preset
-                seed = [int]$definition.seed
-                targetDeviceCount = [int]$definition.targetDeviceCount
-                targetTotalVulnRows = [int]$definition.targetTotalVulnRows
-                sourcePath = Resolve-BenchmarkDatasetSourcePath -Definition $definition -RepoRoot $repoRoot
-                datasetPath = $resolvedOutputPath
-                generatedBy = 'New-BenchmarkDataset.ps1'
-                generatedOnUtc = [datetime]::UtcNow.ToString('o')
-                historyTags = @($definition.historyTags)
-            }
+        $existingMetadata = if (Test-Path -LiteralPath $metadataPath -PathType Leaf) {
+            Get-Content -LiteralPath $metadataPath -Raw | ConvertFrom-Json -Depth 20
+        }
+        else {
+            $null
+        }
+
+        if (-not (Test-BenchmarkDatasetMetadataBreadthSupport -Metadata $existingMetadata)) {
+            $metadata = Get-BenchmarkDatasetMetadataRecord -Definition $definition -DatasetPath $resolvedOutputPath -SourcePath (Resolve-BenchmarkDatasetSourcePath -Definition $definition -RepoRoot $repoRoot) -Manifest $existingManifest
             $metadata | ConvertTo-Json -Depth 20 | Set-Content -LiteralPath $metadataPath -Encoding utf8
         }
 
@@ -86,21 +157,11 @@ if ((Test-Path -LiteralPath $resolvedOutputPath) -and $Force) {
     -Seed ([int]$definition.seed) `
     -MinimumAvailableMemoryGB $MinimumAvailableMemoryGB `
     -MinimumFreeDiskGB $MinimumFreeDiskGB `
+    -AllowLargeDataset:$AllowLargeDataset `
     -CleanOutput
 
-$metadata = [ordered]@{
-    id = [string]$definition.id
-    description = [string]$definition.description
-    preset = [string]$definition.preset
-    seed = [int]$definition.seed
-    targetDeviceCount = [int]$definition.targetDeviceCount
-    targetTotalVulnRows = [int]$definition.targetTotalVulnRows
-    sourcePath = $sourcePath
-    datasetPath = $resolvedOutputPath
-    generatedBy = 'New-BenchmarkDataset.ps1'
-    generatedOnUtc = [datetime]::UtcNow.ToString('o')
-    historyTags = @($definition.historyTags)
-}
+$generatedManifest = Get-Content -LiteralPath $manifestPath -Raw | ConvertFrom-Json -Depth 20
+$metadata = Get-BenchmarkDatasetMetadataRecord -Definition $definition -DatasetPath $resolvedOutputPath -SourcePath $sourcePath -Manifest $generatedManifest
 $metadata | ConvertTo-Json -Depth 20 | Set-Content -LiteralPath $metadataPath -Encoding utf8
 
 Write-Host ('Benchmark dataset ready: {0}' -f $resolvedOutputPath) -ForegroundColor Green

--- a/tests/README.md
+++ b/tests/README.md
@@ -309,7 +309,7 @@ That dataset definition currently maps to:
 For the larger reusable Azure stress seed, materialize or register the existing 50k-device dataset with:
 
 ```powershell
-pwsh -NoProfile -File .\tests\New-BenchmarkDataset.ps1 -DatasetId benchmark-large-50k-v1
+pwsh -NoProfile -File .\tests\New-BenchmarkDataset.ps1 -DatasetId benchmark-large-50k-v1 -AllowLargeDataset
 ```
 
 That dataset definition maps to:
@@ -319,6 +319,13 @@ That dataset definition maps to:
 - target vulnerability rows: `1,500,000`
 - seed: `20260322`
 - output path: `.local\large-datasets\synthetic-50k-1_5m`
+
+Each generated benchmark dataset now records durable breadth counters in both `synthetic-manifest.json` and `benchmark-dataset.json`:
+- `uniqueCveIdCount`: distinct raw `CveId` values present in the compact content dictionary
+- `normalizedCveLookupCount`: distinct normalized CVE lookup entries (`CveId` + score/severity/exploitability/url/title), which is the same breadth surfaced as `CVEs` in dashboard and Azure acceptance summaries
+- `contentTemplateCount`: distinct compact vulnerability content templates in the dataset
+
+Use those counters when you need to compare regenerated benchmark breadth over time without unpacking the dataset by hand.
 
 When you want to keep the large seed current and exercise the vulnerability-store merge path without regenerating 1.5M rows, create a shifted current-snapshot delta overlay with:
 

--- a/tests/Record-BenchmarkHistory.ps1
+++ b/tests/Record-BenchmarkHistory.ps1
@@ -454,6 +454,22 @@ function Format-PhaseDeltaSummaryValue {
     return ($phaseParts -join '; ')
 }
 
+function Format-BenchmarkBreadthValue {
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory = $false)]
+        [AllowNull()]
+        $Value
+    )
+
+    if ($null -eq $Value) {
+        return 'n/a'
+    }
+
+    return [string]$Value
+}
+
 function Write-BenchmarkHistorySummary {
     [CmdletBinding()]
     param(
@@ -490,7 +506,7 @@ function Write-BenchmarkHistorySummary {
     $datasetLabel = if (-not [string]::IsNullOrWhiteSpace([string]$Entry.dataset.definition_id)) { [string]$Entry.dataset.definition_id } else { [string]$Entry.dataset.leaf }
     $lines.Add(('- Dataset: `{0}` | preset `{1}` | `{2}` rows | `{3}` devices' -f $datasetLabel, $Entry.dataset.preset, $Entry.dataset.total_rows, $Entry.dataset.actual_device_count)) | Out-Null
     if ($null -ne $Entry.dataset.unique_cve_id_count -or $null -ne $Entry.dataset.normalized_cve_lookup_count -or $null -ne $Entry.dataset.content_template_count) {
-        $lines.Add(('- Dataset breadth: `{0}` unique CVE IDs | `{1}` normalized CVE lookups | `{2}` content templates' -f $Entry.dataset.unique_cve_id_count, $Entry.dataset.normalized_cve_lookup_count, $Entry.dataset.content_template_count)) | Out-Null
+        $lines.Add(('- Dataset breadth: `{0}` unique CVE IDs | `{1}` normalized CVE lookups | `{2}` content templates' -f (Format-BenchmarkBreadthValue -Value $Entry.dataset.unique_cve_id_count), (Format-BenchmarkBreadthValue -Value $Entry.dataset.normalized_cve_lookup_count), (Format-BenchmarkBreadthValue -Value $Entry.dataset.content_template_count))) | Out-Null
     }
     $lines.Add(('- Current baseline: `{0}`' -f $Entry.current.baseline)) | Out-Null
     if ($null -ne $Entry.current.repo) {

--- a/tests/Record-BenchmarkHistory.ps1
+++ b/tests/Record-BenchmarkHistory.ps1
@@ -20,29 +20,7 @@ $ErrorActionPreference = 'Stop'
 
 . (Join-Path $PSScriptRoot 'Import-BenchmarkDatasetCatalog.ps1')
 . (Join-Path $PSScriptRoot 'helpers\BenchmarkSeriesTools.ps1')
-
-function Get-ObjectPropertyValue {
-    [CmdletBinding()]
-    param(
-        [Parameter(Mandatory = $false)]
-        [AllowNull()]
-        $InputObject,
-
-        [Parameter(Mandatory = $true)]
-        [string]$Name
-    )
-
-    if ($null -eq $InputObject) {
-        return $null
-    }
-
-    $property = $InputObject.PSObject.Properties[$Name]
-    if ($null -eq $property) {
-        return $null
-    }
-
-    return $property.Value
-}
+. (Join-Path $PSScriptRoot 'helpers\TestScriptSupport.ps1')
 
 function Format-DateTimeValue {
     [CmdletBinding()]
@@ -76,34 +54,6 @@ function Format-DateTimeValue {
     }
 
     return $text
-}
-
-function Invoke-GitText {
-    [CmdletBinding()]
-    [OutputType([string])]
-    param(
-        [Parameter(Mandatory = $true)]
-        [string]$RepoPath,
-
-        [Parameter(Mandatory = $true)]
-        [string[]]$Arguments
-    )
-
-    if (-not (Test-Path -LiteralPath $RepoPath -PathType Container)) {
-        return $null
-    }
-
-    $output = (& git -C $RepoPath @Arguments 2>$null | Out-String)
-    if ($LASTEXITCODE -ne 0) {
-        return $null
-    }
-
-    $trimmed = $output.Trim()
-    if ([string]::IsNullOrWhiteSpace($trimmed)) {
-        return $null
-    }
-
-    return $trimmed
 }
 
 function Get-RepoSnapshot {
@@ -182,6 +132,9 @@ function Get-DatasetSummary {
         actual_current_rows = Get-ObjectPropertyValue -InputObject $manifest -Name 'actualCurrentRows'
         actual_history_rows = Get-ObjectPropertyValue -InputObject $manifest -Name 'actualHistoryRows'
         advanced_hunting_rows = Get-ObjectPropertyValue -InputObject $manifest -Name 'advancedHuntingRows'
+        content_template_count = Get-ObjectPropertyValue -InputObject $manifest -Name 'contentTemplateCount'
+        unique_cve_id_count = Get-ObjectPropertyValue -InputObject $manifest -Name 'uniqueCveIdCount'
+        normalized_cve_lookup_count = Get-ObjectPropertyValue -InputObject $manifest -Name 'normalizedCveLookupCount'
         history_periods = @((Get-ObjectPropertyValue -InputObject $manifest -Name 'historyPeriods') | ForEach-Object { [string]$_ })
     }
 }
@@ -536,6 +489,9 @@ function Write-BenchmarkHistorySummary {
     $lines.Add(('- Benchmark mode: `{0}`' -f $Entry.benchmark_mode)) | Out-Null
     $datasetLabel = if (-not [string]::IsNullOrWhiteSpace([string]$Entry.dataset.definition_id)) { [string]$Entry.dataset.definition_id } else { [string]$Entry.dataset.leaf }
     $lines.Add(('- Dataset: `{0}` | preset `{1}` | `{2}` rows | `{3}` devices' -f $datasetLabel, $Entry.dataset.preset, $Entry.dataset.total_rows, $Entry.dataset.actual_device_count)) | Out-Null
+    if ($null -ne $Entry.dataset.unique_cve_id_count -or $null -ne $Entry.dataset.normalized_cve_lookup_count -or $null -ne $Entry.dataset.content_template_count) {
+        $lines.Add(('- Dataset breadth: `{0}` unique CVE IDs | `{1}` normalized CVE lookups | `{2}` content templates' -f $Entry.dataset.unique_cve_id_count, $Entry.dataset.normalized_cve_lookup_count, $Entry.dataset.content_template_count)) | Out-Null
+    }
     $lines.Add(('- Current baseline: `{0}`' -f $Entry.current.baseline)) | Out-Null
     if ($null -ne $Entry.current.repo) {
         $lines.Add(('- Current git: `{0}` @ `{1}` ({2})' -f $Entry.current.repo.branch, $Entry.current.repo.commit_short, $(if ($Entry.current.repo.dirty) { 'dirty' } else { 'clean' }))) | Out-Null
@@ -581,6 +537,9 @@ function Write-BenchmarkHistorySummary {
         }
         $lines.Add(('- Runbook delta: {0}' -f (Format-DeltaValue -CurrentValue $Entry.current.runbook_elapsed_seconds -PreviousValue $PreviousEntry.current.runbook_elapsed_seconds))) | Out-Null
         $lines.Add(('- Function delta: {0}' -f (Format-DeltaValue -CurrentValue $Entry.current.function_elapsed_seconds -PreviousValue $PreviousEntry.current.function_elapsed_seconds))) | Out-Null
+        if ($null -ne $Entry.dataset.unique_cve_id_count -and $null -ne $PreviousEntry.dataset.unique_cve_id_count) {
+            $lines.Add(('- Dataset breadth delta: unique CVE IDs {0} | normalized CVE lookups {1} | content templates {2}' -f (Format-DeltaValue -CurrentValue $Entry.dataset.unique_cve_id_count -PreviousValue $PreviousEntry.dataset.unique_cve_id_count), (Format-DeltaValue -CurrentValue $Entry.dataset.normalized_cve_lookup_count -PreviousValue $PreviousEntry.dataset.normalized_cve_lookup_count), (Format-DeltaValue -CurrentValue $Entry.dataset.content_template_count -PreviousValue $PreviousEntry.dataset.content_template_count))) | Out-Null
+        }
         if ($null -ne $Entry.current.function_end_to_end_elapsed_seconds -and $null -ne $PreviousEntry.current.function_end_to_end_elapsed_seconds) {
             $lines.Add(('- Function end-to-end delta: {0}' -f (Format-DeltaValue -CurrentValue $Entry.current.function_end_to_end_elapsed_seconds -PreviousValue $PreviousEntry.current.function_end_to_end_elapsed_seconds))) | Out-Null
         }

--- a/tests/helpers/TestScriptSupport.ps1
+++ b/tests/helpers/TestScriptSupport.ps1
@@ -1,0 +1,289 @@
+# Shared helper surface for benchmark and validation scripts under tests\.
+
+function Get-AvailableMemoryGB {
+    [CmdletBinding()]
+    [OutputType([double])]
+    param()
+
+    if (-not $IsWindows) {
+        return [double]::NaN
+    }
+
+    $os = Get-CimInstance Win32_OperatingSystem -ErrorAction Stop
+    return [math]::Round(($os.FreePhysicalMemory / 1MB), 2)
+}
+
+function Get-HeartbeatTimestampText {
+    [CmdletBinding()]
+    [OutputType([string])]
+    param()
+
+    return (Get-Date).ToString('yyyy-MM-dd HH:mm:ss')
+}
+
+function Get-HeartbeatFileStatus {
+    [CmdletBinding()]
+    [OutputType([pscustomobject])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Path
+    )
+
+    if (-not (Test-Path -LiteralPath $Path -PathType Leaf)) {
+        return [PSCustomObject]@{
+            bytes = 0L
+            ageSeconds = $null
+        }
+    }
+
+    $item = Get-Item -LiteralPath $Path
+    return [PSCustomObject]@{
+        bytes = [int64]$item.Length
+        ageSeconds = [math]::Round(((Get-Date).ToUniversalTime() - $item.LastWriteTimeUtc).TotalSeconds, 1)
+    }
+}
+
+function Get-TextWithoutAnsiEscape {
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [AllowEmptyString()]
+        [string]$Text
+    )
+
+    return ([regex]::Replace($Text, "`e\[[0-9;]*m", ''))
+}
+
+function ConvertTo-UtcDateTime {
+    [CmdletBinding()]
+    [OutputType([datetime])]
+    param(
+        [Parameter(Mandatory = $false)]
+        [AllowNull()]
+        $Value
+    )
+
+    if ($null -eq $Value) {
+        return $null
+    }
+
+    if ($Value -is [datetime]) {
+        return ([datetime]$Value).ToUniversalTime()
+    }
+
+    if ($Value -is [datetimeoffset]) {
+        return ([datetimeoffset]$Value).UtcDateTime
+    }
+
+    $text = [string]$Value
+    if ([string]::IsNullOrWhiteSpace($text)) {
+        return $null
+    }
+
+    $parsed = [datetimeoffset]::MinValue
+    if ([datetimeoffset]::TryParse($text, [ref]$parsed)) {
+        return $parsed.UtcDateTime
+    }
+
+    return $null
+}
+
+function Get-ObjectPropertyValue {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $false)]
+        [AllowNull()]
+        $InputObject,
+
+        [Parameter(Mandatory = $true)]
+        [string]$Name
+    )
+
+    if ($null -eq $InputObject) {
+        return $null
+    }
+
+    $property = $InputObject.PSObject.Properties[$Name]
+    if ($null -eq $property) {
+        return $null
+    }
+
+    return $property.Value
+}
+
+function Test-ScriptParameterSupport {
+    [CmdletBinding()]
+    [OutputType([bool])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$ScriptPath,
+
+        [Parameter(Mandatory = $true)]
+        [string]$ParameterName
+    )
+
+    if (-not (Test-Path -LiteralPath $ScriptPath -PathType Leaf)) {
+        return $false
+    }
+
+    try {
+        $command = Get-Command -Name $ScriptPath -ErrorAction Stop
+        return $command.Parameters.ContainsKey($ParameterName)
+    }
+    catch {
+        Write-Verbose ("Unable to inspect parameters for {0}: {1}" -f $ScriptPath, $_.Exception.Message)
+        return $false
+    }
+}
+
+function Invoke-GitText {
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$RepoPath,
+
+        [Parameter(Mandatory = $true)]
+        [string[]]$Arguments
+    )
+
+    if (-not (Test-Path -LiteralPath $RepoPath -PathType Container)) {
+        return $null
+    }
+
+    $output = (& git -C $RepoPath @Arguments 2>$null | Out-String)
+    if ($LASTEXITCODE -ne 0) {
+        return $null
+    }
+
+    $trimmed = $output.Trim()
+    if ([string]::IsNullOrWhiteSpace($trimmed)) {
+        return $null
+    }
+
+    return $trimmed
+}
+
+function Add-PathSuffixBeforeExtensionLocal {
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Path,
+
+        [Parameter(Mandatory = $true)]
+        [string]$Suffix
+    )
+
+    $extension = [System.IO.Path]::GetExtension($Path)
+    if ([string]::IsNullOrEmpty($extension)) {
+        return ($Path + $Suffix)
+    }
+
+    return ($Path.Substring(0, $Path.Length - $extension.Length) + $Suffix + $extension)
+}
+
+function Get-DiagnosticPhaseTimingSummary {
+    [CmdletBinding()]
+    [OutputType([pscustomobject])]
+    param(
+        [Parameter(Mandatory = $false)]
+        [AllowEmptyString()]
+        [string]$Path
+    )
+
+    if ([string]::IsNullOrWhiteSpace($Path) -or -not (Test-Path -LiteralPath $Path -PathType Leaf)) {
+        return $null
+    }
+
+    $phaseByName = [ordered]@{}
+    $pipelineStartUtc = $null
+    $pipelineEndUtc = $null
+
+    foreach ($line in Get-Content -LiteralPath $Path) {
+        if ([string]::IsNullOrWhiteSpace($line)) {
+            continue
+        }
+
+        $parts = @([string]$line -split "`t")
+        if ($parts.Count -lt 3) {
+            continue
+        }
+
+        $timestampUtc = ConvertTo-UtcDateTime -Value $parts[0]
+        if ($null -eq $timestampUtc) {
+            continue
+        }
+
+        $eventType = [string]$parts[1]
+        $name = [string]$parts[2]
+        $status = if ($parts.Count -ge 4) { [string]$parts[3] } else { $null }
+
+        switch ($eventType) {
+            'pipeline-start' {
+                if ($null -eq $pipelineStartUtc) {
+                    $pipelineStartUtc = $timestampUtc
+                }
+            }
+            'pipeline-end' {
+                $pipelineEndUtc = $timestampUtc
+            }
+            'phase-start' {
+                if (-not $phaseByName.Contains($name)) {
+                    $phaseByName[$name] = [ordered]@{
+                        name = $name
+                        start_utc = $null
+                        end_utc = $null
+                        status = $null
+                    }
+                }
+
+                if ($null -eq $phaseByName[$name].start_utc) {
+                    $phaseByName[$name].start_utc = $timestampUtc
+                }
+            }
+            'phase-end' {
+                if (-not $phaseByName.Contains($name)) {
+                    $phaseByName[$name] = [ordered]@{
+                        name = $name
+                        start_utc = $null
+                        end_utc = $null
+                        status = $null
+                    }
+                }
+
+                $phaseByName[$name].end_utc = $timestampUtc
+                $phaseByName[$name].status = $status
+            }
+        }
+    }
+
+    $phaseSummaries = @(
+        foreach ($phaseEntry in $phaseByName.Values) {
+            $elapsedSeconds = if ($null -ne $phaseEntry.start_utc -and $null -ne $phaseEntry.end_utc) {
+                [math]::Round((New-TimeSpan -Start $phaseEntry.start_utc -End $phaseEntry.end_utc).TotalSeconds, 2)
+            }
+            else {
+                $null
+            }
+
+            [PSCustomObject]@{
+                name = [string]$phaseEntry.name
+                status = if ([string]::IsNullOrWhiteSpace([string]$phaseEntry.status)) { 'unknown' } else { [string]$phaseEntry.status }
+                elapsedSeconds = $elapsedSeconds
+            }
+        }
+    )
+
+    return [PSCustomObject]@{
+        path = $Path
+        phase_summaries = $phaseSummaries
+        pipeline_elapsed_seconds = if ($null -ne $pipelineStartUtc -and $null -ne $pipelineEndUtc) {
+            [math]::Round((New-TimeSpan -Start $pipelineStartUtc -End $pipelineEndUtc).TotalSeconds, 2)
+        }
+        else {
+            $null
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add CODEOWNERS plus source-of-truth guidance for tracked generated artifacts
- extract dashboard runtime-contract and validation-plan helpers without behavior changes
- deduplicate repeated benchmark/test helpers into `tests/helpers/TestScriptSupport.ps1`
- persist synthetic dataset breadth counters and document the seeded-large CVE drift findings

## Validation
- `pwsh -NoProfile -File .\build\Invoke-RegressionValidation.ps1`
- `pwsh -NoProfile -File .\tests\Run-SharedHelperRegression.ps1`
- `pwsh -NoProfile -File .\tests\Invoke-BenchmarkSeries.ps1 -BenchmarkDatasetId benchmark-medium-v1 -Iterations 1 -LocalOnly`
- `pwsh -NoProfile -File .\tests\New-BenchmarkDataset.ps1 -DatasetId benchmark-large-50k-v1 -AllowLargeDataset`
- `pwsh -NoProfile -File .\build\Invoke-AzureDeploymentValidation.ps1 -AutomationAccountName aa-defender-reporting -FunctionAppName func-defender-reporting -DashboardDeliveryMode Dual -SkipMdePermissions -FunctionExecutionDatasetPath .\.local\large-datasets\synthetic-50k-1_5m`
- reseeded the canonical seeded dataset into Azure storage before each rerun, then ran `pwsh -NoProfile -File .\tests\Measure-RunbookOnlyAzureBenchmark.ps1 -DashboardDeliveryMode Dual -UseExistingExportsOnly` twice (`-SkipDeployRunbook -SkipTemplateUpload` on rerun 2) to confirm the runbook memory delta was Azure working-set variance rather than a stable regression