### PR TITLE
Make Azure template publishing work from release packages

### DIFF
--- a/Setup-AzureResources.ps1
+++ b/Setup-AzureResources.ps1
@@ -1747,19 +1747,19 @@ try {
     if (-not $SkipValidation) {
         Write-Host "`nStep 14: Running end-to-end validation..." -ForegroundColor Cyan
 
-        # 14a: Upload template files via the public build-layer publish contract
+        # 14a: Upload template files via the package-safe Azure publish contract
         Write-Host "  Uploading template files..." -ForegroundColor Gray
-        $publishTemplatesScript = Join-Path -Path $PSScriptRoot -ChildPath 'build' | Join-Path -ChildPath 'Publish-DashboardTemplates.ps1'
-        $uploadScript = if (Test-Path -LiteralPath $publishTemplatesScript -PathType Leaf) {
-            $publishTemplatesScript
-        }
-        else {
-            Join-Path -Path $PSScriptRoot -ChildPath 'azure' | Join-Path -ChildPath 'Upload-Templates.ps1'
-        }
+        $uploadScriptCandidates = @(
+            (Join-Path -Path $PSScriptRoot -ChildPath 'azure' | Join-Path -ChildPath 'Upload-Templates.ps1')
+            (Join-Path -Path $PSScriptRoot -ChildPath 'build' | Join-Path -ChildPath 'Publish-DashboardTemplates.ps1')
+        )
+        $uploadScript = $uploadScriptCandidates |
+            Where-Object { Test-Path -LiteralPath $_ -PathType Leaf } |
+            Select-Object -First 1
 
-        if (-not (Test-Path -LiteralPath $uploadScript -PathType Leaf)) {
-            Write-Warning "Template publish script not found at: $uploadScript"
-            Write-Host "  Run .\build\Publish-DashboardTemplates.ps1 manually before the pipeline." -ForegroundColor Yellow
+        if ([string]::IsNullOrWhiteSpace($uploadScript) -or -not (Test-Path -LiteralPath $uploadScript -PathType Leaf)) {
+            Write-Warning "Template publish script not found. Expected one of: $($uploadScriptCandidates -join ', ')"
+            Write-Host "  Run .\azure\Upload-Templates.ps1 manually before the pipeline." -ForegroundColor Yellow
         }
         else {
             & $uploadScript -StorageAccountName $StorageAccountName
@@ -2570,7 +2570,7 @@ exec caddy file-server --root /data --listen :80
         }
     }
     else {
-        Write-Host "  1. Upload templates: .\build\Publish-DashboardTemplates.ps1 -StorageAccountName $StorageAccountName" -ForegroundColor Gray
+        Write-Host "  1. Upload templates: .\azure\Upload-Templates.ps1 -StorageAccountName $StorageAccountName" -ForegroundColor Gray
         if ($ComputeType -eq 'AutomationAccount') {
             Write-Host "  2. Run the pipeline: start the runbook manually from the Azure portal" -ForegroundColor Gray
         } else {

--- a/azure/Upload-Templates.ps1
+++ b/azure/Upload-Templates.ps1
@@ -2,13 +2,12 @@
 
 <#
 .SYNOPSIS
-    Compatibility wrapper for uploading dashboard templates to Azure Blob Storage.
+    Uploads dashboard templates to Azure Blob Storage.
 
 .DESCRIPTION
-    Delegates to the supported build-layer publish contract at
-    build/Publish-DashboardTemplates.ps1 so existing callers can keep using the
-    historical azure/Upload-Templates.ps1 path while wrappers and CI migrate to
-    the documented build entrypoint.
+    Azure-side template publisher used by Setup-AzureResources.ps1 and release
+    packages. This script is self-contained under the azure/ tree so extracted
+    deployment packages do not depend on build/ artifacts being present.
 
 .PARAMETER StorageAccountName
     Name of the Azure Storage account.
@@ -29,7 +28,8 @@
     .\Upload-Templates.ps1 -StorageAccountName "stdefenderreporting" -TemplatesPath "C:\repo\templates"
 
 .NOTES
-    Prefer build/Publish-DashboardTemplates.ps1 for new automation and wrapper integrations.
+    Repo-owned wrappers can call build/Publish-DashboardTemplates.ps1, which now
+    delegates to this Azure-shipped implementation.
 #>
 
 [CmdletBinding(SupportsShouldProcess)]
@@ -48,11 +48,71 @@ param(
 )
 
 $ErrorActionPreference = 'Stop'
-$repoRoot = Split-Path -Path $PSScriptRoot -Parent
-$publishScriptPath = Join-Path -Path $repoRoot -ChildPath 'build\Publish-DashboardTemplates.ps1'
-
-if (-not (Test-Path -LiteralPath $publishScriptPath -PathType Leaf)) {
-    throw "Supported dashboard template publish script not found: $publishScriptPath"
+$publishToolsPath = Join-Path -Path $PSScriptRoot -ChildPath 'private\DashboardTemplatePublishTools.ps1'
+if (-not (Test-Path -LiteralPath $publishToolsPath -PathType Leaf)) {
+    throw "Required dashboard template publish helper not found: $publishToolsPath"
 }
 
-& $publishScriptPath @PSBoundParameters
+. $publishToolsPath
+
+$repoRoot = Split-Path -Path $PSScriptRoot -Parent
+$resolvedTemplatesPath = Resolve-DashboardTemplatesPath -RepoRoot $repoRoot -TemplatesPath $TemplatesPath
+$publishState = Get-DashboardTemplatePublishState -TemplatesPath $resolvedTemplatesPath -RepoRoot $repoRoot
+
+Write-Output ("Preparing dashboard template publish contract from: {0}" -f $publishState.TemplatesDisplayPath)
+Write-Output ("Template file count: {0}" -f $publishState.FileCount)
+Write-Output ("Template fingerprint: {0}" -f $publishState.Fingerprint)
+
+if ($PSBoundParameters.ContainsKey('MetadataPath')) {
+    $publishManifest = [PSCustomObject]@{
+        generatedOnUtc = [datetime]::UtcNow.ToString('o')
+        publishScript = 'azure/Upload-Templates.ps1'
+        storageAccountName = $StorageAccountName
+        containerName = $ContainerName
+        templatesPath = $publishState.TemplatesDisplayPath
+        templateFingerprint = $publishState.Fingerprint
+        templateFileCount = $publishState.FileCount
+        totalSizeBytes = $publishState.TotalSizeBytes
+        files = @(
+            $publishState.Files |
+                ForEach-Object {
+                    [PSCustomObject]@{
+                        path = $_.Path
+                        sourcePath = $_.SourcePath
+                        sha256 = $_.Sha256
+                        contentType = $_.ContentType
+                        sizeBytes = $_.SizeBytes
+                    }
+                }
+        )
+    }
+
+    if ($PSCmdlet.ShouldProcess($MetadataPath, 'Write dashboard template publish manifest')) {
+        Write-DashboardTemplatePublishUtf8BomFile -Path $MetadataPath -Content (($publishManifest | ConvertTo-Json -Depth 10) + [Environment]::NewLine)
+        Write-Output ("Dashboard template publish manifest: {0}" -f $MetadataPath)
+    }
+}
+
+if (-not $PSCmdlet.ShouldProcess(("$StorageAccountName/$ContainerName"), ("Upload {0} dashboard template file(s)" -f $publishState.FileCount))) {
+    return
+}
+
+Write-Output 'Authenticating to Azure Storage...'
+$storageToken = Get-DashboardTemplatePublishStorageAccessToken
+
+Write-Output ("Uploading dashboard templates to '{0}' container..." -f $ContainerName)
+foreach ($templateFile in $publishState.Files) {
+    $fileSizeKb = [math]::Round($templateFile.SizeBytes / 1KB, 1)
+    Write-Output ("  Uploading {0} ({1} KB)..." -f $templateFile.Path, $fileSizeKb)
+    Publish-DashboardTemplateBlobFileWithRetry `
+        -StorageAccountName $StorageAccountName `
+        -ContainerName $ContainerName `
+        -BlobName $templateFile.Path `
+        -FilePath $templateFile.FullPath `
+        -ContentType $templateFile.ContentType `
+        -StorageToken $storageToken
+    Write-Output '    Uploaded'
+}
+
+Write-Output ("Published dashboard templates to: https://{0}.blob.core.windows.net/{1}/" -f $StorageAccountName, $ContainerName)
+Write-Output 'The dashboard pipeline runbook and Function App will download these templates at generation time.'

--- a/azure/Upload-Templates.ps1
+++ b/azure/Upload-Templates.ps1
@@ -48,7 +48,7 @@ param(
 )
 
 $ErrorActionPreference = 'Stop'
-$publishToolsPath = Join-Path -Path $PSScriptRoot -ChildPath 'private\DashboardTemplatePublishTools.ps1'
+$publishToolsPath = Join-Path -Path (Join-Path -Path $PSScriptRoot -ChildPath 'private') -ChildPath 'DashboardTemplatePublishTools.ps1'
 if (-not (Test-Path -LiteralPath $publishToolsPath -PathType Leaf)) {
     throw "Required dashboard template publish helper not found: $publishToolsPath"
 }

--- a/azure/private/DashboardTemplatePublishTools.ps1
+++ b/azure/private/DashboardTemplatePublishTools.ps1
@@ -1,0 +1,336 @@
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Assert-DashboardTemplatePublishPath {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Path,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateSet('Leaf', 'Container')]
+        [string]$PathType
+    )
+
+    if (-not (Test-Path -LiteralPath $Path -PathType $PathType)) {
+        throw "Required path not found: $Path"
+    }
+}
+
+function Initialize-DashboardTemplatePublishParentDirectory {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Path
+    )
+
+    $parentPath = Split-Path -Path $Path -Parent
+    if (-not [string]::IsNullOrWhiteSpace($parentPath) -and -not (Test-Path -LiteralPath $parentPath -PathType Container)) {
+        New-Item -Path $parentPath -ItemType Directory -Force | Out-Null
+    }
+}
+
+function Write-DashboardTemplatePublishUtf8BomFile {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Path,
+
+        [Parameter(Mandatory = $true)]
+        [AllowEmptyString()]
+        [string]$Content
+    )
+
+    Initialize-DashboardTemplatePublishParentDirectory -Path $Path
+    [System.IO.File]::WriteAllText($Path, $Content, [System.Text.UTF8Encoding]::new($true))
+}
+
+function Get-DashboardTemplatePublishTextSha256Hex {
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [AllowEmptyString()]
+        [string]$Text
+    )
+
+    $hashBytes = [System.Security.Cryptography.SHA256]::HashData([System.Text.Encoding]::UTF8.GetBytes($Text))
+    return ([System.BitConverter]::ToString($hashBytes)).Replace('-', '').ToLowerInvariant()
+}
+
+function Get-DashboardTemplatePublishFileContentSha256Hex {
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Path
+    )
+
+    Assert-DashboardTemplatePublishPath -Path $Path -PathType Leaf
+    return (Get-FileHash -LiteralPath $Path -Algorithm SHA256).Hash.ToLowerInvariant()
+}
+
+function Test-DashboardTemplatePublishPathWithinRoot {
+    [CmdletBinding()]
+    [OutputType([bool])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Path,
+
+        [Parameter(Mandatory = $true)]
+        [string]$Root
+    )
+
+    $resolvedPath = [System.IO.Path]::GetFullPath($Path)
+    $resolvedRoot = [System.IO.Path]::GetFullPath($Root)
+    $comparison = [System.StringComparison]::OrdinalIgnoreCase
+
+    if ($resolvedPath.Equals($resolvedRoot, $comparison)) {
+        return $true
+    }
+
+    $rootWithSeparator = $resolvedRoot.TrimEnd('\', '/') + [System.IO.Path]::DirectorySeparatorChar
+    return $resolvedPath.StartsWith($rootWithSeparator, $comparison)
+}
+
+function Get-DashboardTemplatePublishDisplayPath {
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Path,
+
+        [Parameter(Mandatory = $true)]
+        [string]$RepoRoot
+    )
+
+    $resolvedPath = [System.IO.Path]::GetFullPath($Path)
+    $resolvedRoot = [System.IO.Path]::GetFullPath($RepoRoot)
+    if ($resolvedPath.StartsWith($resolvedRoot, [System.StringComparison]::OrdinalIgnoreCase)) {
+        return $resolvedPath.Substring($resolvedRoot.Length + 1).Replace('\', '/')
+    }
+
+    return $resolvedPath.Replace('\', '/')
+}
+
+function Resolve-DashboardTemplatesPath {
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$RepoRoot,
+
+        [Parameter(Mandatory = $false)]
+        [string]$TemplatesPath
+    )
+
+    $resolvedTemplatesPath = if ([string]::IsNullOrWhiteSpace($TemplatesPath)) {
+        Join-Path -Path $RepoRoot -ChildPath 'templates'
+    }
+    else {
+        [System.IO.Path]::GetFullPath($TemplatesPath)
+    }
+
+    Assert-DashboardTemplatePublishPath -Path $resolvedTemplatesPath -PathType Container
+    return $resolvedTemplatesPath
+}
+
+function Get-DashboardTemplatePublishContentType {
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [System.IO.FileInfo]$File
+    )
+
+    switch ($File.Extension.ToLowerInvariant()) {
+        '.html' { return 'text/html' }
+        '.css' { return 'text/css' }
+        '.js' { return 'application/javascript' }
+        '.json' { return 'application/json' }
+        default { return 'application/octet-stream' }
+    }
+}
+
+function Get-DashboardTemplatePublishState {
+    [CmdletBinding()]
+    [OutputType([pscustomobject])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$TemplatesPath,
+
+        [Parameter(Mandatory = $false)]
+        [string]$RepoRoot
+    )
+
+    $templateFiles = @(
+        Get-ChildItem -LiteralPath $TemplatesPath -File -Recurse -ErrorAction Stop |
+            Sort-Object FullName
+    )
+    if ($templateFiles.Count -eq 0) {
+        throw "No template files found under '$TemplatesPath'."
+    }
+
+    $fingerprintBuilder = [System.Text.StringBuilder]::new()
+    $resolvedRepoRoot = if ([string]::IsNullOrWhiteSpace($RepoRoot)) { $null } else { [System.IO.Path]::GetFullPath($RepoRoot) }
+    $templateEntries = foreach ($file in $templateFiles) {
+        $relativePath = [System.IO.Path]::GetRelativePath($TemplatesPath, $file.FullName).Replace('\', '/')
+        $contentSha256 = Get-DashboardTemplatePublishFileContentSha256Hex -Path $file.FullName
+        $contentType = Get-DashboardTemplatePublishContentType -File $file
+        $sourcePath = if ($null -ne $resolvedRepoRoot -and (Test-DashboardTemplatePublishPathWithinRoot -Path $file.FullName -Root $resolvedRepoRoot)) {
+            Get-DashboardTemplatePublishDisplayPath -Path $file.FullName -RepoRoot $resolvedRepoRoot
+        }
+        else {
+            $file.FullName
+        }
+
+        [void]$fingerprintBuilder.AppendLine("path:$relativePath")
+        [void]$fingerprintBuilder.AppendLine("sha256:$contentSha256")
+        [void]$fingerprintBuilder.AppendLine("contentType:$contentType")
+
+        [PSCustomObject]@{
+            Path = $relativePath
+            SourcePath = $sourcePath
+            FullPath = $file.FullName
+            Sha256 = $contentSha256
+            ContentType = $contentType
+            SizeBytes = $file.Length
+        }
+    }
+
+    $templatesDisplayPath = if ($null -ne $resolvedRepoRoot -and (Test-DashboardTemplatePublishPathWithinRoot -Path $TemplatesPath -Root $resolvedRepoRoot)) {
+        Get-DashboardTemplatePublishDisplayPath -Path $TemplatesPath -RepoRoot $resolvedRepoRoot
+    }
+    else {
+        $TemplatesPath
+    }
+
+    return [PSCustomObject]@{
+        TemplatesPath = $TemplatesPath
+        TemplatesDisplayPath = $templatesDisplayPath
+        FileCount = $templateEntries.Count
+        TotalSizeBytes = [int64]($templateEntries | Measure-Object -Property SizeBytes -Sum | Select-Object -ExpandProperty Sum)
+        Fingerprint = Get-DashboardTemplatePublishTextSha256Hex -Text $fingerprintBuilder.ToString()
+        Files = @($templateEntries)
+    }
+}
+
+function ConvertTo-DashboardTemplatePublishPlainTextToken {
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [System.Security.SecureString]$Token
+    )
+
+    $tokenPointer = [System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($Token)
+    try {
+        return [System.Runtime.InteropServices.Marshal]::PtrToStringBSTR($tokenPointer)
+    }
+    finally {
+        [System.Runtime.InteropServices.Marshal]::ZeroFreeBSTR($tokenPointer)
+    }
+}
+
+function Get-DashboardTemplatePublishStorageAccessToken {
+    [CmdletBinding()]
+    [OutputType([string])]
+    param()
+
+    $getAzAccessTokenCommand = Get-Command -Name 'Get-AzAccessToken' -ErrorAction SilentlyContinue
+    if ($null -ne $getAzAccessTokenCommand) {
+        $hasAzContext = $true
+        $getAzContextCommand = Get-Command -Name 'Get-AzContext' -ErrorAction SilentlyContinue
+        if ($null -ne $getAzContextCommand) {
+            try {
+                $azContext = Get-AzContext -ErrorAction Stop
+                $hasAzContext = ($null -ne $azContext -and $null -ne $azContext.Account)
+            }
+            catch {
+                $hasAzContext = $false
+            }
+        }
+
+        if ($hasAzContext) {
+            try {
+                $tokenResponse = Get-AzAccessToken -ResourceUrl 'https://storage.azure.com/' -AsSecureString -ErrorAction Stop
+                return ConvertTo-DashboardTemplatePublishPlainTextToken -Token $tokenResponse.Token
+            }
+            catch {
+                Write-Verbose "Az PowerShell token acquisition failed: $_"
+            }
+        }
+    }
+
+    if ($null -ne (Get-Command -Name 'az' -CommandType Application -ErrorAction SilentlyContinue)) {
+        try {
+            $azAccessToken = (& az 'account' 'get-access-token' '--resource' 'https://storage.azure.com/' '--query' 'accessToken' '-o' 'tsv' 2>&1 | Out-String)
+            if ($LASTEXITCODE -eq 0 -and -not [string]::IsNullOrWhiteSpace($azAccessToken)) {
+                return $azAccessToken.Trim()
+            }
+
+            if ($LASTEXITCODE -ne 0 -and -not [string]::IsNullOrWhiteSpace($azAccessToken)) {
+                Write-Verbose ("Azure CLI token acquisition failed: {0}" -f $azAccessToken.Trim())
+            }
+        }
+        catch {
+            Write-Verbose "Azure CLI token acquisition failed: $_"
+        }
+    }
+
+    throw "No Azure Storage token source available. Run Connect-AzAccount or az login, then retry."
+}
+
+function Publish-DashboardTemplateBlobFileWithRetry {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$StorageAccountName,
+
+        [Parameter(Mandatory = $true)]
+        [string]$ContainerName,
+
+        [Parameter(Mandatory = $true)]
+        [string]$BlobName,
+
+        [Parameter(Mandatory = $true)]
+        [string]$FilePath,
+
+        [Parameter(Mandatory = $true)]
+        [string]$ContentType,
+
+        [Parameter(Mandatory = $true)]
+        [string]$StorageToken,
+
+        [Parameter(Mandatory = $false)]
+        [int]$MaxRetries = 3,
+
+        [Parameter(Mandatory = $false)]
+        [int]$InitialRetryDelaySeconds = 2
+    )
+
+    Assert-DashboardTemplatePublishPath -Path $FilePath -PathType Leaf
+    $blobUri = "https://$StorageAccountName.blob.core.windows.net/$ContainerName/$BlobName"
+    $headers = @{
+        'Authorization'    = "Bearer $StorageToken"
+        'x-ms-version'     = '2021-12-02'
+        'x-ms-blob-type'   = 'BlockBlob'
+        'x-ms-access-tier' = 'Cool'
+    }
+
+    $retryDelaySeconds = $InitialRetryDelaySeconds
+    for ($attempt = 1; $attempt -le $MaxRetries; $attempt++) {
+        try {
+            Invoke-RestMethod -Uri $blobUri -Method Put -Headers $headers -InFile $FilePath -ContentType $ContentType -ErrorAction Stop
+            return
+        }
+        catch {
+            if ($attempt -eq $MaxRetries) {
+                throw "Failed to upload '$BlobName' to container '$ContainerName' in storage account '$StorageAccountName' after $MaxRetries attempt(s): $_"
+            }
+
+            Start-Sleep -Seconds $retryDelaySeconds
+            $retryDelaySeconds *= 2
+        }
+    }
+}

