### PR TITLE
Update and pin GitHub Actions

### DIFF
--- a/.github/workflows/export-pdf-reports.yml
+++ b/.github/workflows/export-pdf-reports.yml
@@ -19,13 +19,13 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           ref: ${{ github.ref_name }}
 
       - name: Check whether PDF export is needed
         id: freshness
-        uses: actions/github-script@v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3
         with:
           script: |
             const htmlPath = 'VulnerabilityDashboard.html';
@@ -114,7 +114,7 @@ jobs:
 
       - name: Setup Node.js
         if: steps.freshness.outputs.should_export == 'true'
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
         with:
           node-version: '24'
 
@@ -150,7 +150,7 @@ jobs:
 
       - name: Upload PDF reports
         if: steps.freshness.outputs.should_export == 'true'
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: vulnerability-reports-${{ github.run_number }}
           path: reports/*.pdf

--- a/.github/workflows/release-azure-package.yml
+++ b/.github/workflows/release-azure-package.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Checkout release tag
-        uses: actions/checkout@v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           ref: ${{ github.event.release.tag_name }}
           fetch-depth: 0

--- a/.github/workflows/sync-azure-package.yml
+++ b/.github/workflows/sync-azure-package.yml
@@ -37,7 +37,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           ref: ${{ github.ref_name }}
           fetch-depth: 0
@@ -74,7 +74,7 @@ jobs:
           .\build\Build-AzureReleasePackage.ps1 -OutputPath $packagePath
 
       - name: Upload Azure package artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: ${{ steps.package.outputs.artifact_name }}
           path: ${{ steps.package.outputs.package_path }}

--- a/.github/workflows/sync-azure-runbook.yml
+++ b/.github/workflows/sync-azure-runbook.yml
@@ -34,7 +34,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           ref: ${{ github.ref_name }}
           fetch-depth: 0

--- a/.github/workflows/update-vulnerability-dashboard.yml
+++ b/.github/workflows/update-vulnerability-dashboard.yml
@@ -32,7 +32,7 @@ jobs:
     
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
 
       - name: Install Az.Accounts PowerShell module
         shell: pwsh
@@ -50,7 +50,7 @@ jobs:
 
       - name: Upload live validation artifacts
         if: ${{ always() }}
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: dashboard-live-validation
           path: |

--- a/.github/workflows/validate-dashboard.yml
+++ b/.github/workflows/validate-dashboard.yml
@@ -55,7 +55,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
 
       - name: Install validation modules
         shell: pwsh


### PR DESCRIPTION
## Summary

- Update GitHub Actions to the current verified release commits.
- Pin every external action reference in the affected workflow files to an immutable commit SHA.
- Preserve local action references.

## Why

This keeps workflow execution reproducible and applies the approved action-runtime and security updates. This PR does not change application code, permissions, triggers, secrets, deployments, or release behavior.

## Validation

- git diff --check passed locally.
- Workflow checks should run on this PR where the repository has pull-request triggers.
- Release, signing, live-smoke, and deployment workflows were not dispatched automatically.

## Commit

2369e4709a59f2f8db50891f80cc0da6f22f5a13
