### PR TITLE
Add Function App packaging entrypoint

### DIFF
--- a/.github/workflows/sync-azure-package.yml
+++ b/.github/workflows/sync-azure-package.yml
@@ -12,7 +12,6 @@ on:
       - 'Setup-AzureResources.ps1'
       - 'templates/**'
       - 'azure/**'
-      - 'build/Build-FunctionAppPackage.ps1'
       - 'build/Build-AzureReleasePackage.ps1'
       - 'build/Build-SharedHelpers.ps1'
       - 'build/private/AzureArtifactBuildTools.ps1'

--- a/.github/workflows/sync-azure-package.yml
+++ b/.github/workflows/sync-azure-package.yml
@@ -12,6 +12,7 @@ on:
       - 'Setup-AzureResources.ps1'
       - 'templates/**'
       - 'azure/**'
+      - 'build/Build-FunctionAppPackage.ps1'
       - 'build/Build-AzureReleasePackage.ps1'
       - 'build/Build-SharedHelpers.ps1'
       - 'build/private/AzureArtifactBuildTools.ps1'

--- a/Setup-AzureResources.ps1
+++ b/Setup-AzureResources.ps1
@@ -1523,13 +1523,24 @@ try {
             # Steps 9-12 (FunctionApp): Build deployment zip and deploy
             Write-Host "`nSteps 9-12: Building and deploying Function App..." -ForegroundColor Cyan
 
-            # Build the Function App from build/azure/runbook-source.ps1 when the build source is available.
+            $packageScript = Join-Path $PSScriptRoot 'build' 'Build-FunctionAppPackage.ps1'
             $buildScript = Join-Path $PSScriptRoot 'build' 'azure' 'Build-FunctionApp.ps1'
             $functionAppDir = Join-Path $PSScriptRoot 'azure' 'function-app'
             $functionAppEntryPoint = Join-Path $functionAppDir 'ExportAndGenerate' 'run.ps1'
             $functionAppModulesPath = Join-Path $functionAppDir 'Modules' 'Az.Accounts'
+            $zipMetadataPath = $null
+            $zipPath = Join-Path ([System.IO.Path]::GetTempPath()) ('funcapp-deploy-' + [guid]::NewGuid().ToString('N') + '.zip')
+            if (Test-Path $zipPath) { Remove-Item $zipPath -Force }
 
-            if (Test-Path $buildScript) {
+            if (Test-Path $packageScript) {
+                $zipMetadataPath = Join-Path ([System.IO.Path]::GetTempPath()) ('funcapp-deploy-' + [guid]::NewGuid().ToString('N') + '.manifest.json')
+                Write-Host "  Building Function App deployment package..." -ForegroundColor Gray
+                & $packageScript -OutputPath $zipPath -MetadataPath $zipMetadataPath
+                Write-Host "  Function App package built successfully" -ForegroundColor Green
+            }
+            elseif (Test-Path $buildScript) {
+                # Release packages do not ship build/Build-FunctionAppPackage.ps1, so preserve
+                # the older source-build fallback when only the low-level build script is present.
                 Write-Host "  Building Function App from build/azure/runbook-source.ps1..." -ForegroundColor Gray
                 & $buildScript
                 # Build-FunctionApp.ps1 uses $ErrorActionPreference = 'Stop' and throws
@@ -1546,14 +1557,14 @@ try {
             # Deploy function app code via az CLI zip deployment (Flex Consumption
             # uses a Kudu-lite pipeline that packages and uploads to blob storage)
             Write-Host "  Deploying function app code via zip deployment..." -ForegroundColor Gray
-            $zipPath = Join-Path ([System.IO.Path]::GetTempPath()) ('funcapp-deploy-' + [guid]::NewGuid().ToString('N') + '.zip')
-            if (Test-Path $zipPath) { Remove-Item $zipPath -Force }
-
-            Push-Location $functionAppDir
-            try {
-                Compress-Archive -Path '.\*' -DestinationPath $zipPath -Force
-            } finally {
-                Pop-Location
+            if (-not (Test-Path -LiteralPath $zipPath -PathType Leaf)) {
+                Push-Location $functionAppDir
+                try {
+                    Compress-Archive -Path '.\*' -DestinationPath $zipPath -Force
+                }
+                finally {
+                    Pop-Location
+                }
             }
 
             try {
@@ -1623,6 +1634,9 @@ try {
             }
             finally {
                 Remove-Item $zipPath -Force -ErrorAction SilentlyContinue
+                if (-not [string]::IsNullOrWhiteSpace($zipMetadataPath)) {
+                    Remove-Item $zipMetadataPath -Force -ErrorAction SilentlyContinue
+                }
             }
 
             Write-Host "  Function App deployed successfully" -ForegroundColor Green

--- a/build/Build-AzureReleasePackage.ps1
+++ b/build/Build-AzureReleasePackage.ps1
@@ -25,7 +25,7 @@ Write-Output 'Building Azure runbook artifact...'
 & (Join-Path $buildRoot 'azure\Build-Runbook.ps1')
 
 Write-Output 'Building Azure Function App artifact...'
-& (Join-Path $buildRoot 'azure\Build-FunctionApp.ps1')
+$functionAppArtifactState = Initialize-AzureFunctionAppArtifactState -BuildContext $azureBuildContext
 
 $requiredLeafPaths = @(
     Join-Path $repoRoot 'Setup-AzureResources.ps1'
@@ -53,9 +53,9 @@ if ([string]::IsNullOrWhiteSpace($sharedHelpersFingerprint)) {
     throw "Generated shared helpers '$($azureBuildContext.SharedHelpersPath)' are missing fingerprint metadata."
 }
 $runbookFingerprintState = Assert-AzureArtifactFingerprint -ArtifactPath $azureBuildContext.RunbookOutputPath -ExpectedFingerprint $sharedHelpersFingerprint -ArtifactDescription 'Azure Automation runbook artifact'
-$functionAppEntryPointPath = Join-Path $azureBuildContext.FunctionAppRoot 'ExportAndGenerate\run.ps1'
-$functionAppFingerprintState = Assert-AzureArtifactFingerprint -ArtifactPath $functionAppEntryPointPath -ExpectedFingerprint $sharedHelpersFingerprint -ArtifactDescription 'Azure Function App entry point artifact'
-$stagedModuleSummary = Get-AzAccountsModuleStagingSummary -ModuleRoot (Join-Path $azureBuildContext.FunctionAppRoot 'Modules\Az.Accounts') -RepoRoot $repoRoot
+$functionAppEntryPointPath = $functionAppArtifactState.EntryPointPath
+$functionAppFingerprintState = $functionAppArtifactState.EntryPointFingerprintState
+$stagedModuleSummary = $functionAppArtifactState.ModuleSummary
 
 Initialize-ParentDirectory -Path $OutputPath
 if (Test-Path -LiteralPath $OutputPath -PathType Leaf) {
@@ -84,7 +84,7 @@ finally {
 }
 
 $outputItem = Get-Item -LiteralPath $OutputPath
-$manifestPath = Join-Path (Split-Path -Path $OutputPath -Parent) (([System.IO.Path]::GetFileNameWithoutExtension($OutputPath)) + '.manifest.json')
+$manifestPath = Get-AzurePackageManifestPath -PackagePath $OutputPath
 $packageManifest = [PSCustomObject]@{
     generatedOnUtc = [datetime]::UtcNow.ToString('o')
     packagePath = $outputItem.FullName
@@ -95,8 +95,10 @@ $packageManifest = [PSCustomObject]@{
     functionAppFingerprint = $functionAppFingerprintState.Fingerprint
     stagedAzAccountsModule = [PSCustomObject]@{
         version = $stagedModuleSummary.ModuleVersion
+        bundledVersions = @($stagedModuleSummary.BundledVersions)
         fileCount = $stagedModuleSummary.FileCount
         manifestPath = $stagedModuleSummary.ManifestDisplayPath
+        manifestPaths = @($stagedModuleSummary.BundledManifestPaths)
     }
     payloadFiles = @(
         [PSCustomObject]@{

--- a/build/Build-FunctionAppPackage.ps1
+++ b/build/Build-FunctionAppPackage.ps1
@@ -1,0 +1,84 @@
+#Requires -Version 7.0
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $false)]
+    [string]$OutputPath,
+
+    [Parameter(Mandatory = $false)]
+    [string]$MetadataPath
+)
+
+. (Join-Path -Path $PSScriptRoot -ChildPath 'private\AzureArtifactBuildTools.ps1')
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$repoRoot = Split-Path -Path $PSScriptRoot -Parent
+$azureBuildContext = Get-AzureArtifactBuildContext -BuildScriptRoot (Join-Path $PSScriptRoot 'azure')
+
+if (-not $PSBoundParameters.ContainsKey('OutputPath')) {
+    $OutputPath = Get-AzureFunctionAppPackageDefaultOutputPath -RepoRoot $repoRoot
+}
+
+if (-not $PSBoundParameters.ContainsKey('MetadataPath')) {
+    $MetadataPath = Get-AzurePackageManifestPath -PackagePath $OutputPath
+}
+
+Write-Output 'Building Azure Function App deployment package...'
+$functionAppArtifactState = Initialize-AzureFunctionAppArtifactState -BuildContext $azureBuildContext
+
+Initialize-ParentDirectory -Path $OutputPath
+Initialize-ParentDirectory -Path $MetadataPath
+if (Test-Path -LiteralPath $OutputPath -PathType Leaf) {
+    Remove-Item -LiteralPath $OutputPath -Force
+}
+
+if (Test-Path -LiteralPath $MetadataPath -PathType Leaf) {
+    Remove-Item -LiteralPath $MetadataPath -Force
+}
+
+$packageRoot = Join-Path -Path ([System.IO.Path]::GetTempPath()) -ChildPath ('function-app-package-' + [guid]::NewGuid().ToString('N'))
+$stagingRoot = Join-Path -Path $packageRoot -ChildPath 'payload'
+
+try {
+    New-Item -Path $stagingRoot -ItemType Directory -Force | Out-Null
+    foreach ($item in Get-ChildItem -LiteralPath $azureBuildContext.FunctionAppRoot -Force -ErrorAction Stop) {
+        Copy-Item -LiteralPath $item.FullName -Destination $stagingRoot -Recurse -Force
+    }
+
+    Compress-Archive -Path (Join-Path -Path $stagingRoot -ChildPath '*') -DestinationPath $OutputPath -Force
+}
+finally {
+    if (Test-Path -LiteralPath $packageRoot) {
+        Remove-Item -LiteralPath $packageRoot -Recurse -Force -ErrorAction SilentlyContinue
+    }
+}
+
+$outputItem = Get-Item -LiteralPath $OutputPath
+$packageManifest = [PSCustomObject]@{
+    generatedOnUtc = [datetime]::UtcNow.ToString('o')
+    buildScript = 'build/Build-FunctionAppPackage.ps1'
+    packagePath = $outputItem.FullName
+    packageSha256 = Get-FileContentSha256Hex -Path $outputItem.FullName
+    packageSizeBytes = $outputItem.Length
+    sourcePath = 'azure/function-app'
+    functionAppEntryPoint = 'azure/function-app/ExportAndGenerate/run.ps1'
+    functionAppEntryPointSha256 = Get-FileContentSha256Hex -Path $functionAppArtifactState.EntryPointPath
+    functionAppEntryPointFingerprint = $functionAppArtifactState.EntryPointFingerprintState.Fingerprint
+    sharedHelpersFingerprint = $functionAppArtifactState.SharedHelpersFingerprint
+    stagedAzAccountsModule = [PSCustomObject]@{
+        version = $functionAppArtifactState.ModuleSummary.ModuleVersion
+        bundledVersions = @($functionAppArtifactState.ModuleSummary.BundledVersions)
+        fileCount = $functionAppArtifactState.ModuleSummary.FileCount
+        manifestPath = $functionAppArtifactState.ModuleSummary.ManifestDisplayPath
+        manifestPaths = @($functionAppArtifactState.ModuleSummary.BundledManifestPaths)
+    }
+}
+Write-Utf8BomFile -Path $MetadataPath -Content (($packageManifest | ConvertTo-Json -Depth 10) + [Environment]::NewLine)
+
+Write-Output ("Created Function App package: {0}" -f $outputItem.FullName)
+Write-Output ("Package size: {0:N2} MB" -f ($outputItem.Length / 1MB))
+Write-Output ("Function App fingerprint: {0}" -f $functionAppArtifactState.EntryPointFingerprintState.Fingerprint)
+Write-Output ("Staged Az.Accounts module: v{0} ({1} files)" -f $functionAppArtifactState.ModuleSummary.ModuleVersion, $functionAppArtifactState.ModuleSummary.FileCount)
+Write-Output ("Function App package manifest: {0}" -f $MetadataPath)

--- a/build/README.md
+++ b/build/README.md
@@ -25,6 +25,9 @@ This directory contains maintainer-facing build, validation, import, and packagi
 .\build\azure\Build-Runbook.ps1
 .\build\azure\Build-FunctionApp.ps1
 
+# Build the stable Function App deployment zip + manifest used by wrappers/CI
+.\build\Build-FunctionAppPackage.ps1
+
 # Run the deterministic local and CI-aligned preflight path
 .\build\Invoke-RegressionValidation.ps1
 
@@ -77,7 +80,7 @@ When you change `src/powershell/Shared/**/*.ps1` or `build/azure/runbook-source.
 .\build\azure\Build-FunctionApp.ps1 -SkipModuleStaging
 ```
 
-Use the default `Build-FunctionApp.ps1` invocation when you also need module staging for packaging. `-SkipModuleStaging` is sufficient for the routine script-only refresh loop.
+Use the default `Build-FunctionApp.ps1` invocation when you only need the generated entry point plus staged modules refreshed in place. Use `Build-FunctionAppPackage.ps1` when you need the stable deployable zip/manifest surface for CI, wrappers, or manual zip deployment. `-SkipModuleStaging` is sufficient for the routine script-only refresh loop.
 
 ## User-facing scripts
 

--- a/build/private/AzureArtifactBuildTools.ps1
+++ b/build/private/AzureArtifactBuildTools.ps1
@@ -54,6 +54,34 @@ function Initialize-ParentDirectory {
     }
 }
 
+function Get-AzurePackageManifestPath {
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$PackagePath
+    )
+
+    $packageDirectory = Split-Path -Path $PackagePath -Parent
+    $packageBaseName = [System.IO.Path]::GetFileNameWithoutExtension($PackagePath)
+    if ([string]::IsNullOrWhiteSpace($packageDirectory) -or [string]::IsNullOrWhiteSpace($packageBaseName)) {
+        throw "Could not derive a package manifest path from '$PackagePath'."
+    }
+
+    return Join-Path -Path $packageDirectory -ChildPath ($packageBaseName + '.manifest.json')
+}
+
+function Get-AzureFunctionAppPackageDefaultOutputPath {
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$RepoRoot
+    )
+
+    return Join-Path -Path $RepoRoot -ChildPath '.local\local-reports\function-app-package\defender-reporting-function-app.zip'
+}
+
 function Get-AzureSharedAssemblyInput {
     [CmdletBinding()]
     [OutputType([pscustomobject])]
@@ -184,7 +212,8 @@ function Get-AzAccountsModuleStagingSummary {
         }
     }
 
-    $selectedManifest = $validManifests | Sort-Object -Property ModuleVersion -Descending | Select-Object -First 1
+    $orderedValidManifests = @($validManifests | Sort-Object -Property ModuleVersion -Descending)
+    $selectedManifest = $orderedValidManifests | Select-Object -First 1
     if ($null -eq $selectedManifest) {
         $failurePreview = @(
             $manifestValidationFailures |
@@ -207,14 +236,66 @@ function Get-AzAccountsModuleStagingSummary {
     }
 
     $manifestDisplayPath = [string]$selectedManifest.DisplayPath
+    $bundledVersions = @(
+        $orderedValidManifests |
+            Sort-Object -Property ModuleVersion -Descending -Unique |
+            ForEach-Object { $_.ModuleVersion.ToString() }
+    )
+    $bundledManifestPaths = @(
+        $orderedValidManifests |
+            ForEach-Object { [string]$_.DisplayPath }
+    )
 
     return [PSCustomObject]@{
         ModuleRoot = $ModuleRoot
         ManifestPath = $selectedManifest.Path
         ManifestDisplayPath = $manifestDisplayPath
         ModuleVersion = $selectedManifest.ModuleVersion.ToString()
+        BundledVersions = $bundledVersions
+        BundledManifestPaths = $bundledManifestPaths
         FileCount = $fileCount
         InvalidManifestCandidateCount = $manifestValidationFailures.Count
+    }
+}
+
+function Initialize-AzureFunctionAppArtifactState {
+    [CmdletBinding()]
+    [OutputType([pscustomobject])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [pscustomobject]$BuildContext
+    )
+
+    $buildScriptPath = Join-Path -Path $BuildContext.BuildRoot -ChildPath 'azure\Build-FunctionApp.ps1'
+    $entryPointPath = Join-Path -Path $BuildContext.FunctionAppRoot -ChildPath 'ExportAndGenerate\run.ps1'
+    $moduleRoot = Join-Path -Path $BuildContext.FunctionAppRoot -ChildPath 'Modules\Az.Accounts'
+
+    if (Test-Path -LiteralPath $buildScriptPath -PathType Leaf) {
+        & $buildScriptPath | ForEach-Object { Write-Host $_ }
+    }
+    elseif ((Test-Path -LiteralPath $entryPointPath -PathType Leaf) -and (Test-Path -LiteralPath $moduleRoot -PathType Container)) {
+        # Prebuilt release-package flow: the generated entry point and staged modules
+        # are already present even though the source build script is not shipped.
+    }
+    else {
+        throw "Function App build script not found at $buildScriptPath and prebuilt artifacts are incomplete. Expected '$entryPointPath' and '$moduleRoot'."
+    }
+
+    $sharedHelpersFingerprint = Read-PowerShellArtifactEmbeddedFingerprint -Path $BuildContext.SharedHelpersPath
+    if ([string]::IsNullOrWhiteSpace($sharedHelpersFingerprint)) {
+        throw "Generated shared helpers '$($BuildContext.SharedHelpersPath)' are missing fingerprint metadata."
+    }
+
+    $entryPointFingerprintState = Assert-AzureArtifactFingerprint -ArtifactPath $entryPointPath -ExpectedFingerprint $sharedHelpersFingerprint -ArtifactDescription 'Azure Function App entry point artifact'
+    $moduleSummary = Get-AzAccountsModuleStagingSummary -ModuleRoot $moduleRoot -RepoRoot $BuildContext.RepoRoot
+
+    return [PSCustomObject]@{
+        BuildScriptPath = $buildScriptPath
+        EntryPointPath = $entryPointPath
+        ModuleRoot = $moduleRoot
+        SharedHelpersFingerprint = $sharedHelpersFingerprint
+        EntryPointFingerprintState = $entryPointFingerprintState
+        ModuleSummary = $moduleSummary
     }
 }
 

--- a/docs/azure-setup.md
+++ b/docs/azure-setup.md
@@ -232,9 +232,14 @@ To change the pipeline logic:
 
 # Rebuild the Function App entry point
 .\build\azure\Build-FunctionApp.ps1
+
+# Build the stable Function App deployment zip + sidecar manifest
+.\build\Build-FunctionAppPackage.ps1
 ```
 
 The Function App build transforms `runbook-source.ps1` into a timer-triggered function, replacing Automation Account variables with environment variable lookups and inlining the manifest-driven shared helper bundle generated from `src/powershell/Shared/`.
+
+`build/Build-FunctionAppPackage.ps1` is the supported packaging surface for CI and wrapper repositories. By default it rebuilds the generated Function App artifacts, stages `Az.Accounts`, writes a stable zip to `.local/local-reports/function-app-package/defender-reporting-function-app.zip`, and emits a sibling `.manifest.json` file that records the package path, SHA-256, and Function App artifact fingerprints.
 
 ## Related docs
 


### PR DESCRIPTION
## Summary
- add a stable public build/Build-FunctionAppPackage.ps1 surface for Function App packaging
- refactor Setup-AzureResources.ps1 and Azure release packaging to consume the new artifact helpers
- document the package-manifest contract used by the azd wrapper

## Validation
- pwsh -NoLogo -NoProfile -File .\build\Build-FunctionAppPackage.ps1
- pwsh -NoLogo -NoProfile -File .\build\Build-AzureReleasePackage.ps1 -OutputPath .local\local-reports\validation\Azure-validation.zip
- pwsh -NoLogo -NoProfile -File .\build\Invoke-RegressionValidation.ps1 (stops only at the pre-existing 4 GB large-dataset memory guard in tests\Generate-SyntheticLargeExports.ps1 after earlier phases pass)