--- a/build/Publish-DashboardTemplates.ps1
+++ b/build/Publish-DashboardTemplates.ps1
@@ -15,69 +15,13 @@ param(
     [string]$MetadataPath
 )
 
-. (Join-Path -Path $PSScriptRoot -ChildPath 'private\AzureArtifactBuildTools.ps1')
-
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
 $repoRoot = Split-Path -Path $PSScriptRoot -Parent
-$resolvedTemplatesPath = Resolve-DashboardTemplatesPath -RepoRoot $repoRoot -TemplatesPath $TemplatesPath
-$publishState = Get-DashboardTemplatePublishState -TemplatesPath $resolvedTemplatesPath -RepoRoot $repoRoot
-
-Write-Output ("Preparing dashboard template publish contract from: {0}" -f $publishState.TemplatesDisplayPath)
-Write-Output ("Template file count: {0}" -f $publishState.FileCount)
-Write-Output ("Template fingerprint: {0}" -f $publishState.Fingerprint)
-
-if ($PSBoundParameters.ContainsKey('MetadataPath')) {
-    $publishManifest = [PSCustomObject]@{
-        generatedOnUtc = [datetime]::UtcNow.ToString('o')
-        publishScript = 'build/Publish-DashboardTemplates.ps1'
-        storageAccountName = $StorageAccountName
-        containerName = $ContainerName
-        templatesPath = $publishState.TemplatesDisplayPath
-        templateFingerprint = $publishState.Fingerprint
-        templateFileCount = $publishState.FileCount
-        totalSizeBytes = $publishState.TotalSizeBytes
-        files = @(
-            $publishState.Files |
-                ForEach-Object {
-                    [PSCustomObject]@{
-                        path = $_.Path
-                        sourcePath = $_.SourcePath
-                        sha256 = $_.Sha256
-                        contentType = $_.ContentType
-                        sizeBytes = $_.SizeBytes
-                    }
-                }
-        )
-    }
-
-    if ($PSCmdlet.ShouldProcess($MetadataPath, 'Write dashboard template publish manifest')) {
-        Write-Utf8BomFile -Path $MetadataPath -Content (($publishManifest | ConvertTo-Json -Depth 10) + [Environment]::NewLine)
-        Write-Output ("Dashboard template publish manifest: {0}" -f $MetadataPath)
-    }
+$azurePublishScriptPath = Join-Path -Path $repoRoot -ChildPath 'azure\Upload-Templates.ps1'
+if (-not (Test-Path -LiteralPath $azurePublishScriptPath -PathType Leaf)) {
+    throw "Azure dashboard template publish script not found: $azurePublishScriptPath"
 }
 
-if (-not $PSCmdlet.ShouldProcess(("$StorageAccountName/$ContainerName"), ("Upload {0} dashboard template file(s)" -f $publishState.FileCount))) {
-    return
-}
-
-Write-Output 'Authenticating to Azure Storage...'
-$storageToken = Get-StorageAccessToken
-
-Write-Output ("Uploading dashboard templates to '{0}' container..." -f $ContainerName)
-foreach ($templateFile in $publishState.Files) {
-    $fileSizeKb = [math]::Round($templateFile.SizeBytes / 1KB, 1)
-    Write-Output ("  Uploading {0} ({1} KB)..." -f $templateFile.Path, $fileSizeKb)
-    Publish-BlobFileWithRetry `
-        -StorageAccountName $StorageAccountName `
-        -ContainerName $ContainerName `
-        -BlobName $templateFile.Path `
-        -FilePath $templateFile.FullPath `
-        -ContentType $templateFile.ContentType `
-        -StorageToken $storageToken
-    Write-Output '    Uploaded'
-}
-
-Write-Output ("Published dashboard templates to: https://{0}.blob.core.windows.net/{1}/" -f $StorageAccountName, $ContainerName)
-Write-Output 'The dashboard pipeline runbook and Function App will download these templates at generation time.'
+& $azurePublishScriptPath @PSBoundParameters

--- a/build/Publish-DashboardTemplates.ps1
+++ b/build/Publish-DashboardTemplates.ps1
@@ -19,7 +19,7 @@ Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
 $repoRoot = Split-Path -Path $PSScriptRoot -Parent
-$azurePublishScriptPath = Join-Path -Path $repoRoot -ChildPath 'azure\Upload-Templates.ps1'
+$azurePublishScriptPath = Join-Path -Path (Join-Path -Path $repoRoot -ChildPath 'azure') -ChildPath 'Upload-Templates.ps1'
 if (-not (Test-Path -LiteralPath $azurePublishScriptPath -PathType Leaf)) {
     throw "Azure dashboard template publish script not found: $azurePublishScriptPath"
 }

--- a/build/README.md
+++ b/build/README.md
@@ -50,7 +50,7 @@ This directory contains maintainer-facing build, validation, import, and packagi
 When `-SkipMdePermissions` is paired with Function App execution validation, pass `-FunctionExecutionDatasetPath <dataset>` so the script can reseed the Function App exports container before invocation. Use `-SkipFunctionExecution` only when you intentionally want deployment validation without the final Function App run.
 Use `-SkipAutomationValidation` when the Function App is the isolated subject of a test; the default still validates both compute paths. This is useful when a complete Function App dataset is available but the Automation lane is being measured separately.
 
-The Azure builders now assert that the generated runbook and Function App entry point still carry the current shared-helper fingerprint before packaging or deployment. `Build-AzureReleasePackage.ps1` also writes a sibling `.manifest.json` sidecar beside the zip so package provenance, staged `Az.Accounts` version, and artifact fingerprints are easier to audit locally. `Publish-DashboardTemplates.ps1` is the supported dashboard-template upload surface for wrappers, CI, and maintainer automation; `azure/Upload-Templates.ps1` remains only as a compatibility shim for older callers and release-package layouts.
+The Azure builders now assert that the generated runbook and Function App entry point still carry the current shared-helper fingerprint before packaging or deployment. `Build-AzureReleasePackage.ps1` also writes a sibling `.manifest.json` sidecar beside the zip so package provenance, staged `Az.Accounts` version, and artifact fingerprints are easier to audit locally. `azure/Upload-Templates.ps1` now owns the package-safe template upload implementation shipped in release bundles, while `build/Publish-DashboardTemplates.ps1` remains the repo-owned wrapper surface for CI, wrappers, and maintainer automation.
 
 During seeded Function App validation, the script now writes a short-lived control blob at `dashboards/_diagnostics/ExportAndGenerate.control.json` and polls the runtime status blob at `dashboards/_diagnostics/ExportAndGenerate.status.json`. This makes Flex Consumption execution diagnosable even when admin VFS access and built-in log streaming are unavailable.
 
@@ -89,7 +89,7 @@ When you change `src/powershell/Shared/**/*.ps1` or `build/azure/runbook-source.
 
 Use the default `Build-FunctionApp.ps1` invocation when you only need the generated entry point plus staged modules refreshed in place. Use `Build-FunctionAppPackage.ps1` when you need the stable deployable zip/manifest surface for CI, wrappers, or manual zip deployment. `-SkipModuleStaging` is sufficient for the routine script-only refresh loop.
 
-When you need to refresh the `templates` blob container, prefer `build/Publish-DashboardTemplates.ps1` over calling `azure/Upload-Templates.ps1` directly. The build-layer entrypoint is the documented public contract and supports `-WhatIf` for deterministic smoke coverage in the maintainer preflight.
+When you need to refresh the `templates` blob container from a repo checkout, use `build/Publish-DashboardTemplates.ps1`. When you are operating from an extracted Azure release package or through `Setup-AzureResources.ps1`, use `azure/Upload-Templates.ps1`. Both entrypoints support `-WhatIf` and run the same Azure-side publish implementation.
 
 ## Memory-sensitive pipeline changes
 

--- a/docs/azure-setup.md
+++ b/docs/azure-setup.md
@@ -248,7 +248,7 @@ The Azure runbook status evidence includes the selected normalization mode, inpu
 
 `build/Build-FunctionAppPackage.ps1` is the supported packaging surface for CI and wrapper repositories. By default it rebuilds the generated Function App artifacts, stages `Az.Accounts`, writes a stable zip to `.local/local-reports/function-app-package/defender-reporting-function-app.zip`, and emits a sibling `.manifest.json` file that records the package path, SHA-256, and Function App artifact fingerprints.
 
-`build/Publish-DashboardTemplates.ps1` is the supported template-publishing surface for CI, wrapper repositories, and repo-owned deployment automation. It uploads the canonical `templates/` tree to the `templates` blob container, emits a stable tree fingerprint, and can optionally write a JSON manifest with the published file inventory. `azure/Upload-Templates.ps1` remains as a thin compatibility wrapper for older callers.
+`azure/Upload-Templates.ps1` now owns the package-safe template publishing implementation used by `Setup-AzureResources.ps1` and extracted Azure release bundles. `build/Publish-DashboardTemplates.ps1` remains the repo-owned wrapper surface for CI, wrapper repositories, and maintainer automation. Both entrypoints upload the canonical `templates/` tree to the `templates` blob container, emit the same stable tree fingerprint, and can optionally write a JSON manifest with the published file inventory.
 
 ## Related docs
 


### PR DESCRIPTION
## Summary

- move the dashboard template upload implementation into `azure/Upload-Templates.ps1` and a new Azure-shipped helper so extracted release packages no longer depend on `build\Publish-DashboardTemplates.ps1`
- keep `build/Publish-DashboardTemplates.ps1` as the repo-owned wrapper surface, while making `Setup-AzureResources.ps1` prefer the package-safe Azure entrypoint and update its manual guidance
- refresh the related Azure packaging docs so repo checkouts and extracted bundles point at the correct template-publishing path

## Validation

- [ ] Deterministic preflight: `pwsh -NoProfile -File .\build\Invoke-RegressionValidation.ps1`
- [ ] Live export dry run, when API export or shipped dashboard behavior changed: `pwsh -NoProfile -File .\build\Invoke-LiveDashboardDryRun.ps1 -UseExistingAzContext`
- [ ] Large-dataset artifact gate, when normalization, payload, validation, or packaging changed: `pwsh -NoProfile -File .\tests\Invoke-LargeDatasetValidation.ps1 -SkipSyntheticGeneration -SyntheticOutputPath .\.local\large-datasets\synthetic-50k-1_5m -Validate -ValidationMode artifacts`
- [ ] Large-dataset semantic sign-off, when semantics, validation, or perf-sensitive behavior changed: `pwsh -NoProfile -File .\tests\Invoke-LargeDatasetValidation.ps1 -SkipSyntheticGeneration -SyntheticOutputPath .\.local\large-datasets\synthetic-50k-1_5m -Validate -ValidationMode semantic -ForceFullValidation`
- [ ] Azure deployment validation, when Azure deployment, packaging, Automation, Function App, or release packaging changed: `pwsh -NoProfile -File .\build\Invoke-AzureDeploymentValidation.ps1 <local parameters>`
- [ ] Hosted dashboard runtime smoke, when split-assets delivery changed: `pwsh -NoProfile -File .\tests\Invoke-HostedDashboardRuntimeSmoke.ps1 -DashboardPath <hosted-html>`
- [ ] Not applicable: explain skipped gates below.

## Gate Notes

- Dataset(s): N/A
- Artifact path(s): N/A
- Azure acceptance delta vs `docs/performance-baselines.md`: N/A
- Rewrite-trigger review (`two consecutive failures`, `>10%` elapsed or working-set regression, `>15%` execution-unit growth): N/A
- Accepted-envelope refresh, if this PR changes it: N/A
- Skipped gates and reason: did not run the heavyweight repo gates for this packaging fix. Performed targeted PowerShell parse checks plus `-WhatIf` smoke runs for `azure/Upload-Templates.ps1`, `build/Publish-DashboardTemplates.ps1`, and an extracted package layout containing only `azure/` and `templates/`.