### PR TITLE
Refresh MDE token lifecycle

### DIFF
--- a/Generate-VulnerabilityDashboard.ps1
+++ b/Generate-VulnerabilityDashboard.ps1
@@ -740,8 +740,8 @@ try {
         if ((-not $PackageOnly) -and $ExportMachineData) {
             $phaseContext = Get-LocalDiagnosticPhaseContext -Name 'Export machine data'
             try {
-                $accessToken = Get-MdeAccessToken -AccessToken $DefenderAccessToken -UseEnvironmentFallback -UseAzureCliFallback
-                $null = Export-MdeMachineData -AccessToken $accessToken -OutputPath $DirectoryPath
+                $tokenContext = New-MdeAccessTokenContext -AccessToken $DefenderAccessToken -UseEnvironmentFallback -UseAzureCliFallback
+                $null = Export-MdeMachineData -TokenContext $tokenContext -OutputPath $DirectoryPath
             }
             catch {
                 Write-Warning "Failed to export machine data: $_"

--- a/Invoke-VulnerabilityExport.ps1
+++ b/Invoke-VulnerabilityExport.ps1
@@ -105,13 +105,13 @@ try {
     Write-Host '  Vulnerability Data Export Tool' -ForegroundColor Cyan
     Write-Host "========================================`n" -ForegroundColor Cyan
 
-    $accessToken = if ($Script:AuthenticationMode -eq 'AccessToken') {
-        Get-MdeAccessToken -AccessToken $AccessToken -WriteStatus
+    $tokenContext = if ($Script:AuthenticationMode -eq 'AccessToken') {
+        New-MdeAccessTokenContext -AccessToken $AccessToken -WriteStatus
     }
     else {
-        Get-MdeAccessToken -TenantId $TenantId -AppId $AppId -AppSecret $AppSecret -ResourceAppIdUri $Script:BaseApiUrl -WriteStatus
+        New-MdeAccessTokenContext -TenantId $TenantId -AppId $AppId -AppSecret $AppSecret -ResourceAppIdUri $Script:BaseApiUrl -WriteStatus
     }
-    $headers = Get-MdeHeaderCollection -AccessToken $accessToken
+    $headers = Get-MdeHeaderCollection -TokenContext $tokenContext
 
     $downloadedVulnerabilityFiles = Export-MdeBulkVulnerabilityData -Headers $headers -OutputPath $OutputPath -ExportUrl $Script:BulkVulnerabilityExportUrl
     $vulnerabilityResult = Publish-VulnerabilityHistoryStore -OutputPath $OutputPath -DownloadedFiles $downloadedVulnerabilityFiles

--- a/azure/Invoke-DashboardPipeline.ps1
+++ b/azure/Invoke-DashboardPipeline.ps1
@@ -7643,9 +7643,303 @@ function Initialize-AdvancedHuntingStore {
 
 # Shared MDE export helpers used by local export, generator refresh, and the Azure runbook.
 
-function Get-MdeAccessToken {
+function Get-MdeTokenResponsePropertyValue {
+    [CmdletBinding()]
+    [OutputType([object])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [AllowNull()]
+        $InputObject,
+
+        [Parameter(Mandatory = $true)]
+        [string]$Name
+    )
+
+    if ($null -eq $InputObject) {
+        return $null
+    }
+
+    if ($InputObject -is [System.Collections.IDictionary]) {
+        return $InputObject[$Name]
+    }
+
+    $property = $InputObject.PSObject.Properties[$Name]
+    if ($null -eq $property) {
+        return $null
+    }
+
+    return $property.Value
+}
+
+function ConvertTo-MdeUtcDateTime {
+    [CmdletBinding()]
+    [OutputType([Nullable[datetime]])]
+    param(
+        [Parameter(Mandatory = $false)]
+        [AllowNull()]
+        $Value
+    )
+
+    if ($null -eq $Value) {
+        return $null
+    }
+
+    if ($Value -is [datetimeoffset]) {
+        return $Value.UtcDateTime
+    }
+
+    if ($Value -is [datetime]) {
+        return $Value.ToUniversalTime()
+    }
+
+    $valueText = [string]$Value
+    if ([string]::IsNullOrWhiteSpace($valueText)) {
+        return $null
+    }
+
+    $epochSeconds = 0L
+    if ([long]::TryParse($valueText, [ref]$epochSeconds)) {
+        return [System.DateTimeOffset]::FromUnixTimeSeconds($epochSeconds).UtcDateTime
+    }
+
+    $parsedOffset = [System.DateTimeOffset]::MinValue
+    if ([System.DateTimeOffset]::TryParse($valueText, [System.Globalization.CultureInfo]::InvariantCulture, [System.Globalization.DateTimeStyles]::AssumeUniversal, [ref]$parsedOffset)) {
+        return $parsedOffset.UtcDateTime
+    }
+
+    $parsedDateTime = [datetime]::MinValue
+    if ([datetime]::TryParse($valueText, [System.Globalization.CultureInfo]::InvariantCulture, [System.Globalization.DateTimeStyles]::AssumeUniversal, [ref]$parsedDateTime)) {
+        return $parsedDateTime.ToUniversalTime()
+    }
+
+    throw ("Unable to parse MDE token expiration value '{0}' as a UTC timestamp." -f $valueText)
+}
+
+function Resolve-MdeTokenExpirationUtc {
+    [CmdletBinding()]
+    [OutputType([Nullable[datetime]])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [AllowNull()]
+        $TokenResponse,
+
+        [Parameter(Mandatory = $false)]
+        [datetime]$IssuedOnUtc = ([datetime]::UtcNow)
+    )
+
+    foreach ($propertyName in @('expires_on', 'ExpiresOn', 'expiresOn')) {
+        $propertyValue = Get-MdeTokenResponsePropertyValue -InputObject $TokenResponse -Name $propertyName
+        if ($null -ne $propertyValue -and -not [string]::IsNullOrWhiteSpace([string]$propertyValue)) {
+            return (ConvertTo-MdeUtcDateTime -Value $propertyValue)
+        }
+    }
+
+    foreach ($propertyName in @('expires_in', 'ext_expires_in')) {
+        $propertyValue = Get-MdeTokenResponsePropertyValue -InputObject $TokenResponse -Name $propertyName
+        if ($null -eq $propertyValue) {
+            continue
+        }
+
+        $lifetimeSeconds = 0
+        if ([int]::TryParse([string]$propertyValue, [ref]$lifetimeSeconds)) {
+            return $IssuedOnUtc.AddSeconds($lifetimeSeconds)
+        }
+    }
+
+    return $null
+}
+
+function New-MdeTokenContext {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '', Justification = 'Internal factory only returns an in-memory token context object.')]
+    [CmdletBinding()]
+    [OutputType([pscustomobject])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]$AccessToken,
+
+        [Parameter(Mandatory = $false)]
+        [AllowNull()]
+        [Nullable[datetime]]$ExpiresOnUtc,
+
+        [Parameter(Mandatory = $false)]
+        [bool]$CanRefresh = $false,
+
+        [Parameter(Mandatory = $false)]
+        [AllowNull()]
+        [scriptblock]$RefreshScript,
+
+        [Parameter(Mandatory = $false)]
+        [timespan]$RefreshWindow = ([timespan]::FromMinutes(5)),
+
+        [Parameter(Mandatory = $false)]
+        [string]$SourceDescription = 'Microsoft Defender for Endpoint',
+
+        [Parameter(Mandatory = $false)]
+        [switch]$WriteStatus
+    )
+
+    if ($CanRefresh -and $null -eq $RefreshScript) {
+        throw 'Refreshable MDE token contexts require a refresh script.'
+    }
+
+    if ($CanRefresh -and $null -eq $ExpiresOnUtc) {
+        throw ("Refreshable MDE token contexts for '{0}' require expiration metadata." -f $SourceDescription)
+    }
+
+    return [PSCustomObject]@{
+        AccessToken       = $AccessToken.Trim()
+        ExpiresOnUtc      = $ExpiresOnUtc
+        CanRefresh        = $CanRefresh
+        RefreshScript     = $RefreshScript
+        RefreshWindow     = $RefreshWindow
+        SourceDescription = $SourceDescription
+        WriteStatus       = [bool]$WriteStatus
+    }
+}
+
+function Invoke-MdeClientCredentialTokenRequest {
+    [CmdletBinding()]
+    [OutputType([pscustomobject])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$TenantId,
+
+        [Parameter(Mandatory = $true)]
+        [string]$AppId,
+
+        [Parameter(Mandatory = $true)]
+        [string]$AppSecretText,
+
+        [Parameter(Mandatory = $false)]
+        [string]$ResourceAppIdUri = 'https://api.securitycenter.microsoft.com',
+
+        [Parameter(Mandatory = $false)]
+        [switch]$WriteStatus
+    )
+
+    if ($WriteStatus) {
+        Write-Host 'Authenticating to Microsoft Defender for Endpoint...' -ForegroundColor Cyan
+    }
+
+    $oAuthUri = "https://login.microsoftonline.com/$TenantId/oauth2/token"
+    $authBody = [ordered]@{
+        resource      = $ResourceAppIdUri
+        client_id     = $AppId
+        client_secret = $AppSecretText
+        grant_type    = 'client_credentials'
+    }
+
+    try {
+        $issuedOnUtc = [datetime]::UtcNow
+        $response = Invoke-RestMethod -Method Post -Uri $oAuthUri -Body $authBody -ErrorAction Stop
+        $accessToken = [string](Get-MdeTokenResponsePropertyValue -InputObject $response -Name 'access_token')
+        if ([string]::IsNullOrWhiteSpace($accessToken)) {
+            throw 'The authentication response did not contain an access_token value.'
+        }
+
+        if ($WriteStatus) {
+            Write-Host '  Authentication successful' -ForegroundColor Green
+        }
+
+        return [PSCustomObject]@{
+            AccessToken  = $accessToken
+            ExpiresOnUtc = Resolve-MdeTokenExpirationUtc -TokenResponse $response -IssuedOnUtc $issuedOnUtc
+        }
+    }
+    catch {
+        throw ("Failed to authenticate to Microsoft Defender for Endpoint for tenant '{0}', app '{1}', resource '{2}': {3}" -f $TenantId, $AppId, $ResourceAppIdUri, $_.Exception.Message)
+    }
+}
+
+function Invoke-MdeAzureCliTokenRequest {
+    [CmdletBinding()]
+    [OutputType([pscustomobject])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$AzureCliPath,
+
+        [Parameter(Mandatory = $false)]
+        [string]$ResourceAppIdUri = 'https://api.securitycenter.microsoft.com'
+    )
+
+    $rawResponse = [string](& $AzureCliPath 'account' 'get-access-token' '--resource' $ResourceAppIdUri '-o' 'json')
+    if ([string]::IsNullOrWhiteSpace($rawResponse)) {
+        throw "Azure CLI fallback returned no access token for resource '$ResourceAppIdUri'."
+    }
+
+    try {
+        $response = $rawResponse | ConvertFrom-Json -ErrorAction Stop
+    }
+    catch {
+        throw ("Azure CLI fallback returned an unreadable access token payload for resource '{0}': {1}" -f $ResourceAppIdUri, $_.Exception.Message)
+    }
+
+    $accessToken = [string](Get-MdeTokenResponsePropertyValue -InputObject $response -Name 'accessToken')
+    if ([string]::IsNullOrWhiteSpace($accessToken)) {
+        throw "Azure CLI fallback returned no access token for resource '$ResourceAppIdUri'."
+    }
+
+    return [PSCustomObject]@{
+        AccessToken  = $accessToken
+        ExpiresOnUtc = Resolve-MdeTokenExpirationUtc -TokenResponse $response
+    }
+}
+
+function Get-MdeUsableAccessToken {
     [CmdletBinding()]
     [OutputType([string])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [pscustomobject]$TokenContext
+    )
+
+    if ([string]::IsNullOrWhiteSpace([string]$TokenContext.AccessToken)) {
+        throw 'The MDE token context does not contain an access token.'
+    }
+
+    $shouldRefresh = (
+        [bool]$TokenContext.CanRefresh -and
+        $null -ne $TokenContext.ExpiresOnUtc -and
+        ([datetime]::UtcNow -ge ([datetime]$TokenContext.ExpiresOnUtc).Subtract([timespan]$TokenContext.RefreshWindow))
+    )
+
+    if ($shouldRefresh) {
+        if ($null -eq $TokenContext.RefreshScript) {
+            throw ("The MDE token context for '{0}' is marked refreshable but has no refresh script." -f [string]$TokenContext.SourceDescription)
+        }
+
+        if ($TokenContext.WriteStatus) {
+            Write-Host ("Refreshing Microsoft Defender for Endpoint access token ({0})..." -f [string]$TokenContext.SourceDescription) -ForegroundColor Cyan
+        }
+
+        $refreshResult = & $TokenContext.RefreshScript
+        $refreshedAccessToken = [string](Get-MdeTokenResponsePropertyValue -InputObject $refreshResult -Name 'AccessToken')
+        if ([string]::IsNullOrWhiteSpace($refreshedAccessToken)) {
+            throw ("Refreshing the MDE token context for '{0}' returned no access token." -f [string]$TokenContext.SourceDescription)
+        }
+
+        $refreshedExpirationUtc = Get-MdeTokenResponsePropertyValue -InputObject $refreshResult -Name 'ExpiresOnUtc'
+        if ($null -eq $refreshedExpirationUtc) {
+            throw ("Refreshing the MDE token context for '{0}' returned no expiration metadata." -f [string]$TokenContext.SourceDescription)
+        }
+
+        $TokenContext.AccessToken = $refreshedAccessToken.Trim()
+        $TokenContext.ExpiresOnUtc = ConvertTo-MdeUtcDateTime -Value $refreshedExpirationUtc
+
+        if ($TokenContext.WriteStatus) {
+            Write-Host '  Token refresh successful' -ForegroundColor Green
+        }
+    }
+
+    return [string]$TokenContext.AccessToken
+}
+
+function New-MdeAccessTokenContext {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '', Justification = 'Token acquisition is an authentication read operation that returns an in-memory context object.')]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSReviewUnusedParameter', 'ResourceAppIdUri', Justification = 'This parameter is captured in refresh closures used to reacquire the token for the same resource.')]
+    [CmdletBinding()]
+    [OutputType([pscustomobject])]
     param(
         [Parameter(Mandatory = $false)]
         [AllowEmptyString()]
@@ -7681,7 +7975,7 @@ function Get-MdeAccessToken {
             Write-Host 'Using provided Microsoft Defender for Endpoint access token' -ForegroundColor Cyan
         }
 
-        return $AccessToken.Trim()
+        return (New-MdeTokenContext -AccessToken $AccessToken -SourceDescription 'provided access token' -WriteStatus:$WriteStatus)
     }
 
     $resolvedTenantId = $TenantId
@@ -7691,7 +7985,7 @@ function Get-MdeAccessToken {
     if ($UseEnvironmentFallback) {
         $environmentAccessToken = $env:DEFENDER_ACCESS_TOKEN
         if (-not [string]::IsNullOrWhiteSpace($environmentAccessToken)) {
-            return $environmentAccessToken.Trim()
+            return (New-MdeTokenContext -AccessToken $environmentAccessToken -SourceDescription 'DEFENDER_ACCESS_TOKEN environment variable' -WriteStatus:$WriteStatus)
         }
 
         if ([string]::IsNullOrWhiteSpace($resolvedTenantId)) {
@@ -7718,29 +8012,14 @@ function Get-MdeAccessToken {
         -not [string]::IsNullOrWhiteSpace($resolvedAppId) -and
         -not [string]::IsNullOrWhiteSpace($resolvedSecretText)
     ) {
-        if ($WriteStatus) {
-            Write-Host 'Authenticating to Microsoft Defender for Endpoint...' -ForegroundColor Cyan
-        }
+        $resolvedWriteStatus = [bool]$WriteStatus
+        $invokeClientCredentialTokenRequest = ${function:Invoke-MdeClientCredentialTokenRequest}
+        $refreshScript = {
+            & $invokeClientCredentialTokenRequest -TenantId $resolvedTenantId -AppId $resolvedAppId -AppSecretText $resolvedSecretText -ResourceAppIdUri $ResourceAppIdUri -WriteStatus:$resolvedWriteStatus
+        }.GetNewClosure()
 
-        $oAuthUri = "https://login.microsoftonline.com/$resolvedTenantId/oauth2/token"
-        $authBody = [ordered]@{
-            resource = $ResourceAppIdUri
-            client_id = $resolvedAppId
-            client_secret = $resolvedSecretText
-            grant_type = 'client_credentials'
-        }
-
-        try {
-            $response = Invoke-RestMethod -Method Post -Uri $oAuthUri -Body $authBody -ErrorAction Stop
-            if ($WriteStatus) {
-                Write-Host '  Authentication successful' -ForegroundColor Green
-            }
-
-            return [string]$response.access_token
-        }
-        catch {
-            throw ("Failed to authenticate to Microsoft Defender for Endpoint for tenant '{0}', app '{1}', resource '{2}': {3}" -f $resolvedTenantId, $resolvedAppId, $ResourceAppIdUri, $_.Exception.Message)
-        }
+        $initialToken = & $refreshScript
+        return (New-MdeTokenContext -AccessToken $initialToken.AccessToken -ExpiresOnUtc $initialToken.ExpiresOnUtc -CanRefresh $true -RefreshScript $refreshScript -SourceDescription ("client credentials for app '{0}'" -f $resolvedAppId) -WriteStatus:$WriteStatus)
     }
 
     $diagnostics = [System.Collections.Generic.List[string]]::new()
@@ -7758,12 +8037,12 @@ function Get-MdeAccessToken {
         $azCommand = Get-Command -Name 'az' -CommandType Application -ErrorAction SilentlyContinue
         if ($null -ne $azCommand) {
             try {
-                $azAccessToken = [string](& $azCommand.Source 'account' 'get-access-token' '--resource' $ResourceAppIdUri '--query' 'accessToken' '-o' 'tsv')
-                if (-not [string]::IsNullOrWhiteSpace($azAccessToken)) {
-                    return $azAccessToken.Trim()
-                }
-
-                $diagnostics.Add("Azure CLI fallback returned no access token for resource '$ResourceAppIdUri'")
+                $invokeAzureCliTokenRequest = ${function:Invoke-MdeAzureCliTokenRequest}
+                $refreshScript = {
+                    & $invokeAzureCliTokenRequest -AzureCliPath $azCommand.Source -ResourceAppIdUri $ResourceAppIdUri
+                }.GetNewClosure()
+                $initialToken = & $refreshScript
+                return (New-MdeTokenContext -AccessToken $initialToken.AccessToken -ExpiresOnUtc $initialToken.ExpiresOnUtc -CanRefresh $true -RefreshScript $refreshScript -SourceDescription 'Azure CLI access token' -WriteStatus:$WriteStatus)
             }
             catch {
                 Write-Verbose "Azure CLI token acquisition failed: $_"
@@ -7804,19 +8083,88 @@ function Get-MdeAccessToken {
     throw ("No Defender API token source available. Provide -AccessToken or -TenantId/-AppId/-AppSecret.{0}" -f $diagnosticSuffix)
 }
 
+function Get-MdeAccessToken {
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory = $false)]
+        [AllowEmptyString()]
+        [string]$AccessToken,
+
+        [Parameter(Mandatory = $false)]
+        [AllowEmptyString()]
+        [string]$TenantId,
+
+        [Parameter(Mandatory = $false)]
+        [AllowEmptyString()]
+        [string]$AppId,
+
+        [Parameter(Mandatory = $false)]
+        [AllowNull()]
+        $AppSecret,
+
+        [Parameter(Mandatory = $false)]
+        [string]$ResourceAppIdUri = 'https://api.securitycenter.microsoft.com',
+
+        [Parameter(Mandatory = $false)]
+        [switch]$UseEnvironmentFallback,
+
+        [Parameter(Mandatory = $false)]
+        [switch]$UseAzureCliFallback,
+
+        [Parameter(Mandatory = $false)]
+        [switch]$WriteStatus
+    )
+
+    $tokenContext = New-MdeAccessTokenContext @PSBoundParameters
+    return (Get-MdeUsableAccessToken -TokenContext $tokenContext)
+}
+
 function Get-MdeHeaderCollection {
     [CmdletBinding()]
     [OutputType([hashtable])]
     param(
-        [Parameter(Mandatory = $true)]
-        [string]$AccessToken
+        [Parameter(Mandatory = $true, ParameterSetName = 'AccessToken')]
+        [string]$AccessToken,
+
+        [Parameter(Mandatory = $true, ParameterSetName = 'TokenContext')]
+        [pscustomobject]$TokenContext
     )
 
-    return @{
+    $authorizationToken = if ($PSCmdlet.ParameterSetName -eq 'TokenContext') {
+        Get-MdeUsableAccessToken -TokenContext $TokenContext
+    }
+    else {
+        $AccessToken.Trim()
+    }
+
+    $headers = @{
         'Content-Type'  = 'application/json'
         'Accept'        = 'application/json'
-        'Authorization' = "Bearer $AccessToken"
+        'Authorization' = "Bearer $authorizationToken"
     }
+
+    if ($PSCmdlet.ParameterSetName -eq 'TokenContext') {
+        Add-Member -InputObject $headers -NotePropertyName MdeTokenContext -NotePropertyValue $TokenContext -Force
+    }
+
+    return $headers
+}
+
+function Resolve-MdeHeaderCollection {
+    [CmdletBinding()]
+    [OutputType([hashtable])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [hashtable]$Headers
+    )
+
+    $tokenContextProperty = $Headers.PSObject.Properties['MdeTokenContext']
+    if ($null -ne $tokenContextProperty -and $null -ne $tokenContextProperty.Value) {
+        $Headers['Authorization'] = "Bearer $(Get-MdeUsableAccessToken -TokenContext $tokenContextProperty.Value)"
+    }
+
+    return $Headers
 }
 
 function Resolve-UriQueryParameterValue {
@@ -7898,7 +8246,7 @@ function Invoke-MdeBulkVulnerabilitySnapshotDownload {
     $emptyDownloadBackoffMultiplier = 2.0
 
     $resolvedExportUrl = Get-MdeBulkVulnerabilityExportRequestUri -ExportUrl $ExportUrl
-    $response = Invoke-RestMethodWithRetry -Uri $resolvedExportUrl -Headers $Headers -Method Get -MaxRetries 4 -InitialDelayMs 5000 -TimeoutSec 600 -RetryTransientTransportFailures
+    $response = Invoke-RestMethodWithRetry -Uri $resolvedExportUrl -Headers (Resolve-MdeHeaderCollection -Headers $Headers) -Method Get -MaxRetries 4 -InitialDelayMs 5000 -TimeoutSec 600 -RetryTransientTransportFailures
     $exportFiles = @($response.exportFiles)
     if ($exportFiles.Count -eq 0) {
         throw 'Bulk vulnerability export returned no files.'
@@ -8047,7 +8395,7 @@ function Invoke-MdeAdvancedHuntingStoreRefresh {
 
         Write-Information ("  Running Advanced Hunting query: {0}" -f $Label) -InformationAction Continue
         $body = @{ Query = $Query } | ConvertTo-Json
-        $response = Invoke-RestMethodWithRetry -Uri $RequestUrl -Headers $RequestHeaders -Method Post -Body $body
+        $response = Invoke-RestMethodWithRetry -Uri $RequestUrl -Headers (Resolve-MdeHeaderCollection -Headers $RequestHeaders) -Method Post -Body $body
         if ($null -eq $response -or $null -eq $response.Results) {
             return @()
         }
@@ -8290,7 +8638,7 @@ function Get-MdeMachineRefreshPublishPlan {
 
         do {
             $pageCount++
-            $response = Invoke-RestMethodWithRetry -Uri $url -Headers $Headers -Method Get
+            $response = Invoke-RestMethodWithRetry -Uri $url -Headers (Resolve-MdeHeaderCollection -Headers $Headers) -Method Get
 
             if ($response.value) {
                 foreach ($machine in $response.value) {
@@ -8571,6 +8919,9 @@ function Export-MdeMachineData {
         [Parameter(Mandatory = $true, ParameterSetName = 'AccessToken')]
         [string]$AccessToken,
 
+        [Parameter(Mandatory = $true, ParameterSetName = 'TokenContext')]
+        [pscustomobject]$TokenContext,
+
         [Parameter(Mandatory = $true)]
         [string]$OutputPath,
 
@@ -8580,6 +8931,9 @@ function Export-MdeMachineData {
 
     $resolvedHeaders = if ($PSCmdlet.ParameterSetName -eq 'AccessToken') {
         Get-MdeHeaderCollection -AccessToken $AccessToken
+    }
+    elseif ($PSCmdlet.ParameterSetName -eq 'TokenContext') {
+        Get-MdeHeaderCollection -TokenContext $TokenContext
     }
     else {
         $Headers
@@ -19448,7 +19802,7 @@ function ConvertTo-NormalizedData {
         PayloadPath = $writerCloseResult.PayloadPath
     }
 }
-# ArtifactFingerprint: 9753af70f88bb1a9cb1df8b5c7f3f8ec0909d841b6a814efd0dbcaec7995f47e
+# ArtifactFingerprint: e4a7a2e09aeca27f7607151c94d15ea3bf71376beb3b4c900fa8a9638ad84c63
 
 
 
@@ -19684,6 +20038,31 @@ function Write-PipelineExecutionStatus {
 # HELPER FUNCTIONS - TOKEN MANAGEMENT
 # =============================================================================
 
+function Get-PlainTokenResponse {
+    <#
+    .SYNOPSIS
+        Gets a plain-text bearer token plus expiration metadata using Get-AzAccessToken -AsSecureString.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$ResourceUrl
+    )
+
+    $tokenResponse = Get-AzAccessToken -ResourceUrl $ResourceUrl -AsSecureString
+    $ssPtr = [System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($tokenResponse.Token)
+
+    try {
+        return [PSCustomObject]@{
+            AccessToken  = [System.Runtime.InteropServices.Marshal]::PtrToStringBSTR($ssPtr)
+            ExpiresOnUtc = ConvertTo-MdeUtcDateTime -Value $tokenResponse.ExpiresOn
+        }
+    }
+    finally {
+        [System.Runtime.InteropServices.Marshal]::ZeroFreeBSTR($ssPtr)
+    }
+}
+
 function Get-PlainToken {
     <#
     .SYNOPSIS
@@ -19695,11 +20074,28 @@ function Get-PlainToken {
         [string]$ResourceUrl
     )
 
-    $tokenResponse = Get-AzAccessToken -ResourceUrl $ResourceUrl -AsSecureString
-    $ssPtr = [System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($tokenResponse.Token)
+    return [string](Get-PlainTokenResponse -ResourceUrl $ResourceUrl).AccessToken
+}
 
-    try { return [System.Runtime.InteropServices.Marshal]::PtrToStringBSTR($ssPtr) }
-    finally { [System.Runtime.InteropServices.Marshal]::ZeroFreeBSTR($ssPtr) }
+function New-AzResourceTokenContext {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '', Justification = 'Internal factory only returns an in-memory token context object for the current Az session.')]
+    [CmdletBinding()]
+    [OutputType([pscustomobject])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$ResourceUrl,
+
+        [Parameter(Mandatory = $false)]
+        [switch]$WriteStatus
+    )
+
+    $getPlainTokenResponse = ${function:Get-PlainTokenResponse}
+    $refreshScript = {
+        & $getPlainTokenResponse -ResourceUrl $ResourceUrl
+    }.GetNewClosure()
+
+    $initialToken = & $refreshScript
+    return (New-MdeTokenContext -AccessToken $initialToken.AccessToken -ExpiresOnUtc $initialToken.ExpiresOnUtc -CanRefresh $true -RefreshScript $refreshScript -SourceDescription ("Az context for '{0}'" -f $ResourceUrl) -WriteStatus:$WriteStatus)
 }
 
 # =============================================================================
@@ -20388,8 +20784,8 @@ try {
         Write-Output "  Stress mode enabled: using existing exports from blob storage only"
     }
     else {
-        $mdeToken = Get-PlainToken -ResourceUrl 'https://api.securitycenter.microsoft.com'
-        $mdeHeaders = Get-MdeHeaderCollection -AccessToken $mdeToken
+        $mdeTokenContext = New-AzResourceTokenContext -ResourceUrl 'https://api.securitycenter.microsoft.com'
+        $mdeHeaders = Get-MdeHeaderCollection -TokenContext $mdeTokenContext
         Write-Output "  Tokens acquired"
     }
 

--- a/build/azure/runbook-source.ps1
+++ b/build/azure/runbook-source.ps1
@@ -453,6 +453,31 @@ function Write-PipelineExecutionStatus {
 # HELPER FUNCTIONS - TOKEN MANAGEMENT
 # =============================================================================
 
+function Get-PlainTokenResponse {
+    <#
+    .SYNOPSIS
+        Gets a plain-text bearer token plus expiration metadata using Get-AzAccessToken -AsSecureString.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$ResourceUrl
+    )
+
+    $tokenResponse = Get-AzAccessToken -ResourceUrl $ResourceUrl -AsSecureString
+    $ssPtr = [System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($tokenResponse.Token)
+
+    try {
+        return [PSCustomObject]@{
+            AccessToken  = [System.Runtime.InteropServices.Marshal]::PtrToStringBSTR($ssPtr)
+            ExpiresOnUtc = ConvertTo-MdeUtcDateTime -Value $tokenResponse.ExpiresOn
+        }
+    }
+    finally {
+        [System.Runtime.InteropServices.Marshal]::ZeroFreeBSTR($ssPtr)
+    }
+}
+
 function Get-PlainToken {
     <#
     .SYNOPSIS
@@ -464,11 +489,28 @@ function Get-PlainToken {
         [string]$ResourceUrl
     )
 
-    $tokenResponse = Get-AzAccessToken -ResourceUrl $ResourceUrl -AsSecureString
-    $ssPtr = [System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($tokenResponse.Token)
+    return [string](Get-PlainTokenResponse -ResourceUrl $ResourceUrl).AccessToken
+}
 
-    try { return [System.Runtime.InteropServices.Marshal]::PtrToStringBSTR($ssPtr) }
-    finally { [System.Runtime.InteropServices.Marshal]::ZeroFreeBSTR($ssPtr) }
+function New-AzResourceTokenContext {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '', Justification = 'Internal factory only returns an in-memory token context object for the current Az session.')]
+    [CmdletBinding()]
+    [OutputType([pscustomobject])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$ResourceUrl,
+
+        [Parameter(Mandatory = $false)]
+        [switch]$WriteStatus
+    )
+
+    $getPlainTokenResponse = ${function:Get-PlainTokenResponse}
+    $refreshScript = {
+        & $getPlainTokenResponse -ResourceUrl $ResourceUrl
+    }.GetNewClosure()
+
+    $initialToken = & $refreshScript
+    return (New-MdeTokenContext -AccessToken $initialToken.AccessToken -ExpiresOnUtc $initialToken.ExpiresOnUtc -CanRefresh $true -RefreshScript $refreshScript -SourceDescription ("Az context for '{0}'" -f $ResourceUrl) -WriteStatus:$WriteStatus)
 }
 
 # =============================================================================
@@ -1157,8 +1199,8 @@ try {
         Write-Output "  Stress mode enabled: using existing exports from blob storage only"
     }
     else {
-        $mdeToken = Get-PlainToken -ResourceUrl 'https://api.securitycenter.microsoft.com'
-        $mdeHeaders = Get-MdeHeaderCollection -AccessToken $mdeToken
+        $mdeTokenContext = New-AzResourceTokenContext -ResourceUrl 'https://api.securitycenter.microsoft.com'
+        $mdeHeaders = Get-MdeHeaderCollection -TokenContext $mdeTokenContext
         Write-Output "  Tokens acquired"
     }
 

--- a/src/powershell/Shared/DefenderApi/MdeExport.ps1
+++ b/src/powershell/Shared/DefenderApi/MdeExport.ps1
@@ -1,9 +1,303 @@
 
 # Shared MDE export helpers used by local export, generator refresh, and the Azure runbook.
 
-function Get-MdeAccessToken {
+function Get-MdeTokenResponsePropertyValue {
+    [CmdletBinding()]
+    [OutputType([object])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [AllowNull()]
+        $InputObject,
+
+        [Parameter(Mandatory = $true)]
+        [string]$Name
+    )
+
+    if ($null -eq $InputObject) {
+        return $null
+    }
+
+    if ($InputObject -is [System.Collections.IDictionary]) {
+        return $InputObject[$Name]
+    }
+
+    $property = $InputObject.PSObject.Properties[$Name]
+    if ($null -eq $property) {
+        return $null
+    }
+
+    return $property.Value
+}
+
+function ConvertTo-MdeUtcDateTime {
+    [CmdletBinding()]
+    [OutputType([Nullable[datetime]])]
+    param(
+        [Parameter(Mandatory = $false)]
+        [AllowNull()]
+        $Value
+    )
+
+    if ($null -eq $Value) {
+        return $null
+    }
+
+    if ($Value -is [datetimeoffset]) {
+        return $Value.UtcDateTime
+    }
+
+    if ($Value -is [datetime]) {
+        return $Value.ToUniversalTime()
+    }
+
+    $valueText = [string]$Value
+    if ([string]::IsNullOrWhiteSpace($valueText)) {
+        return $null
+    }
+
+    $epochSeconds = 0L
+    if ([long]::TryParse($valueText, [ref]$epochSeconds)) {
+        return [System.DateTimeOffset]::FromUnixTimeSeconds($epochSeconds).UtcDateTime
+    }
+
+    $parsedOffset = [System.DateTimeOffset]::MinValue
+    if ([System.DateTimeOffset]::TryParse($valueText, [System.Globalization.CultureInfo]::InvariantCulture, [System.Globalization.DateTimeStyles]::AssumeUniversal, [ref]$parsedOffset)) {
+        return $parsedOffset.UtcDateTime
+    }
+
+    $parsedDateTime = [datetime]::MinValue
+    if ([datetime]::TryParse($valueText, [System.Globalization.CultureInfo]::InvariantCulture, [System.Globalization.DateTimeStyles]::AssumeUniversal, [ref]$parsedDateTime)) {
+        return $parsedDateTime.ToUniversalTime()
+    }
+
+    throw ("Unable to parse MDE token expiration value '{0}' as a UTC timestamp." -f $valueText)
+}
+
+function Resolve-MdeTokenExpirationUtc {
+    [CmdletBinding()]
+    [OutputType([Nullable[datetime]])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [AllowNull()]
+        $TokenResponse,
+
+        [Parameter(Mandatory = $false)]
+        [datetime]$IssuedOnUtc = ([datetime]::UtcNow)
+    )
+
+    foreach ($propertyName in @('expires_on', 'ExpiresOn', 'expiresOn')) {
+        $propertyValue = Get-MdeTokenResponsePropertyValue -InputObject $TokenResponse -Name $propertyName
+        if ($null -ne $propertyValue -and -not [string]::IsNullOrWhiteSpace([string]$propertyValue)) {
+            return (ConvertTo-MdeUtcDateTime -Value $propertyValue)
+        }
+    }
+
+    foreach ($propertyName in @('expires_in', 'ext_expires_in')) {
+        $propertyValue = Get-MdeTokenResponsePropertyValue -InputObject $TokenResponse -Name $propertyName
+        if ($null -eq $propertyValue) {
+            continue
+        }
+
+        $lifetimeSeconds = 0
+        if ([int]::TryParse([string]$propertyValue, [ref]$lifetimeSeconds)) {
+            return $IssuedOnUtc.AddSeconds($lifetimeSeconds)
+        }
+    }
+
+    return $null
+}
+
+function New-MdeTokenContext {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '', Justification = 'Internal factory only returns an in-memory token context object.')]
+    [CmdletBinding()]
+    [OutputType([pscustomobject])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]$AccessToken,
+
+        [Parameter(Mandatory = $false)]
+        [AllowNull()]
+        [Nullable[datetime]]$ExpiresOnUtc,
+
+        [Parameter(Mandatory = $false)]
+        [bool]$CanRefresh = $false,
+
+        [Parameter(Mandatory = $false)]
+        [AllowNull()]
+        [scriptblock]$RefreshScript,
+
+        [Parameter(Mandatory = $false)]
+        [timespan]$RefreshWindow = ([timespan]::FromMinutes(5)),
+
+        [Parameter(Mandatory = $false)]
+        [string]$SourceDescription = 'Microsoft Defender for Endpoint',
+
+        [Parameter(Mandatory = $false)]
+        [switch]$WriteStatus
+    )
+
+    if ($CanRefresh -and $null -eq $RefreshScript) {
+        throw 'Refreshable MDE token contexts require a refresh script.'
+    }
+
+    if ($CanRefresh -and $null -eq $ExpiresOnUtc) {
+        throw ("Refreshable MDE token contexts for '{0}' require expiration metadata." -f $SourceDescription)
+    }
+
+    return [PSCustomObject]@{
+        AccessToken       = $AccessToken.Trim()
+        ExpiresOnUtc      = $ExpiresOnUtc
+        CanRefresh        = $CanRefresh
+        RefreshScript     = $RefreshScript
+        RefreshWindow     = $RefreshWindow
+        SourceDescription = $SourceDescription
+        WriteStatus       = [bool]$WriteStatus
+    }
+}
+
+function Invoke-MdeClientCredentialTokenRequest {
+    [CmdletBinding()]
+    [OutputType([pscustomobject])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$TenantId,
+
+        [Parameter(Mandatory = $true)]
+        [string]$AppId,
+
+        [Parameter(Mandatory = $true)]
+        [string]$AppSecretText,
+
+        [Parameter(Mandatory = $false)]
+        [string]$ResourceAppIdUri = 'https://api.securitycenter.microsoft.com',
+
+        [Parameter(Mandatory = $false)]
+        [switch]$WriteStatus
+    )
+
+    if ($WriteStatus) {
+        Write-Host 'Authenticating to Microsoft Defender for Endpoint...' -ForegroundColor Cyan
+    }
+
+    $oAuthUri = "https://login.microsoftonline.com/$TenantId/oauth2/token"
+    $authBody = [ordered]@{
+        resource      = $ResourceAppIdUri
+        client_id     = $AppId
+        client_secret = $AppSecretText
+        grant_type    = 'client_credentials'
+    }
+
+    try {
+        $issuedOnUtc = [datetime]::UtcNow
+        $response = Invoke-RestMethod -Method Post -Uri $oAuthUri -Body $authBody -ErrorAction Stop
+        $accessToken = [string](Get-MdeTokenResponsePropertyValue -InputObject $response -Name 'access_token')
+        if ([string]::IsNullOrWhiteSpace($accessToken)) {
+            throw 'The authentication response did not contain an access_token value.'
+        }
+
+        if ($WriteStatus) {
+            Write-Host '  Authentication successful' -ForegroundColor Green
+        }
+
+        return [PSCustomObject]@{
+            AccessToken  = $accessToken
+            ExpiresOnUtc = Resolve-MdeTokenExpirationUtc -TokenResponse $response -IssuedOnUtc $issuedOnUtc
+        }
+    }
+    catch {
+        throw ("Failed to authenticate to Microsoft Defender for Endpoint for tenant '{0}', app '{1}', resource '{2}': {3}" -f $TenantId, $AppId, $ResourceAppIdUri, $_.Exception.Message)
+    }
+}
+
+function Invoke-MdeAzureCliTokenRequest {
+    [CmdletBinding()]
+    [OutputType([pscustomobject])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$AzureCliPath,
+
+        [Parameter(Mandatory = $false)]
+        [string]$ResourceAppIdUri = 'https://api.securitycenter.microsoft.com'
+    )
+
+    $rawResponse = [string](& $AzureCliPath 'account' 'get-access-token' '--resource' $ResourceAppIdUri '-o' 'json')
+    if ([string]::IsNullOrWhiteSpace($rawResponse)) {
+        throw "Azure CLI fallback returned no access token for resource '$ResourceAppIdUri'."
+    }
+
+    try {
+        $response = $rawResponse | ConvertFrom-Json -ErrorAction Stop
+    }
+    catch {
+        throw ("Azure CLI fallback returned an unreadable access token payload for resource '{0}': {1}" -f $ResourceAppIdUri, $_.Exception.Message)
+    }
+
+    $accessToken = [string](Get-MdeTokenResponsePropertyValue -InputObject $response -Name 'accessToken')
+    if ([string]::IsNullOrWhiteSpace($accessToken)) {
+        throw "Azure CLI fallback returned no access token for resource '$ResourceAppIdUri'."
+    }
+
+    return [PSCustomObject]@{
+        AccessToken  = $accessToken
+        ExpiresOnUtc = Resolve-MdeTokenExpirationUtc -TokenResponse $response
+    }
+}
+
+function Get-MdeUsableAccessToken {
     [CmdletBinding()]
     [OutputType([string])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [pscustomobject]$TokenContext
+    )
+
+    if ([string]::IsNullOrWhiteSpace([string]$TokenContext.AccessToken)) {
+        throw 'The MDE token context does not contain an access token.'
+    }
+
+    $shouldRefresh = (
+        [bool]$TokenContext.CanRefresh -and
+        $null -ne $TokenContext.ExpiresOnUtc -and
+        ([datetime]::UtcNow -ge ([datetime]$TokenContext.ExpiresOnUtc).Subtract([timespan]$TokenContext.RefreshWindow))
+    )
+
+    if ($shouldRefresh) {
+        if ($null -eq $TokenContext.RefreshScript) {
+            throw ("The MDE token context for '{0}' is marked refreshable but has no refresh script." -f [string]$TokenContext.SourceDescription)
+        }
+
+        if ($TokenContext.WriteStatus) {
+            Write-Host ("Refreshing Microsoft Defender for Endpoint access token ({0})..." -f [string]$TokenContext.SourceDescription) -ForegroundColor Cyan
+        }
+
+        $refreshResult = & $TokenContext.RefreshScript
+        $refreshedAccessToken = [string](Get-MdeTokenResponsePropertyValue -InputObject $refreshResult -Name 'AccessToken')
+        if ([string]::IsNullOrWhiteSpace($refreshedAccessToken)) {
+            throw ("Refreshing the MDE token context for '{0}' returned no access token." -f [string]$TokenContext.SourceDescription)
+        }
+
+        $refreshedExpirationUtc = Get-MdeTokenResponsePropertyValue -InputObject $refreshResult -Name 'ExpiresOnUtc'
+        if ($null -eq $refreshedExpirationUtc) {
+            throw ("Refreshing the MDE token context for '{0}' returned no expiration metadata." -f [string]$TokenContext.SourceDescription)
+        }
+
+        $TokenContext.AccessToken = $refreshedAccessToken.Trim()
+        $TokenContext.ExpiresOnUtc = ConvertTo-MdeUtcDateTime -Value $refreshedExpirationUtc
+
+        if ($TokenContext.WriteStatus) {
+            Write-Host '  Token refresh successful' -ForegroundColor Green
+        }
+    }
+
+    return [string]$TokenContext.AccessToken
+}
+
+function New-MdeAccessTokenContext {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '', Justification = 'Token acquisition is an authentication read operation that returns an in-memory context object.')]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSReviewUnusedParameter', 'ResourceAppIdUri', Justification = 'This parameter is captured in refresh closures used to reacquire the token for the same resource.')]
+    [CmdletBinding()]
+    [OutputType([pscustomobject])]
     param(
         [Parameter(Mandatory = $false)]
         [AllowEmptyString()]
@@ -39,7 +333,7 @@ function Get-MdeAccessToken {
             Write-Host 'Using provided Microsoft Defender for Endpoint access token' -ForegroundColor Cyan
         }
 
-        return $AccessToken.Trim()
+        return (New-MdeTokenContext -AccessToken $AccessToken -SourceDescription 'provided access token' -WriteStatus:$WriteStatus)
     }
 
     $resolvedTenantId = $TenantId
@@ -49,7 +343,7 @@ function Get-MdeAccessToken {
     if ($UseEnvironmentFallback) {
         $environmentAccessToken = $env:DEFENDER_ACCESS_TOKEN
         if (-not [string]::IsNullOrWhiteSpace($environmentAccessToken)) {
-            return $environmentAccessToken.Trim()
+            return (New-MdeTokenContext -AccessToken $environmentAccessToken -SourceDescription 'DEFENDER_ACCESS_TOKEN environment variable' -WriteStatus:$WriteStatus)
         }
 
         if ([string]::IsNullOrWhiteSpace($resolvedTenantId)) {
@@ -76,29 +370,14 @@ function Get-MdeAccessToken {
         -not [string]::IsNullOrWhiteSpace($resolvedAppId) -and
         -not [string]::IsNullOrWhiteSpace($resolvedSecretText)
     ) {
-        if ($WriteStatus) {
-            Write-Host 'Authenticating to Microsoft Defender for Endpoint...' -ForegroundColor Cyan
-        }
+        $resolvedWriteStatus = [bool]$WriteStatus
+        $invokeClientCredentialTokenRequest = ${function:Invoke-MdeClientCredentialTokenRequest}
+        $refreshScript = {
+            & $invokeClientCredentialTokenRequest -TenantId $resolvedTenantId -AppId $resolvedAppId -AppSecretText $resolvedSecretText -ResourceAppIdUri $ResourceAppIdUri -WriteStatus:$resolvedWriteStatus
+        }.GetNewClosure()
 
-        $oAuthUri = "https://login.microsoftonline.com/$resolvedTenantId/oauth2/token"
-        $authBody = [ordered]@{
-            resource = $ResourceAppIdUri
-            client_id = $resolvedAppId
-            client_secret = $resolvedSecretText
-            grant_type = 'client_credentials'
-        }
-
-        try {
-            $response = Invoke-RestMethod -Method Post -Uri $oAuthUri -Body $authBody -ErrorAction Stop
-            if ($WriteStatus) {
-                Write-Host '  Authentication successful' -ForegroundColor Green
-            }
-
-            return [string]$response.access_token
-        }
-        catch {
-            throw ("Failed to authenticate to Microsoft Defender for Endpoint for tenant '{0}', app '{1}', resource '{2}': {3}" -f $resolvedTenantId, $resolvedAppId, $ResourceAppIdUri, $_.Exception.Message)
-        }
+        $initialToken = & $refreshScript
+        return (New-MdeTokenContext -AccessToken $initialToken.AccessToken -ExpiresOnUtc $initialToken.ExpiresOnUtc -CanRefresh $true -RefreshScript $refreshScript -SourceDescription ("client credentials for app '{0}'" -f $resolvedAppId) -WriteStatus:$WriteStatus)
     }
 
     $diagnostics = [System.Collections.Generic.List[string]]::new()
@@ -116,12 +395,12 @@ function Get-MdeAccessToken {
         $azCommand = Get-Command -Name 'az' -CommandType Application -ErrorAction SilentlyContinue
         if ($null -ne $azCommand) {
             try {
-                $azAccessToken = [string](& $azCommand.Source 'account' 'get-access-token' '--resource' $ResourceAppIdUri '--query' 'accessToken' '-o' 'tsv')
-                if (-not [string]::IsNullOrWhiteSpace($azAccessToken)) {
-                    return $azAccessToken.Trim()
-                }
-
-                $diagnostics.Add("Azure CLI fallback returned no access token for resource '$ResourceAppIdUri'")
+                $invokeAzureCliTokenRequest = ${function:Invoke-MdeAzureCliTokenRequest}
+                $refreshScript = {
+                    & $invokeAzureCliTokenRequest -AzureCliPath $azCommand.Source -ResourceAppIdUri $ResourceAppIdUri
+                }.GetNewClosure()
+                $initialToken = & $refreshScript
+                return (New-MdeTokenContext -AccessToken $initialToken.AccessToken -ExpiresOnUtc $initialToken.ExpiresOnUtc -CanRefresh $true -RefreshScript $refreshScript -SourceDescription 'Azure CLI access token' -WriteStatus:$WriteStatus)
             }
             catch {
                 Write-Verbose "Azure CLI token acquisition failed: $_"
@@ -162,19 +441,88 @@ function Get-MdeAccessToken {
     throw ("No Defender API token source available. Provide -AccessToken or -TenantId/-AppId/-AppSecret.{0}" -f $diagnosticSuffix)
 }
 
+function Get-MdeAccessToken {
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory = $false)]
+        [AllowEmptyString()]
+        [string]$AccessToken,
+
+        [Parameter(Mandatory = $false)]
+        [AllowEmptyString()]
+        [string]$TenantId,
+
+        [Parameter(Mandatory = $false)]
+        [AllowEmptyString()]
+        [string]$AppId,
+
+        [Parameter(Mandatory = $false)]
+        [AllowNull()]
+        $AppSecret,
+
+        [Parameter(Mandatory = $false)]
+        [string]$ResourceAppIdUri = 'https://api.securitycenter.microsoft.com',
+
+        [Parameter(Mandatory = $false)]
+        [switch]$UseEnvironmentFallback,
+
+        [Parameter(Mandatory = $false)]
+        [switch]$UseAzureCliFallback,
+
+        [Parameter(Mandatory = $false)]
+        [switch]$WriteStatus
+    )
+
+    $tokenContext = New-MdeAccessTokenContext @PSBoundParameters
+    return (Get-MdeUsableAccessToken -TokenContext $tokenContext)
+}
+
 function Get-MdeHeaderCollection {
     [CmdletBinding()]
     [OutputType([hashtable])]
     param(
-        [Parameter(Mandatory = $true)]
-        [string]$AccessToken
+        [Parameter(Mandatory = $true, ParameterSetName = 'AccessToken')]
+        [string]$AccessToken,
+
+        [Parameter(Mandatory = $true, ParameterSetName = 'TokenContext')]
+        [pscustomobject]$TokenContext
     )
 
-    return @{
+    $authorizationToken = if ($PSCmdlet.ParameterSetName -eq 'TokenContext') {
+        Get-MdeUsableAccessToken -TokenContext $TokenContext
+    }
+    else {
+        $AccessToken.Trim()
+    }
+
+    $headers = @{
         'Content-Type'  = 'application/json'
         'Accept'        = 'application/json'
-        'Authorization' = "Bearer $AccessToken"
+        'Authorization' = "Bearer $authorizationToken"
     }
+
+    if ($PSCmdlet.ParameterSetName -eq 'TokenContext') {
+        Add-Member -InputObject $headers -NotePropertyName MdeTokenContext -NotePropertyValue $TokenContext -Force
+    }
+
+    return $headers
+}
+
+function Resolve-MdeHeaderCollection {
+    [CmdletBinding()]
+    [OutputType([hashtable])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [hashtable]$Headers
+    )
+
+    $tokenContextProperty = $Headers.PSObject.Properties['MdeTokenContext']
+    if ($null -ne $tokenContextProperty -and $null -ne $tokenContextProperty.Value) {
+        $Headers['Authorization'] = "Bearer $(Get-MdeUsableAccessToken -TokenContext $tokenContextProperty.Value)"
+    }
+
+    return $Headers
 }
 
 function Resolve-UriQueryParameterValue {
@@ -256,7 +604,7 @@ function Invoke-MdeBulkVulnerabilitySnapshotDownload {
     $emptyDownloadBackoffMultiplier = 2.0
 
     $resolvedExportUrl = Get-MdeBulkVulnerabilityExportRequestUri -ExportUrl $ExportUrl
-    $response = Invoke-RestMethodWithRetry -Uri $resolvedExportUrl -Headers $Headers -Method Get -MaxRetries 4 -InitialDelayMs 5000 -TimeoutSec 600 -RetryTransientTransportFailures
+    $response = Invoke-RestMethodWithRetry -Uri $resolvedExportUrl -Headers (Resolve-MdeHeaderCollection -Headers $Headers) -Method Get -MaxRetries 4 -InitialDelayMs 5000 -TimeoutSec 600 -RetryTransientTransportFailures
     $exportFiles = @($response.exportFiles)
     if ($exportFiles.Count -eq 0) {
         throw 'Bulk vulnerability export returned no files.'
@@ -405,7 +753,7 @@ function Invoke-MdeAdvancedHuntingStoreRefresh {
 
         Write-Information ("  Running Advanced Hunting query: {0}" -f $Label) -InformationAction Continue
         $body = @{ Query = $Query } | ConvertTo-Json
-        $response = Invoke-RestMethodWithRetry -Uri $RequestUrl -Headers $RequestHeaders -Method Post -Body $body
+        $response = Invoke-RestMethodWithRetry -Uri $RequestUrl -Headers (Resolve-MdeHeaderCollection -Headers $RequestHeaders) -Method Post -Body $body
         if ($null -eq $response -or $null -eq $response.Results) {
             return @()
         }
@@ -648,7 +996,7 @@ function Get-MdeMachineRefreshPublishPlan {
 
         do {
             $pageCount++
-            $response = Invoke-RestMethodWithRetry -Uri $url -Headers $Headers -Method Get
+            $response = Invoke-RestMethodWithRetry -Uri $url -Headers (Resolve-MdeHeaderCollection -Headers $Headers) -Method Get
 
             if ($response.value) {
                 foreach ($machine in $response.value) {
@@ -929,6 +1277,9 @@ function Export-MdeMachineData {
         [Parameter(Mandatory = $true, ParameterSetName = 'AccessToken')]
         [string]$AccessToken,
 
+        [Parameter(Mandatory = $true, ParameterSetName = 'TokenContext')]
+        [pscustomobject]$TokenContext,
+
         [Parameter(Mandatory = $true)]
         [string]$OutputPath,
 
@@ -938,6 +1289,9 @@ function Export-MdeMachineData {
 
     $resolvedHeaders = if ($PSCmdlet.ParameterSetName -eq 'AccessToken') {
         Get-MdeHeaderCollection -AccessToken $AccessToken
+    }
+    elseif ($PSCmdlet.ParameterSetName -eq 'TokenContext') {
+        Get-MdeHeaderCollection -TokenContext $TokenContext
     }
     else {
         $Headers

--- a/tests/Generate-SyntheticLargeExports.ps1
+++ b/tests/Generate-SyntheticLargeExports.ps1
@@ -956,7 +956,8 @@ if ($sourcePlanningRowCount -gt $PlanningSourceRowLimit) {
 Write-Output "Reading source machine data from '$SourcePath'..."
 $sourceMachines = Read-MachineData -Path $SourcePath
 $machineTemplates = [System.Collections.Generic.List[object]]::new()
-foreach ($machine in $sourceMachines.Values) {
+foreach ($machineKey in @($sourceMachines.Keys | Sort-Object)) {
+    $machine = $sourceMachines[$machineKey]
     if ($null -eq $machine) { continue }
     $machineTemplates.Add($machine)
 }
@@ -1052,7 +1053,8 @@ foreach ($historyEntry in $sourceHistoryEntries) {
 }
 
 $rowProfiles = [System.Collections.Generic.List[object]]::new()
-foreach ($rowProfileEntry in $rowProfileMap.Values) {
+foreach ($profileKey in @($rowProfileMap.Keys | Sort-Object)) {
+    $rowProfileEntry = $rowProfileMap[$profileKey]
     if ($null -eq $rowProfileEntry.TemplateMachine) {
         $fallbackRow = if ($rowProfileEntry.CurrentRows.Count -gt 0) { $rowProfileEntry.CurrentRows[0] } elseif ($rowProfileEntry.HistoryEntries.Count -gt 0) { $rowProfileEntry.HistoryEntries[0].Row } else { $null }
         if ($null -ne $fallbackRow) {

--- a/tests/Run-SharedHelperRegression.ps1
+++ b/tests/Run-SharedHelperRegression.ps1
@@ -1123,18 +1123,90 @@ function Test-GetMdeAccessTokenReportsAuthenticationContext {
     try {
         $failure = $null
         try {
-            $null = Get-MdeAccessToken -TenantId 'tenant-001' -AppId 'app-001' -AppSecret 'secret-value'
+            $null = Invoke-MdeClientCredentialTokenRequest -TenantId 'tenant-001' -AppId 'app-001' -AppSecretText 'secret-value'
         }
         catch {
             $failure = $_
         }
 
         Assert-True ($null -ne $failure) 'Expected failed MDE authentication attempts to surface context-rich diagnostics.'
-        Assert-True ($failure.Exception.Message -like "*tenant 'tenant-001'*app 'app-001'*resource 'https://api.securitycenter.microsoft.com'*invalid_client*") 'Expected authentication failures to include the tenant, app, resource, and underlying error message.'
+        $message = [string]$failure.Exception.Message
+        Assert-True ($message.Contains("tenant 'tenant-001'")) 'Expected authentication failures to include the tenant identifier.'
+        Assert-True ($message.Contains("app 'app-001'")) 'Expected authentication failures to include the app identifier.'
+        Assert-True ($message.Contains("resource 'https://api.securitycenter.microsoft.com'")) 'Expected authentication failures to include the resource identifier.'
+        Assert-True ($message.Contains('invalid_client')) 'Expected authentication failures to preserve the underlying error message.'
     }
     finally {
         Remove-Item -Path Function:Invoke-RestMethod -ErrorAction SilentlyContinue
     }
+}
+
+function Test-NewMdeAccessTokenContextRejectsMissingExpirationMetadata {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '', Justification = 'Test function name mirrors the scenario under test.')]
+    [CmdletBinding()]
+    param()
+
+    $failure = $null
+    try {
+        $null = New-MdeTokenContext -AccessToken 'token-without-expiry' -CanRefresh $true -RefreshScript { return $null } -SourceDescription 'test context'
+    }
+    catch {
+        $failure = $_
+    }
+
+    Assert-True ($null -ne $failure) 'Expected refreshable MDE token contexts to reject missing expiration metadata.'
+    Assert-True ($failure.Exception.Message -like "*require expiration metadata*") 'Expected missing-expiration validation to explain why refreshable MDE token contexts cannot be created.'
+}
+
+function Test-MdeRequestHeaderRefreshesNearExpiryTokenContext {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '', Justification = 'Test function name mirrors the scenario under test.')]
+    [CmdletBinding()]
+    param()
+
+    $script:MockMdeTokenRequestCount = 0
+    Set-Item -Path Function:Invoke-RestMethod -Value {
+        $script:MockMdeTokenRequestCount++
+        if ($script:MockMdeTokenRequestCount -eq 1) {
+            return [PSCustomObject]@{
+                access_token = 'token-initial'
+                expires_in   = 3600
+            }
+        }
+
+        return [PSCustomObject]@{
+            access_token = 'token-refreshed'
+            expires_in   = 3600
+        }
+    }
+
+    try {
+        $tokenContext = New-MdeAccessTokenContext -TenantId 'tenant-001' -AppId 'app-001' -AppSecret 'secret-value'
+        $headers = Get-MdeHeaderCollection -TokenContext $tokenContext
+        Assert-True ($headers.Authorization -eq 'Bearer token-initial') 'Expected the initial MDE header collection to use the original token.'
+
+        $tokenContext.ExpiresOnUtc = [datetime]::UtcNow.AddMinutes(4)
+        $resolvedHeaders = Resolve-MdeHeaderCollection -Headers $headers
+
+        Assert-True ($resolvedHeaders.Authorization -eq 'Bearer token-refreshed') 'Expected near-expiry MDE headers to refresh the bearer token before the next request.'
+        Assert-True ($script:MockMdeTokenRequestCount -eq 2) 'Expected MDE token refresh to reacquire a token exactly once when the remaining lifetime drops below the refresh window.'
+    }
+    finally {
+        Remove-Item -Path Function:Invoke-RestMethod -ErrorAction SilentlyContinue
+        Remove-Variable -Name MockMdeTokenRequestCount -Scope Script -ErrorAction SilentlyContinue
+    }
+}
+
+function Test-MdeRequestHeaderKeepsExplicitAccessTokenContextStable {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '', Justification = 'Test function name mirrors the scenario under test.')]
+    [CmdletBinding()]
+    param()
+
+    $tokenContext = New-MdeAccessTokenContext -AccessToken 'token-explicit'
+    $headers = Get-MdeHeaderCollection -TokenContext $tokenContext
+    $resolvedHeaders = Resolve-MdeHeaderCollection -Headers $headers
+
+    Assert-True ($tokenContext.CanRefresh -eq $false) 'Expected explicitly supplied access tokens to remain non-refreshable.'
+    Assert-True ($resolvedHeaders.Authorization -eq 'Bearer token-explicit') 'Expected explicit MDE access tokens to remain usable without refresh metadata.'
 }
 
 function Test-BulkSnapshotImportSmoke {
@@ -6014,6 +6086,124 @@ function Test-LargeDatasetValidationSemanticModeForcesFullReplay {
     }
 }
 
+function Test-GenerateSyntheticLargeExportsUsesStablePlannerOrdering {
+    [CmdletBinding()]
+    param()
+
+    $repoRoot = Split-Path -Path $PSScriptRoot -Parent
+    $generatorScriptPath = Join-Path $repoRoot 'tests\Generate-SyntheticLargeExports.ps1'
+    Assert-True ((Test-Path -LiteralPath $generatorScriptPath -PathType Leaf)) "Expected synthetic large-export generator script at '$generatorScriptPath'."
+
+    $pwshCommand = Get-Command -Name 'pwsh' -ErrorAction Stop
+    $tempRoot = Join-Path ([System.IO.Path]::GetTempPath()) ('synthetic-ordering-' + [guid]::NewGuid().ToString('N'))
+
+    try {
+        [void](New-Item -Path $tempRoot -ItemType Directory -Force)
+
+        $runDirectories = @(
+            (Join-Path $tempRoot 'run-a')
+            (Join-Path $tempRoot 'run-b')
+        )
+
+        foreach ($runDirectory in $runDirectories) {
+            $stdoutPath = Join-Path $runDirectory 'stdout.log'
+            $stderrPath = Join-Path $runDirectory 'stderr.log'
+            [void](New-Item -Path $runDirectory -ItemType Directory -Force)
+
+            $argumentList = @(
+                '-NoProfile'
+                '-File'
+                $generatorScriptPath
+                '-SourcePath'
+                (Join-Path $repoRoot 'exports')
+                '-OutputPath'
+                $runDirectory
+                '-TargetDeviceCount'
+                '12'
+                '-TargetTotalVulnRows'
+                '300'
+                '-MinimumAvailableMemoryGB'
+                '1'
+                '-Seed'
+                '20260322'
+            )
+
+            $process = Start-Process -FilePath $pwshCommand.Source -ArgumentList $argumentList -WorkingDirectory $repoRoot -RedirectStandardOutput $stdoutPath -RedirectStandardError $stderrPath -PassThru
+            $process.WaitForExit()
+
+            $stdoutContent = if (Test-Path -LiteralPath $stdoutPath -PathType Leaf) { Get-Content -LiteralPath $stdoutPath -Raw } else { '' }
+            $stderrContent = if (Test-Path -LiteralPath $stderrPath -PathType Leaf) { Get-Content -LiteralPath $stderrPath -Raw } else { '' }
+            $processOutput = @($stdoutContent, $stderrContent) -join [Environment]::NewLine
+
+            Assert-True ($process.ExitCode -eq 0) ("Expected deterministic generator smoke run to succeed. Output:`n{0}" -f $processOutput.Trim())
+        }
+
+        $manifestPropertyNames = @(
+            'preset'
+            'seed'
+            'targetDeviceCount'
+            'targetTotalVulnRows'
+            'targetCurrentRows'
+            'targetHistoryRows'
+            'actualDeviceCount'
+            'includeRawRows'
+            'actualCurrentRows'
+            'actualHistoryRows'
+            'actualTotalVulnRows'
+            'scaleFactor'
+            'sourceCurrentRows'
+            'sourceHistoryRows'
+            'sourceRowProfiles'
+            'historyPeriods'
+            'advancedHuntingRows'
+            'contentTemplateCount'
+            'uniqueCveIdCount'
+            'normalizedCveLookupCount'
+        )
+
+        $normalizedManifestJson = foreach ($runDirectory in $runDirectories) {
+            $manifest = Get-Content -LiteralPath (Join-Path $runDirectory 'synthetic-manifest.json') -Raw | ConvertFrom-Json -Depth 20
+            $normalizedManifest = [ordered]@{}
+            foreach ($propertyName in $manifestPropertyNames) {
+                $normalizedManifest[$propertyName] = $manifest.$propertyName
+            }
+
+            $normalizedManifest | ConvertTo-Json -Depth 20 -Compress
+        }
+
+        Assert-True ($normalizedManifestJson[0] -eq $normalizedManifestJson[1]) 'Expected synthetic manifests to match across fresh PowerShell processes when using the same seed.'
+
+        $gzipPaths = @(
+            @{ RelativePath = 'Machines_Current.json.gz'; PathResolver = { param($basePath) (Get-MachineCurrentPath -BasePath $basePath) } }
+            @{ RelativePath = 'VulnCurrentRefs.json.gz'; PathResolver = { param($basePath) (Get-VulnCurrentRefsPath -BasePath $basePath) } }
+            @{ RelativePath = 'AdvancedHunting_Current.json.gz'; PathResolver = { param($basePath) (Get-AdvancedHuntingCurrentPath -BasePath $basePath) } }
+            @{ RelativePath = 'VulnContentDictionary.json.gz'; PathResolver = { param($basePath) (Get-VulnContentDictionaryPath -BasePath $basePath) } }
+        )
+
+        foreach ($gzipPathInfo in $gzipPaths) {
+            $firstPath = & $gzipPathInfo.PathResolver $runDirectories[0]
+            $secondPath = & $gzipPathInfo.PathResolver $runDirectories[1]
+            Assert-True ((Read-GzipTextFile -Path $firstPath) -eq (Read-GzipTextFile -Path $secondPath)) ("Expected {0} to be stable across fresh PowerShell processes." -f $gzipPathInfo.RelativePath)
+        }
+
+        $historyRefNamesA = @((Get-ChildItem -LiteralPath $runDirectories[0] -Filter 'VulnHistoryRefs_*.json.gz' -File | Sort-Object Name).Name)
+        $historyRefNamesB = @((Get-ChildItem -LiteralPath $runDirectories[1] -Filter 'VulnHistoryRefs_*.json.gz' -File | Sort-Object Name).Name)
+
+        Assert-True (($historyRefNamesA.Count -eq $historyRefNamesB.Count) -and ((@($historyRefNamesA) -join '|') -eq (@($historyRefNamesB) -join '|'))) 'Expected synthetic history ref file sets to match across fresh PowerShell processes.'
+
+        foreach ($historyRefName in $historyRefNamesA) {
+            $firstPath = Join-Path $runDirectories[0] $historyRefName
+            $secondPath = Join-Path $runDirectories[1] $historyRefName
+            Assert-True ((Read-GzipTextFile -Path $firstPath) -eq (Read-GzipTextFile -Path $secondPath)) ("Expected history ref file '{0}' to be stable across fresh PowerShell processes." -f $historyRefName)
+        }
+    }
+    finally {
+        if (Test-Path -LiteralPath $tempRoot) {
+            Remove-Item -LiteralPath $tempRoot -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+}
+
 function Test-HotPhaseReviewArtifactsModeSmoke {
     [CmdletBinding()]
     param()
@@ -6169,6 +6359,9 @@ $sharedHelperRegressionTests = @(
     @{ Name = 'Test-BulkVulnerabilitySnapshotDownloadCleanupBehavior'; SuccessMessage = 'Multipart vulnerability failed-download cleanup checks passed.' }
     @{ Name = 'Test-GetMdeAccessTokenReportsMissingConfigurationDiagnostic'; SuccessMessage = 'MDE token-source diagnostics checks passed.' }
     @{ Name = 'Test-GetMdeAccessTokenReportsAuthenticationContext'; SuccessMessage = 'MDE authentication context diagnostics checks passed.' }
+    @{ Name = 'Test-NewMdeAccessTokenContextRejectsMissingExpirationMetadata'; SuccessMessage = 'MDE token expiration metadata checks passed.' }
+    @{ Name = 'Test-MdeRequestHeaderRefreshesNearExpiryTokenContext'; SuccessMessage = 'MDE proactive token refresh checks passed.' }
+    @{ Name = 'Test-MdeRequestHeaderKeepsExplicitAccessTokenContextStable'; SuccessMessage = 'Explicit MDE access token compatibility checks passed.' }
     @{ Name = 'Test-VulnCurrentFileRejectsDuplicateId'; SuccessMessage = 'Current-file duplicate Id checks passed.' }
     @{ Name = 'Test-RepairVulnHistoryLayoutSkipsCanonicalQuarterlyStore'; SuccessMessage = 'Canonical quarterly history repair skip checks passed.' }
     @{ Name = 'Test-VulnStoreRequiresCanonicalRepairDetectsMalformedQuarterlyHistory'; SuccessMessage = 'Canonical quarterly history gate checks passed.' }
@@ -6210,6 +6403,7 @@ $sharedHelperRegressionTests = @(
     @{ Name = 'Test-WriteCombinedPayloadGzipCanConsumeColumnLookupData'; SuccessMessage = 'Payload lookup consumption checks passed.' }
     @{ Name = 'Test-GetDashboardEmbeddedPayloadInspectionStreamsSelfContainedPayload'; SuccessMessage = 'Embedded payload inspection checks passed.' }
     @{ Name = 'Test-MeasureStressRunWritesProgressAndFinalReport'; SuccessMessage = 'Measure-StressRun report persistence checks passed.' }
+    @{ Name = 'Test-GenerateSyntheticLargeExportsUsesStablePlannerOrdering'; SuccessMessage = 'Synthetic planner ordering checks passed.' }
     @{ Name = 'Test-LargeDatasetValidationSemanticModeForcesFullReplay'; SuccessMessage = 'Large-dataset semantic sign-off checks passed.' }
     @{ Name = 'Test-HotPhaseReviewArtifactsModeSmoke'; SuccessMessage = 'Hot-phase review wrapper smoke checks passed.' }
     @{ Name = 'Test-GetDashboardTemplateContentAcceptsExplicitTemplatesPathWithEmptyDefaultRoot'; SuccessMessage = 'Dashboard template explicit-path checks passed.' }


### PR DESCRIPTION
## Summary
- refresh MDE access tokens proactively when less than five minutes remain and use the refresh-aware token context throughout local and Azure export flows
- regenerate the Azure runbook and Function App entrypoint artifacts from the updated auth helpers
- stabilize synthetic large-export planner ordering and add a regression that proves seeded runs stay identical across fresh PowerShell processes

## Validation
- build\Invoke-RegressionValidation.ps1

Closes #51