### PR TITLE
Handle Flex deployment RBAC lag

### DIFF
--- a/Setup-AzureResources.ps1
+++ b/Setup-AzureResources.ps1
@@ -1164,8 +1164,10 @@ try {
             }
         }
 
-        # Poll to verify role assignments are effective
-        Wait-WithPolling -Description "RBAC propagation" -IntervalSeconds 5 -TimeoutSeconds 30 -Condition {
+        # Poll until ARM reflects the role assignment records. Storage data-plane
+        # authorization can still lag behind ARM visibility, so the zip deployment
+        # loop also retries storage 403s with backoff.
+        Wait-WithPolling -Description "RBAC records visible in ARM" -IntervalSeconds 5 -TimeoutSeconds 120 -Condition {
             $saResource = Invoke-ArmApi -Path "$subPath/resourceGroups/$ResourceGroupName/providers/Microsoft.Storage/storageAccounts/$StorageAccountName/providers/Microsoft.Authorization/roleAssignments?api-version=$($Script:ArmApiVersions.RoleAssignment)&`$filter=principalId eq '$miPrincipalId'" -Method GET -Description "Check RBAC"
             return ($saResource.value.Count -ge 3)
         } | Out-Null
@@ -1526,7 +1528,7 @@ try {
             }
 
             try {
-                $maxAttempts = 3
+                $maxAttempts = 5
                 $deployed = $false
                 for ($attempt = 1; $attempt -le $maxAttempts; $attempt++) {
                     $deployOutput = @(az functionapp deployment source config-zip `
@@ -1573,6 +1575,13 @@ try {
                     if ($attempt -lt $maxAttempts -and $deployText -match 'BadGatewayConnection|Bad Gateway') {
                         Write-Warning ("Function App zip deployment hit a transient gateway error (attempt {0}/{1}). Retrying..." -f $attempt, $maxAttempts)
                         Start-Sleep -Seconds (5 * $attempt)
+                        continue
+                    }
+
+                    if ($attempt -lt $maxAttempts -and $deployText -match 'InaccessibleStorageException|BlobUploadFailed|403|inaccessible') {
+                        $waitSeconds = 60 * $attempt
+                        Write-Warning ("Function App zip deployment hit a storage access error (attempt {0}/{1}). Waiting {2}s for storage RBAC propagation before retrying..." -f $attempt, $maxAttempts, $waitSeconds)
+                        Start-Sleep -Seconds $waitSeconds
                         continue
                     }
 


### PR DESCRIPTION
## Summary
- extend the Function App RBAC visibility wait to reflect ARM vs storage data-plane propagation
- retry Flex zip deployment when storage access is still propagating instead of failing on the first 403
- keep the existing transient gateway retry behavior intact

## Validation
- deployed Azure Automation in a fresh resource group with seeded exports and confirmed the runbook path succeeded
- deployed a Function App into the same resource group using the same storage account and confirmed setup completed successfully
- confirmed the Function App status blob reported `succeeded` with `useExistingExportsOnly: true`
- validated the Function-produced dashboard against the Automation baseline and confirmed `BaselineDashboardCoverage.ExactMatch: true`

## Notes
- `westus2` hit this subscription's Automation Account quota during validation, so the successful end-to-end run used `eastus`
- the first Flex zip deploy reproduced `InaccessibleStorageException` / blob `403` until storage RBAC finished propagating, which this change now handles with backoff